### PR TITLE
Fixes icons with no mask (which is optional for 32BPP BMP icons)

### DIFF
--- a/org/lateralgm/file/iconio/BitmapIndexed1BPP.java
+++ b/org/lateralgm/file/iconio/BitmapIndexed1BPP.java
@@ -55,6 +55,20 @@ public class BitmapIndexed1BPP extends AbstractBitmapIndexed
 				}
 			}
 		}
+	
+	
+	void fakeReadBitmap()
+		{
+		int lPixelNo = 0;
+		for (int lRowNo = 0; lRowNo < getHeight(); lRowNo++)
+			{
+			for (int lColNo = 0; lColNo < getWidth(); lColNo++)
+				{
+				pixels[lPixelNo++] = 1;
+				}
+			}
+		}
+	
 
 	private void writeBits(StreamEncoder out, int offset, int count) throws IOException
 		{

--- a/org/lateralgm/file/iconio/BitmapMask.java
+++ b/org/lateralgm/file/iconio/BitmapMask.java
@@ -33,6 +33,14 @@ public class BitmapMask
 		{
 		mask.readBitmap(pDec);
 		}
+	
+	/**
+	 * Fake a read operation, setting all pixels to 1 (full opacity).
+	 */
+	void fakeRead()
+		{
+		mask.fakeReadBitmap();
+		}
 
 	/**
 	 * @param pXPos

--- a/org/lateralgm/file/iconio/BitmapRGB32BPP.java
+++ b/org/lateralgm/file/iconio/BitmapRGB32BPP.java
@@ -15,12 +15,16 @@ import org.lateralgm.file.StreamEncoder;
  */
 public class BitmapRGB32BPP extends AbstractBitmapRGB
 	{
+	///How far can we read before the next image? If <=0, read as far as necessary.
+	protected long readStreamLimit;
+	
 	/**
 	 * @param pDescriptor The image descriptor.
 	 */
 	public BitmapRGB32BPP(final BitmapDescriptor pDescriptor)
 		{
 		super(pDescriptor);
+		readStreamLimit = pDescriptor.getOffset() + pDescriptor.getSize();
 		}
 
 	/**
@@ -47,6 +51,22 @@ public class BitmapRGB32BPP extends AbstractBitmapRGB
 			}
 
 		}
+	
+	
+	/**
+	 * 32BPP Bitmaps can optionally have NO mask.
+	 */
+	protected void readMask(final StreamDecoder pDec) throws IOException
+	{
+	if (readStreamLimit<=0 || pDec.getPos()<readStreamLimit) 
+		{
+		super.readMask(pDec);
+		} else {
+			transparencyMask = new BitmapMask(descriptor);
+			transparencyMask.fakeRead();
+		}
+	}
+	
 
 	/**
 	 * @return Create an ARGB image.


### PR DESCRIPTION
This allows loading of the "rogue" icons and saving them properly.

See below, for the game in question:
http://i.imgur.com/FBnWR5z.png
