### PR TITLE
Fixes external editors by closing file handles

### DIFF
--- a/org/lateralgm/subframes/BackgroundFrame.java
+++ b/org/lateralgm/subframes/BackgroundFrame.java
@@ -384,14 +384,30 @@ public class BackgroundFrame extends InstantiableResourceFrame<Background,PBackg
 				{
 				case CHANGED:
 					BufferedImage img;
+					FileInputStream fis = null;
 					try
 						{
-						img = ImageIO.read(new FileInputStream(monitor.file));
+						fis = new FileInputStream(monitor.file);
+						img = ImageIO.read(fis);
 						}
 					catch (IOException ioe)
 						{
 						ioe.printStackTrace();
 						return;
+						}
+					finally
+						{
+						if (fis != null)
+							{
+								try
+									{
+									fis.close();
+									}
+								catch (IOException ioe)
+									{
+									ioe.printStackTrace();
+									}
+							}
 						}
 					res.setBackgroundImage(img);
 					imageChanged = true;

--- a/org/lateralgm/subframes/ScriptFrame.java
+++ b/org/lateralgm/subframes/ScriptFrame.java
@@ -191,19 +191,33 @@ public class ScriptFrame extends InstantiableResourceFrame<Script,PScript>
 				{
 				case CHANGED:
 					StringBuffer sb = new StringBuffer(1024);
+					BufferedReader reader = null;
 					try
 						{
-						BufferedReader reader = new BufferedReader(new FileReader(monitor.file));
+						reader = new BufferedReader(new FileReader(monitor.file));
 						char[] chars = new char[1024];
 						int len = 0;
 						while ((len = reader.read(chars)) > -1)
 							sb.append(chars,0,len);
-						reader.close();
 						}
 					catch (IOException ioe)
 						{
 						ioe.printStackTrace();
 						return;
+						}
+					finally
+						{
+						if (reader != null)
+							{
+							try
+								{
+								reader.close();
+								}
+							catch (IOException ioe)
+								{
+								ioe.printStackTrace();
+								}
+							}
 						}
 					String s = sb.toString();
 					res.put(PScript.CODE,s);

--- a/org/lateralgm/subframes/SoundFrame.java
+++ b/org/lateralgm/subframes/SoundFrame.java
@@ -306,17 +306,18 @@ public class SoundFrame extends InstantiableResourceFrame<Sound,PSound>
 			try
 				{
 				data = fileToBytes(f);
-				String fn = f.getName();
-				res.put(PSound.FILE_NAME,fn);
-				String ft = CustomFileFilter.getExtension(fn);
-				if (ft == null) ft = "";
-				res.put(PSound.FILE_TYPE,ft);
-				filename.setText(Messages.format("SoundFrame.FILE",fn)); //$NON-NLS-1$
 				}
-			catch (Exception ex)
+			catch (IOException ex)
 				{
 				ex.printStackTrace();
+				return;
 				}
+			String fn = f.getName();
+			res.put(PSound.FILE_NAME,fn);
+			String ft = CustomFileFilter.getExtension(fn);
+			if (ft == null) ft = "";
+			res.put(PSound.FILE_TYPE,ft);
+			filename.setText(Messages.format("SoundFrame.FILE",fn)); //$NON-NLS-1$
 			modified = true;
 			cleanup();
 			return;
@@ -428,7 +429,17 @@ public class SoundFrame extends InstantiableResourceFrame<Sound,PSound>
 			}
 		finally
 			{
-			if (in != null) in.close();
+			if (in != null)
+				{
+				try
+					{
+					in.close();
+					}
+				catch (IOException ioe)
+					{
+					ioe.printStackTrace();
+					}
+				}
 			}
 		}
 

--- a/org/lateralgm/subframes/SpriteFrame.java
+++ b/org/lateralgm/subframes/SpriteFrame.java
@@ -1070,16 +1070,33 @@ public class SpriteFrame extends InstantiableResourceFrame<Sprite,PSprite> imple
 			switch (((FileUpdateEvent) e).flag)
 				{
 				case CHANGED:
-					BufferedImage img;
+					BufferedImage img = null;
+					FileInputStream fis = null;
 					try
 						{
-						img = ImageIO.read(new FileInputStream(monitor.file));
+						fis = new FileInputStream(monitor.file);
+						img = ImageIO.read(fis);
 						}
 					catch (IOException ioe)
 						{
 						ioe.printStackTrace();
 						return;
 						}
+					finally
+						{
+						if (fis != null)
+							{
+								try
+									{
+									fis.close();
+									}
+								catch (IOException ioe)
+									{
+									ioe.printStackTrace();
+									}
+							}
+						}
+					System.out.println("good");
 					res.subImages.replace(image,img);
 					editors.remove(image);
 					editors.put(img,this);

--- a/org/lateralgm/subframes/SpriteFrame.java
+++ b/org/lateralgm/subframes/SpriteFrame.java
@@ -1070,7 +1070,7 @@ public class SpriteFrame extends InstantiableResourceFrame<Sprite,PSprite> imple
 			switch (((FileUpdateEvent) e).flag)
 				{
 				case CHANGED:
-					BufferedImage img = null;
+					BufferedImage img;
 					FileInputStream fis = null;
 					try
 						{
@@ -1096,7 +1096,6 @@ public class SpriteFrame extends InstantiableResourceFrame<Sprite,PSprite> imple
 									}
 							}
 						}
-					System.out.println("good");
 					res.subImages.replace(image,img);
 					editors.remove(image);
 					editors.put(img,this);


### PR DESCRIPTION
The external editors were never closing open file input streams after loading the data back into the IDE. This made it impossible to save more than once from the external editor without closing and reopening from inside LGM. Fixes all four frames with external editors including sprite editor, background editor, sound editor, and code/script editor. This fully addresses #223 as I did in master.

I also refined the exception catching to protect against certain faults. There are 3 different scenarios to consider. I tested extensively to ensure what I believe to be the correct behavior and to prevent dangling file handles. The only way the file wouldn't exist in any of these cases is if the user cleared their temporary files, in which case these handlers delete their reference to the file so it is safe.

**Opening File Input Stream**

1. The file doesn't exist or for some reason a FileInputStream can't be created.
2. Print the exception.
3. The FileInputStream will be null.
4. Return

**Reading File**

1. The file existed and there is a valid FileInputStream but for some reason it fails to be read possibly because it is not a supported file format.
2. Print the exception.
3. The FileInputStream is valid and non-null so try to close it.
    * It fails so print the exception.
    * It succeeds.
4. Return possibly with a dangling file handle if it couldn't be closed.

**Closing File**

1. The file exists and is read successfully.
2. The FileInputStream is valid and non-null so try to close it.
    * It fails so print the exception
    * It succeeds.
3. Put the data into the resource/property map and update the components.
4. Return possibly with a dangling file handle if it couldn't be closed.