### PR TITLE
Implements Find Resource feature

### DIFF
--- a/org/lateralgm/main/Listener.java
+++ b/org/lateralgm/main/Listener.java
@@ -32,6 +32,7 @@ import javax.swing.JTree;
 import javax.swing.TransferHandler;
 import javax.swing.event.CellEditorListener;
 import javax.swing.event.ChangeEvent;
+import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.TreePath;
 
 import org.lateralgm.components.AboutBox;
@@ -262,6 +263,42 @@ public class Listener extends TransferHandler implements ActionListener,CellEdit
 			if (JOptionPane.showConfirmDialog(LGM.frame,msg,
 					Messages.getString("Listener.CONFIRM_DEFRAGIDS_TITLE"), //$NON-NLS-1$
 					JOptionPane.YES_NO_OPTION) == 0) LGM.currentFile.defragIds();
+			}
+		if (com.endsWith(".FIND")) //$NON-NLS-1$
+			{
+			String name = JOptionPane.showInputDialog(LGM.frame,
+					Messages.getString("Listener.INPUT_FINDRES"), //$NON-NLS-1$
+					Messages.getString("Listener.INPUT_FINDRES_TITLE"), //$NON-NLS-1$
+					JOptionPane.PLAIN_MESSAGE);
+			if (name == null) return;
+			// find the resource with the name
+			Enumeration<?> enumeration =
+					((DefaultMutableTreeNode) tree.getModel().getRoot()).preorderEnumeration();
+			ResNode resNode = null;
+			while (enumeration.hasMoreElements())
+				{
+				DefaultMutableTreeNode child = (ResNode) enumeration.nextElement();
+				if (child.toString().equals(name))
+					{
+						resNode = (ResNode) child;
+						break;
+					}
+				}
+			if (resNode != null)
+				{
+				tree.expandPath(new TreePath(resNode.getPath()));
+				tree.setSelectionPath(new TreePath(resNode.getPath()));
+				tree.updateUI();
+				if (resNode.status != ResNode.STATUS_GROUP) resNode.openFrame();
+				}
+			else
+				{
+				JOptionPane.showMessageDialog(LGM.frame,
+						Messages.format("Listener.INPUT_FINDRES_NOTFOUND",name), //$NON-NLS-1$
+						Messages.getString("Listener.INPUT_FINDRES_NOTFOUND_TITLE"), //$NON-NLS-1$
+						JOptionPane.WARNING_MESSAGE);
+				}
+			return;
 			}
 		if (com.endsWith(".EXPAND")) //$NON-NLS-1$
 			{

--- a/org/lateralgm/messages/messages.properties
+++ b/org/lateralgm/messages/messages.properties
@@ -168,6 +168,11 @@ Listener.CONFIRM_DEFRAGIDS=	This action cannot be undone, are you sure you \
 							want to continue?
 Listener.CONFIRM_DEFRAGIDS_TITLE=Defrag Ids
 
+Listener.INPUT_FINDRES=Resource name:
+Listener.INPUT_FINDRES_TITLE=Find Resource
+Listener.INPUT_FINDRES_NOTFOUND=Could not find resource "{0}"
+Listener.INPUT_FINDRES_NOTFOUND_TITLE=Resource Not Found
+
 Listener.TREE_EDIT=Edit
 Listener.TREE_INSERT=Insert Resource
 Listener.TREE_DUPLICATE=Duplicate Resource

--- a/org/lateralgm/messages/messages_fr.properties
+++ b/org/lateralgm/messages/messages_fr.properties
@@ -184,7 +184,7 @@ Listener.CONFIRM_DEFRAGIDS_TITLE=Défrag Ids
 Listener.INPUT_FINDRES=Nom de la ressource:
 Listener.INPUT_FINDRES_TITLE=Trouver la ressource
 Listener.INPUT_FINDRES_NOTFOUND=Impossible de trouver la ressource "{0}"
-Listener.INPUT_FINDRES_NOTFOUND_TITLE=Resource Not Found
+Listener.INPUT_FINDRES_NOTFOUND_TITLE=Ressource non trouvée
 
 Listener.TREE_EDIT=Edition
 Listener.TREE_INSERT=Insérer Resource

--- a/org/lateralgm/messages/messages_fr.properties
+++ b/org/lateralgm/messages/messages_fr.properties
@@ -181,6 +181,11 @@ Listener.CONFIRM_DEFRAGIDS=	Cette action ne peut être défait, vous êtes sûr que 
 							de vouloir continuer?
 Listener.CONFIRM_DEFRAGIDS_TITLE=Défrag Ids
 
+Listener.INPUT_FINDRES=Nom de la ressource:
+Listener.INPUT_FINDRES_TITLE=Trouver la ressource
+Listener.INPUT_FINDRES_NOTFOUND=Impossible de trouver la ressource "{0}"
+Listener.INPUT_FINDRES_NOTFOUND_TITLE=Resource Not Found
+
 Listener.TREE_EDIT=Edition
 Listener.TREE_INSERT=Insérer Resource
 Listener.TREE_DUPLICATE=Dupliquer Resource


### PR DESCRIPTION
In 16b4 the menu item was added but was never made to do anything. This implements the same feature from GM8.1 exactly. It can find every resource which is not a group including game info and settings. By this I mean typing "Game Information" will open game info, it does not do so in GM8.1, GM only let's you find secondary resource nodes. Another difference is that I made the LGM version expand the tree path and highlight the node in the tree (Rusky prefers this), GM does not do this and will leave the parent node of the resource collapsed and still open the frame. In GM8.1 the "Not Found" message is a generic message, I opted to make it a warning for LGM (Rusky has no preference). It is also case sensitive like GM8.1. French translations are again provided by @egofree

![Find resource](https://cloud.githubusercontent.com/assets/3212801/12602830/6ac2b24a-c47a-11e5-9677-677ceafd79fb.png)
