### PR TITLE
Reorganize pane layout

### DIFF
--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -103,6 +103,7 @@ public final class LGM
 			}
 		}
 	public static JFrame frame;
+	public static JPanel content;
 	public static JToolBar tool;
 	public static JTree tree;
 	public static ResNode root;
@@ -429,11 +430,14 @@ public final class LGM
 		splashProgress.progress(20,Messages.getString("LGM.SPLASH_LIBS")); //$NON-NLS-1$
 		LibManager.autoLoad();
 		splashProgress.progress(30,Messages.getString("LGM.SPLASH_TOOLS")); //$NON-NLS-1$
+
 		JComponent toolbar = createToolBar();
-		JComponent left = createTree();
-		JComponent right = createMDI();
-		JSplitPane split = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT,true,left,right);
-		split.setDividerLocation(170);
+		JComponent tree = createTree();
+		content = new JPanel(new BorderLayout());
+		content.add(BorderLayout.CENTER,createMDI());
+		content.add(BorderLayout.EAST,eventSelect = new EventPanel());
+		JSplitPane split = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT,true,tree,content);
+		split.setDividerLocation(200);
 		split.setOneTouchExpandable(true);
 		splashProgress.progress(40,Messages.getString("LGM.SPLASH_THREAD")); //$NON-NLS-1$
 		gameInformationFrameBuilder = new Thread()
@@ -464,10 +468,9 @@ public final class LGM
 		frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 		frame.setContentPane(f);
 		frame.setTransferHandler(Listener.getInstance().fc.new LGMDropHandler());
-		f.add(BorderLayout.NORTH,toolbar);
 		f.add(BorderLayout.CENTER,split);
-		f.add(BorderLayout.EAST,eventSelect = new EventPanel());
-		eventSelect.setVisible(false);
+		eventSelect.setVisible(false); //must occur after adding split
+		f.add(BorderLayout.NORTH,toolbar);
 		f.setOpaque(true);
 		new FramePrefsHandler(frame);
 		splashProgress.progress(70,Messages.getString("LGM.SPLASH_LOGO")); //$NON-NLS-1$

--- a/org/lateralgm/subframes/EventPanel.java
+++ b/org/lateralgm/subframes/EventPanel.java
@@ -496,7 +496,7 @@ public class EventPanel extends JToolBar implements ActionListener,TreeSelection
 		if (b == isVisible()) return;
 		//workaround for java bug 4782243
 		Container c = this, p = c.getParent();
-		while (p != null && p != LGM.frame && p != LGM.frame.getContentPane())
+		while (p != null && p != LGM.frame && p != LGM.content)
 			{
 			c = p;
 			p = c.getParent();


### PR DESCRIPTION
Moved MDI and event selector into their own JPanel, which is in a JSplitPane with the tree; this is to enable a plugin to put a progress pane below the newly-created JPanel.
