### PR TITLE
Change default room background color.

### DIFF
--- a/org/lateralgm/resources/Room.java
+++ b/org/lateralgm/resources/Room.java
@@ -55,7 +55,7 @@ public class Room extends InstantiableResource<Room,Room.PRoom> implements CodeH
 		}
 
 	private static final EnumMap<PRoom,Object> DEFS = PropertyMap.makeDefaultMap(PRoom.class,"",640,
-			480,16,16,false,30,false,Color.LIGHT_GRAY,true,"",true,500,450,true,true,true,true,true,
+			480,16,16,false,30,false,new Color(102, 204, 255),true,"",true,500,450,true,true,true,true,true,
 			false,false,false,TAB_OBJECTS,0,0,false);
 
 	public Room()


### PR DESCRIPTION
Blue is the most likely color to be used as the room background, like the
sky or water. Blue is also by far the most popular color because it
conveys feelings of tranquility. For these reasons, 66CCFF is a logical
choice to set the default room background color to, and is also web safe.
The color matches the Swing look and feel quite nicely.