### PR TITLE
Fixes ActionList lost changes.

### DIFF
--- a/org/lateralgm/components/ActionList.java
+++ b/org/lateralgm/components/ActionList.java
@@ -193,11 +193,11 @@ public class ActionList extends JList
 
 		public void mouseClicked(MouseEvent e)
 			{
-			if (e.getClickCount() != 2 || !(e.getSource() instanceof JList)) return;
-			JList l = (JList) e.getSource();
+			if (e.getClickCount() != 2 || !(e.getSource() instanceof ActionList)) return;
+			ActionList l = (ActionList) e.getSource();
 			Object o = l.getSelectedValue();
 
-			if (o == null && l.getModel().getSize() == 0)
+			if (o == null && l.getModel().getSize() == 0 && l.getActionContainer() != null)
 				{
 				o = new Action(LibManager.codeAction);
 				((ActionListModel) l.getModel()).add((Action) o);


### PR DESCRIPTION
This fully addresses #157 by copying the same behavior from ActionListEditor.

When the action container of the list is null (meaning there is no event or moment) then we should not allow a code action to be added. This is what happens when you attempt to add an action from the action library tabs (https://github.com/IsmAvatar/LateralGM/blob/3d51e5dcc5756f30a8e2f6628de4f37c7d72a7c2/org/lateralgm/components/ActionListEditor.java#L164). If the container of the list is null, it will not allow you to add the action.

If this solution is acceptable, then the same fix will be applied to the master branch.