### PR TITLE
Null pointer exception fix for #34

### DIFF
--- a/org/lateralgm/main/Listener.java
+++ b/org/lateralgm/main/Listener.java
@@ -414,8 +414,11 @@ public class Listener extends TransferHandler implements ActionListener,CellEdit
 
 		public void mouseReleased(MouseEvent e)
 			{
-			ResNode node = (ResNode) LGM.tree.getPathForLocation(e.getX(), e.getY()).getLastPathComponent();
-			if (e.getX() >= LGM.tree.getWidth() && e.getY() >= LGM.tree.getHeight() || node == null)
+			TreePath p = LGM.tree.getPathForLocation(e.getX(), e.getY());
+			if (e.getX() >= LGM.tree.getWidth() && e.getY() >= LGM.tree.getHeight() || p == null)
+				return;
+			ResNode node = (ResNode) p.getLastPathComponent();
+			if(node == null)
 				return;
 			if (e.getModifiers() == InputEvent.BUTTON3_MASK
 			//Isn't Java supposed to handle ctrl+click for us? For some reason it doesn't.


### PR DESCRIPTION
In #34 the resource node was being checked for being null, the the TreePath wasn't. When the TreePath was null, getLastPathComponent() was trying to get the last node of a null TreePath and triggering the NPE.

This commit assigns a variable to the TreePath which is checked for being null before a resource node is gotten from it and checked for being null.
