### PR TITLE
Fixes toolbar layout issues.

### DIFF
--- a/org/lateralgm/subframes/PathFrame.java
+++ b/org/lateralgm/subframes/PathFrame.java
@@ -9,6 +9,7 @@
 
 package org.lateralgm.subframes;
 
+import static java.lang.Integer.MAX_VALUE;
 import static javax.swing.GroupLayout.DEFAULT_SIZE;
 import static javax.swing.GroupLayout.PREFERRED_SIZE;
 
@@ -92,7 +93,7 @@ public class PathFrame extends InstantiableResourceFrame<Path,PPath>
 		JComponent preview = makePreview();
 
 		layout.setHorizontalGroup(layout.createParallelGroup()
-		/**/.addComponent(tb)
+		/**/.addComponent(tb,PREFERRED_SIZE,DEFAULT_SIZE,MAX_VALUE)
 		/**/.addGroup(layout.createSequentialGroup()
 		/*	*/.addComponent(side,DEFAULT_SIZE,0,0)
 		/*	*/.addComponent(preview,240,480,DEFAULT_SIZE)));

--- a/org/lateralgm/subframes/RoomFrame.java
+++ b/org/lateralgm/subframes/RoomFrame.java
@@ -1163,7 +1163,7 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements 
 		JPanel stats = makeStatsPane();
 
 		layout.setHorizontalGroup(layout.createParallelGroup()
-		/**/.addComponent(tools)
+		/**/.addComponent(tools,PREFERRED_SIZE,DEFAULT_SIZE,MAX_VALUE)
 		/**/.addGroup(layout.createSequentialGroup()
 		/*	*/.addComponent(tabs,PREFERRED_SIZE,PREFERRED_SIZE,PREFERRED_SIZE)
 		/*	*/.addGroup(layout.createParallelGroup()


### PR DESCRIPTION
The path and room editors in lgm16b4 put the JToolBar in a group layout
and it doesn't expand to fill the editor horizontally. When resizing the
two editors you can see the toolbar is clipped off at the end. This layout
change allows the toolbar to expand and fill the available space
horizontally.

![Toolbar Clipping](https://cloud.githubusercontent.com/assets/3212801/12531652/f6d98718-c1cd-11e5-9b38-7539f2b81159.png)