### PR TITLE
Fixes EGM loading from Robert's initial fix+revert.

### DIFF
--- a/org/lateralgm/file/ProjectFile.java
+++ b/org/lateralgm/file/ProjectFile.java
@@ -346,7 +346,7 @@ public class ProjectFile implements UpdateListener
 		resMap.put(GameInformation.class,new SingletonResourceHolder<GameInformation>(gameInfo));
 		//TODO: We don't need this anymore. It should however still be iteratable, perhaps we should make a Config resource to manage
 		//all game configurations? - Robert
-		//resMap.put(GameSettings.class,new SingletonResourceHolder<GameSettings>(gs));
+		resMap.put(GameSettings.class,new SingletonResourceHolder<GameSettings>(gs));
 		resMap.put(ExtensionPackages.class,new SingletonResourceHolder<ExtensionPackages>(extPackages));
 		for (ResourceHolder<?> rl : resMap.values())
 			if (rl instanceof ResourceList<?>) ((ResourceList<?>) rl).updateSource.addListener(this);


### PR DESCRIPTION
The GameSettings was disabled by Robert at some point (while he was working on Constants, I think). This change was later reverted, but the line shown below remained commented. This has caused EGM files saved with LateralGM to fail to open for quite a while. This pull request fixes that issue.