### PR TITLE
Load constants instead of just the deafult (empty).

### DIFF
--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -868,8 +868,8 @@ public final class LGM
 		
 		//NOTE: We do this to update the reference to the one now loaded
 		//since we never close these frames, then we simply revert their controls.
-		constantsFrame.res = LGM.currentFile.defaultConstants;
-		constantsFrame.resOriginal = LGM.currentFile.defaultConstants.clone();
+		constantsFrame.res = LGM.currentFile.gameSettings.constants;
+		constantsFrame.resOriginal = LGM.currentFile.gameSettings.constants.clone();
 		constantsFrame.revertResource();
 		constantsFrame.setVisible(false);
 		gameInfo.res = LGM.currentFile.gameInfo;


### PR DESCRIPTION
This is more of a "is there any reason not to do this" request (and is most likely directed at Josh, I think?). 

If we actually use gameSettings.constants instead of currentFile.defaultConstants, then we get the constants saved with the game file, and (combined with my pull request in ENIGMA), the compiler will actually add them to the game. So, in other words, this commit + my other commit enables the use of constants in games, even though 99% of the work was already done, elsewhere (in the GM parsers, the plugin, etc.).
