### PR TITLE
Resource tree clicking behavior fix

### DIFF
--- a/org/lateralgm/main/Listener.java
+++ b/org/lateralgm/main/Listener.java
@@ -414,7 +414,7 @@ public class Listener extends TransferHandler implements ActionListener,CellEdit
 
 		public void mouseReleased(MouseEvent e)
 			{
-			ResNode node = (ResNode) LGM.tree.getLastSelectedPathComponent();
+			ResNode node = (ResNode) LGM.tree.getPathForLocation(e.getX(), e.getY()).getLastPathComponent();
 			if (e.getX() >= LGM.tree.getWidth() && e.getY() >= LGM.tree.getHeight() || node == null)
 				return;
 			if (e.getModifiers() == InputEvent.BUTTON3_MASK


### PR DESCRIPTION
Double / right clicking in the resource tree used to open whatever node was last selected. If an empty part of the tree was double or right clicked, e.g. at the very bottom or towards the rightmost edge, the operation would happen to the last selected node. This could be confusing if the selected node is nowhere near where the mouse was double or right clicked.

This commit changes the behavior by not opening a context menu or frame unless an actual node was double clicked or right clicked with the last mouse event.

Of course, if the previous behavior was intended do not pull this commit.

EDIT:
This does not necessarily fix #32 -- the syntax check button is still duplicated if you double click on the currently open script, however due to the changes, if the script is selected in the resource tree and you double click somewhere else in the resource tree the button will not be duplicated. This commit was not intended as a fix for #32, but it made the bug's behavior more obvious.
