### PR TITLE
Fixes formatting mistake

### DIFF
--- a/org/lateralgm/subframes/BackgroundFrame.java
+++ b/org/lateralgm/subframes/BackgroundFrame.java
@@ -399,14 +399,14 @@ public class BackgroundFrame extends InstantiableResourceFrame<Background,PBackg
 						{
 						if (fis != null)
 							{
-								try
-									{
-									fis.close();
-									}
-								catch (IOException ioe)
-									{
-									ioe.printStackTrace();
-									}
+							try
+								{
+								fis.close();
+								}
+							catch (IOException ioe)
+								{
+								ioe.printStackTrace();
+								}
 							}
 						}
 					res.setBackgroundImage(img);

--- a/org/lateralgm/subframes/SpriteFrame.java
+++ b/org/lateralgm/subframes/SpriteFrame.java
@@ -1086,14 +1086,14 @@ public class SpriteFrame extends InstantiableResourceFrame<Sprite,PSprite> imple
 						{
 						if (fis != null)
 							{
-								try
-									{
-									fis.close();
-									}
-								catch (IOException ioe)
-									{
-									ioe.printStackTrace();
-									}
+							try
+								{
+								fis.close();
+								}
+							catch (IOException ioe)
+								{
+								ioe.printStackTrace();
+								}
 							}
 						}
 					res.subImages.replace(image,img);


### PR DESCRIPTION
I forgot to indent the try/catch block for closing file handles in the sprite and background editors.