### PR TITLE
Fixes ActionList and EventTree issues.

### DIFF
--- a/org/lateralgm/components/ActionList.java
+++ b/org/lateralgm/components/ActionList.java
@@ -121,7 +121,6 @@ public class ActionList extends JList
 			{
 			codeAction = new Action(LibManager.codeAction);
 			model.add(0,codeAction);
-			setSelectedValue(codeAction,true);
 			}
 
 		if (codeAction.getLibAction().actionKind == Action.ACT_CODE) 

--- a/org/lateralgm/components/ActionList.java
+++ b/org/lateralgm/components/ActionList.java
@@ -110,7 +110,7 @@ public class ActionList extends JList
 
 	public void edit() 
 		{
-		if (model.list.size() > 1) return;
+		if (model.list.size() > 1 || getActionContainer() == null) return;
 
 		Action codeAction = null;
 		if (model.list.size() > 0) 

--- a/org/lateralgm/subframes/GmObjectFrame.java
+++ b/org/lateralgm/subframes/GmObjectFrame.java
@@ -706,7 +706,7 @@ public class GmObjectFrame extends InstantiableResourceFrame<GmObject,PGmObject>
 	 * 
 	 * @return Whether the node is valid.
 	 */
-	public static boolean isValidEventInstanceNode(Object node)
+	private static boolean isValidEventInstanceNode(Object node)
 		{
 		return (node != null && node instanceof EventInstanceNode
 				&& ((EventInstanceNode) node).getParent() != null);

--- a/org/lateralgm/subframes/GmObjectFrame.java
+++ b/org/lateralgm/subframes/GmObjectFrame.java
@@ -695,6 +695,17 @@ public class GmObjectFrame extends InstantiableResourceFrame<GmObject,PGmObject>
 		super.actionPerformed(e);
 		}
 
+	/**
+	 * Check if the node is non-null, is an instance of EventInstanceNode and that it has a parent
+	 * and still exists in the events tree. This is useful with 
+	 * {@link javax.swing.JTree#getLastSelectedPathComponent() getLastSelectedPathComponent()} or
+	 * {@link javax.swing.tree.TreePath#getLastPathComponent() getLastPathComponent()} because they
+	 * can return nodes already removed from the tree.
+	 * 
+	 * @param node The node to check for validity.
+	 * 
+	 * @return Whether the node is valid.
+	 */
 	private static boolean isValidEventInstanceNode(Object node)
 		{
 		return (node != null && node instanceof EventInstanceNode

--- a/org/lateralgm/subframes/GmObjectFrame.java
+++ b/org/lateralgm/subframes/GmObjectFrame.java
@@ -325,6 +325,11 @@ public class GmObjectFrame extends InstantiableResourceFrame<GmObject,PGmObject>
 			if (!support.isDataFlavorSupported(EventNode.EVENTNODE_FLAVOR)) return false;
 			EventNode t = (EventNode) LGM.eventSelect.events.getLastSelectedPathComponent();
 			if (t == null || !t.isValid()) return false;
+			Object n = (Object) events.getLastSelectedPathComponent();
+			if (LGM.eventSelect.function.getValue() != EventPanel.FUNCTION_ADD &&
+					(n == null || !(n instanceof EventInstanceNode) ||
+					((EventInstanceNode) n).getParent() == null))
+					return false;
 			if (rootEvent.contains(new Event(t.mainId,t.eventId,t.other))) return false;
 			for (DataFlavor f : support.getDataFlavors())
 				if (f == EventNode.EVENTNODE_FLAVOR) return true;
@@ -491,6 +496,7 @@ public class GmObjectFrame extends InstantiableResourceFrame<GmObject,PGmObject>
 	public void removeEvent(EventInstanceNode n)
 		{
 		DefaultMutableTreeNode p = (DefaultMutableTreeNode) n.getParent();
+		if (p == null) return;
 
 		DefaultMutableTreeNode next = n.getNextSibling();
 		if (next == null) next = n.getPreviousSibling();
@@ -539,7 +545,7 @@ public class GmObjectFrame extends InstantiableResourceFrame<GmObject,PGmObject>
 				break;
 			case EventPanel.FUNCTION_REPLACE:
 				DefaultMutableTreeNode dropNode = (DefaultMutableTreeNode) path.getLastPathComponent();
-				if (!(dropNode instanceof EventInstanceNode)) return;
+				if (!(dropNode instanceof EventInstanceNode) || dropNode.getParent() == null) return;
 				EventInstanceNode drop = (EventInstanceNode) dropNode;
 				removeEvent(drop);
 				Event ev = drop.getUserObject();
@@ -550,7 +556,7 @@ public class GmObjectFrame extends InstantiableResourceFrame<GmObject,PGmObject>
 				break;
 			case EventPanel.FUNCTION_DUPLICATE:
 				dropNode = (DefaultMutableTreeNode) path.getLastPathComponent();
-				if (!(dropNode instanceof EventInstanceNode)) return;
+				if (!(dropNode instanceof EventInstanceNode) || dropNode.getParent() == null) return;
 				drop = (EventInstanceNode) dropNode;
 				ev = drop.getUserObject();
 				actions.save();
@@ -683,7 +689,9 @@ public class GmObjectFrame extends InstantiableResourceFrame<GmObject,PGmObject>
 		if (e.getSource() == eventDelete || e.getSource() == eventDeleteItem)
 			{
 			Object comp = events.getLastSelectedPathComponent();
-			if (!(comp instanceof EventInstanceNode)) return;
+			if (comp == null || !(comp instanceof EventInstanceNode) ||
+					((EventInstanceNode) comp).getParent() == null)
+					return;
 			removeEvent((EventInstanceNode) comp);
 			return;
 			}
@@ -711,7 +719,7 @@ public class GmObjectFrame extends InstantiableResourceFrame<GmObject,PGmObject>
 		DefaultMutableTreeNode node = (DefaultMutableTreeNode) events.getLastSelectedPathComponent();
 		if (node == null || !node.isLeaf() || !(node.getUserObject() instanceof Event))
 			{
-			if (node != null && !node.isLeaf())
+			if (node != null && !node.isLeaf() && node.getParent() != null)
 				{
 				TreePath path = new TreePath(node.getPath());
 				if (events.isExpanded(path))

--- a/org/lateralgm/subframes/GmObjectFrame.java
+++ b/org/lateralgm/subframes/GmObjectFrame.java
@@ -696,8 +696,8 @@ public class GmObjectFrame extends InstantiableResourceFrame<GmObject,PGmObject>
 		}
 
 	/**
-	 * Check if the node is non-null, is an instance of EventInstanceNode and that it has a parent
-	 * and still exists in the events tree. This is useful with 
+	 * Check if a node is non-null, is an instance of EventInstanceNode, and that it has a parent and
+	 * still exists in the events tree. This is useful with 
 	 * {@link javax.swing.JTree#getLastSelectedPathComponent() getLastSelectedPathComponent()} or
 	 * {@link javax.swing.tree.TreePath#getLastPathComponent() getLastPathComponent()} because they
 	 * can return nodes already removed from the tree.
@@ -706,7 +706,7 @@ public class GmObjectFrame extends InstantiableResourceFrame<GmObject,PGmObject>
 	 * 
 	 * @return Whether the node is valid.
 	 */
-	private static boolean isValidEventInstanceNode(Object node)
+	public static boolean isValidEventInstanceNode(Object node)
 		{
 		return (node != null && node instanceof EventInstanceNode
 				&& ((EventInstanceNode) node).getParent() != null);

--- a/org/lateralgm/subframes/GmObjectFrame.java
+++ b/org/lateralgm/subframes/GmObjectFrame.java
@@ -325,9 +325,8 @@ public class GmObjectFrame extends InstantiableResourceFrame<GmObject,PGmObject>
 			if (!support.isDataFlavorSupported(EventNode.EVENTNODE_FLAVOR)) return false;
 			EventNode t = (EventNode) LGM.eventSelect.events.getLastSelectedPathComponent();
 			if (t == null || !t.isValid()) return false;
-			Object n = (Object) events.getLastSelectedPathComponent();
 			if (LGM.eventSelect.function.getValue() != EventPanel.FUNCTION_ADD
-					&& !isValidEventInstanceNode(n))
+					&& !isValidEventInstanceNode(events.getLastSelectedPathComponent()))
 				return false;
 			if (rootEvent.contains(new Event(t.mainId,t.eventId,t.other))) return false;
 			for (DataFlavor f : support.getDataFlavors())

--- a/org/lateralgm/subframes/GmObjectFrame.java
+++ b/org/lateralgm/subframes/GmObjectFrame.java
@@ -326,9 +326,9 @@ public class GmObjectFrame extends InstantiableResourceFrame<GmObject,PGmObject>
 			EventNode t = (EventNode) LGM.eventSelect.events.getLastSelectedPathComponent();
 			if (t == null || !t.isValid()) return false;
 			Object n = (Object) events.getLastSelectedPathComponent();
-			if (LGM.eventSelect.function.getValue() != EventPanel.FUNCTION_ADD &&
-					!isValidEventInstanceNode(n))
-					return false;
+			if (LGM.eventSelect.function.getValue() != EventPanel.FUNCTION_ADD
+					&& !isValidEventInstanceNode(n))
+				return false;
 			if (rootEvent.contains(new Event(t.mainId,t.eventId,t.other))) return false;
 			for (DataFlavor f : support.getDataFlavors())
 				if (f == EventNode.EVENTNODE_FLAVOR) return true;
@@ -689,7 +689,7 @@ public class GmObjectFrame extends InstantiableResourceFrame<GmObject,PGmObject>
 			{
 			Object comp = events.getLastSelectedPathComponent();
 			if (!isValidEventInstanceNode(comp))
-					return;
+				return;
 			removeEvent((EventInstanceNode) comp);
 			return;
 			}

--- a/org/lateralgm/subframes/GmObjectFrame.java
+++ b/org/lateralgm/subframes/GmObjectFrame.java
@@ -327,8 +327,7 @@ public class GmObjectFrame extends InstantiableResourceFrame<GmObject,PGmObject>
 			if (t == null || !t.isValid()) return false;
 			Object n = (Object) events.getLastSelectedPathComponent();
 			if (LGM.eventSelect.function.getValue() != EventPanel.FUNCTION_ADD &&
-					(n == null || !(n instanceof EventInstanceNode) ||
-					((EventInstanceNode) n).getParent() == null))
+					!isValidEventInstanceNode(n))
 					return false;
 			if (rootEvent.contains(new Event(t.mainId,t.eventId,t.other))) return false;
 			for (DataFlavor f : support.getDataFlavors())
@@ -689,13 +688,18 @@ public class GmObjectFrame extends InstantiableResourceFrame<GmObject,PGmObject>
 		if (e.getSource() == eventDelete || e.getSource() == eventDeleteItem)
 			{
 			Object comp = events.getLastSelectedPathComponent();
-			if (comp == null || !(comp instanceof EventInstanceNode) ||
-					((EventInstanceNode) comp).getParent() == null)
+			if (!isValidEventInstanceNode(comp))
 					return;
 			removeEvent((EventInstanceNode) comp);
 			return;
 			}
 		super.actionPerformed(e);
+		}
+
+	private static boolean isValidEventInstanceNode(Object node)
+		{
+		return (node != null && node instanceof EventInstanceNode
+				&& ((EventInstanceNode) node).getParent() != null);
 		}
 
 	@Override


### PR DESCRIPTION
This continues #260 by fixing an additional issue where a code action could still be added when the action container was null. Additional issues are also fixed including an exception when trying to delete an event and there were no events left for an object. The problem was that getLastPathComponent and getLastSelectedPathComponent will return the last selected node even if it is no longer in the tree. Correcting this means checking if the parent of the node is null. This also makes it so that you will not be allowed to drop on an event tree during a drag and drop if the mode is replace or duplicate and there are no events to actually replace or duplicate in the tree.