### PR TITLE
Improved Compatibility for GM Action Libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.class
 lgm16b4.jar
+lib/

--- a/org/lateralgm/components/ActionListEditor.java
+++ b/org/lateralgm/components/ActionListEditor.java
@@ -79,10 +79,10 @@ public class ActionListEditor extends JPanel
 		JTabbedPane tp = new JTabbedPane(JTabbedPane.RIGHT);
 
 		tp.setTabLayoutPolicy(JTabbedPane.SCROLL_TAB_LAYOUT);
-		JPanel lp = null;
 		for (Library l : LibManager.libs)
 			{
 			JPanel p = new JPanel();
+			JPanel lp = null;
 			GroupLayout layout = new GroupLayout(p);
 			p.setLayout(layout);
 			ParallelGroup hg = layout.createParallelGroup();

--- a/org/lateralgm/resources/library/LibManager.java
+++ b/org/lateralgm/resources/library/LibManager.java
@@ -30,6 +30,7 @@ import javax.imageio.ImageIO;
 import org.lateralgm.file.GmStreamDecoder;
 import org.lateralgm.main.LGM;
 import org.lateralgm.main.Prefs;
+import org.lateralgm.main.Util;
 import org.lateralgm.messages.Messages;
 import org.lateralgm.resources.sub.Action;
 import org.lateralgm.resources.sub.Argument;
@@ -274,7 +275,7 @@ public final class LibManager
 
 			byte[] data = new byte[in.read4()];
 			in.read(data);
-			act.actImage = ImageIO.read(new ByteArrayInputStream(data));
+			act.actImage = Util.getTransparentIcon(ImageIO.read(new ByteArrayInputStream(data)));
 
 			act.hidden = in.readBool();
 			act.advanced = in.readBool();

--- a/org/lateralgm/resources/library/LibManager.java
+++ b/org/lateralgm/resources/library/LibManager.java
@@ -275,7 +275,8 @@ public final class LibManager
 
 			byte[] data = new byte[in.read4()];
 			in.read(data);
-			act.actImage = Util.getTransparentIcon(ImageIO.read(new ByteArrayInputStream(data)));
+			act.actImage = Util.getTransparentIcon(
+					ImageIO.read(new ByteArrayInputStream(data))).getSubimage(0,0,24,24);
 
 			act.hidden = in.readBool();
 			act.advanced = in.readBool();


### PR DESCRIPTION
*These are not regressions and existed in 16b4, the transparency is not removed and the image is not cropped to 24x24 as described below.*

First addition is adding the /lib folder to .gitignore so nobody accidentally commits it.

In GameMaker, the bottom left pixel of an action image is used as the transparency key just like sprites. I decided to use the utility method for the transparency key because it already implements the correct behavior. I then crop the image to 24x24 as the manual by Mark Overmars states. This addresses the issue originally reported in #161. This is not a more elaborate fix like I constructed for the master branch. So, it is important to note that this means the action libraries can not be written back to disk by LGM, which is generally ok because LGM does not need to do that, only the action library editor does. LGM also doesn't even have the code to save the libraries if it wanted to.

From the official Mark Overmar's Action Library Maker the manual states:
http://sandbox.yoyogames.com/make/extensions
http://gm6guide.altervista.org/phpBB2/viewtopic.php?t=621&sid=9c170ce54a333371ae972b8dbcab3dda
> General Action Information
> ...Next there is the Image that represents the action. This must be a 32x32 image but the actual image should only be 24x24. (This sounds a bit stupid but this is due to the fact that normally 32x32 icons are used for this.) The bottom left pixel color of the 32x32 image specifies the transparency color. The three basic images for normal actions, drawing actions, and questions are included in the folder Action_Images. You might want to use these as the basis for your images to give the actions a consistent look.

**NOTE: The text is clipped with an ellipsis for the "Transformation" actions, a separate issue.**
![GM Action Library Fix](https://cloud.githubusercontent.com/assets/3212801/12556728/61101df8-c355-11e5-8933-71af32db6f4c.png)

To verify as best as I could, I created the following action image (must be BMP for GM's format, GitHub does not support BMP).
![Test Action Image](https://cloud.githubusercontent.com/assets/3212801/12557012/d2e52314-c356-11e5-9553-198709bb437a.png)
I used that to create a new action library using Overmar's editor. It behaved as expected and was cropped to 24x24 with the bottom left pixel (pink) used for transparency. After these changes it also behaves the same way in LGM.
![GM8.1 Test Action](https://cloud.githubusercontent.com/assets/3212801/12557111/4aaee06a-c357-11e5-8176-59557d4a05e6.png)

Also addressed is an issue where if there was no "- Label" action (the little caption above a group of actions) LGM would throw the actions onto the previous library tab (which could be null/lead to an exception), and that made no sense because it was not part of that library, it would leave its own library tab empty. That was addressed by moving the local inside the for loop, afterwards LGM behaves exactly as GM8.1.
![Action Library Caption Label Fix](https://cloud.githubusercontent.com/assets/3212801/12557562/66c7d4bc-c359-11e5-88f0-9a21b5323d6c.png)



