### PR TITLE
Increase default room editor size

### DIFF
--- a/org/lateralgm/resources/Room.java
+++ b/org/lateralgm/resources/Room.java
@@ -55,7 +55,7 @@ public class Room extends InstantiableResource<Room,Room.PRoom> implements CodeH
 		}
 
 	private static final EnumMap<PRoom,Object> DEFS = PropertyMap.makeDefaultMap(PRoom.class,"",640,
-			480,16,16,false,30,false,new Color(102,204,255),true,"",true,1024,640,true,true,true,true,true,
+			480,16,16,false,30,false,Color.LIGHT_GRAY,true,"",true,1024,640,true,true,true,true,true,
 			false,false,false,TAB_OBJECTS,0,0,false);
 
 	public Room()

--- a/org/lateralgm/resources/Room.java
+++ b/org/lateralgm/resources/Room.java
@@ -55,7 +55,7 @@ public class Room extends InstantiableResource<Room,Room.PRoom> implements CodeH
 		}
 
 	private static final EnumMap<PRoom,Object> DEFS = PropertyMap.makeDefaultMap(PRoom.class,"",640,
-			480,16,16,false,30,false,new Color(102, 204, 255),true,"",true,500,450,true,true,true,true,true,
+			480,16,16,false,30,false,new Color(102,204,255),true,"",true,1024,640,true,true,true,true,true,
 			false,false,false,TAB_OBJECTS,0,0,false);
 
 	public Room()


### PR DESCRIPTION
The room editor opens way too small and DaSpirit and Rusky both agreed. Rusky expressed a preference for 4:3 aspect ratio. However, I came up with 1024x640 instead because it's just big enough to fit the whole default room size. This was done the correct way, unlike master, by changing it in the room properties map, so it will not cause the regression like originally in master that made the editor constantly complain of a changing room size.

![Room editor sizes](https://cloud.githubusercontent.com/assets/3212801/12602314/540d7c32-c476-11e5-81d9-533dbdf425c4.png)
