### PR TITLE
ActionList fixes for stable branch.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.class
+*.log
 lgm16b4.jar
 lib/

--- a/org/lateralgm/components/ActionList.java
+++ b/org/lateralgm/components/ActionList.java
@@ -427,7 +427,7 @@ public class ActionList extends JList
 			ArrayList<DataFlavor> fl = new ArrayList<DataFlavor>(2);
 			fl.add(ACTION_ARRAY_FLAVOR);
 			if (a.length == 1) fl.add(ACTION_FLAVOR);
-			flavors = fl.toArray(new DataFlavor[2]);
+			flavors = fl.toArray(new DataFlavor[fl.size()]);
 			}
 
 		public Object getTransferData(DataFlavor flavor) throws UnsupportedFlavorException
@@ -484,7 +484,7 @@ public class ActionList extends JList
 					{
 					for (int i = 0; i < indices.length; i++)
 						{
-						if (indices[i] > addIndex)
+						if (indices[i] >= addIndex)
 							{
 							indices[i] += addCount;
 							}
@@ -524,7 +524,8 @@ public class ActionList extends JList
 			ActionListModel alm = (ActionListModel) list.getModel();
 			Transferable t = info.getTransferable();
 
-			int index = alm.list.size();
+			int index = list.getSelectedIndex();
+			if (index < 0) index = alm.getSize();
 			if (info.isDrop()) index = ((JList.DropLocation) info.getDropLocation()).getIndex();
 			if (info.isDataFlavorSupported(ACTION_FLAVOR))
 				{
@@ -540,8 +541,11 @@ public class ActionList extends JList
 				//clone properly for drag-copy or clipboard paste
 				if (!info.isDrop() || info.getDropAction() == COPY) a = a.copy();
 				//now add
-				addIndex = index;
-				addCount = 1;
+				if (indices != null)
+					{
+					addIndex = index;
+					addCount = 1;
+					}
 				alm.add(index,a);
 				list.setSelectedIndex(index);
 				return true;
@@ -562,8 +566,11 @@ public class ActionList extends JList
 				if (!info.isDrop() || info.getDropAction() == COPY) for (int i = 0; i < a.length; i++)
 					a[i] = a[i].copy();
 				//now add
-				addIndex = index;
-				addCount = a.length;
+				if (indices != null)
+					{
+					addIndex = index;
+					addCount = a.length;
+					}
 				alm.addAll(index,Arrays.asList(a));
 				list.setSelectionInterval(index,index + a.length - 1);
 				return true;
@@ -582,8 +589,11 @@ public class ActionList extends JList
 					{
 					return false;
 					}
-				addIndex = index;
-				addCount = 1;
+				if (indices != null)
+					{
+					addIndex = index;
+					addCount = 1;
+					}
 				alm.add(index,a);
 				list.setSelectedIndex(index);
 				return true;
@@ -600,9 +610,9 @@ public class ActionList extends JList
 			{
 			JList list = (JList) c;
 			indices = list.getSelectedIndices();
-			Object[] o = list.getSelectedValues();
-			Action[] a = new Action[o.length];
-			a = Arrays.asList(o).toArray(a);
+			List o = list.getSelectedValuesList();
+			Action[] a = new Action[o.size()];
+			a = (Action[]) o.toArray(a);
 			return new ActionTransferable(a);
 			}
 		}

--- a/org/lateralgm/components/ActionList.java
+++ b/org/lateralgm/components/ActionList.java
@@ -608,9 +608,9 @@ public class ActionList extends JList
 
 		protected Transferable createTransferable(JComponent c)
 			{
-			JList list = (JList) c;
+			JList<Action> list = (JList<Action>) c;
 			indices = list.getSelectedIndices();
-			List o = list.getSelectedValuesList();
+			List<Action> o = list.getSelectedValuesList();
 			Action[] a = new Action[o.size()];
 			a = (Action[]) o.toArray(a);
 			return new ActionTransferable(a);

--- a/org/lateralgm/components/ActionList.java
+++ b/org/lateralgm/components/ActionList.java
@@ -608,11 +608,11 @@ public class ActionList extends JList
 
 		protected Transferable createTransferable(JComponent c)
 			{
-			JList<Action> list = (JList<Action>) c;
+			JList list = (JList) c;
 			indices = list.getSelectedIndices();
-			List<Action> o = list.getSelectedValuesList();
-			Action[] a = new Action[o.size()];
-			a = (Action[]) o.toArray(a);
+			Object[] o = list.getSelectedValues();
+			Action[] a = new Action[o.length];
+			a = Arrays.asList(o).toArray(a);
 			return new ActionTransferable(a);
 			}
 		}

--- a/org/lateralgm/components/ActionList.java
+++ b/org/lateralgm/components/ActionList.java
@@ -517,6 +517,15 @@ public class ActionList extends JList
 			return true;
 			}
 
+		private void stashImportRange(int addIndex, int addCount)
+			{
+			if (indices != null)
+				{
+				this.addIndex = addIndex;
+				this.addCount = addCount;
+				}
+			}
+
 		public boolean importData(TransferHandler.TransferSupport info)
 			{
 			if (!canImport(info)) return false;
@@ -541,11 +550,7 @@ public class ActionList extends JList
 				//clone properly for drag-copy or clipboard paste
 				if (!info.isDrop() || info.getDropAction() == COPY) a = a.copy();
 				//now add
-				if (indices != null)
-					{
-					addIndex = index;
-					addCount = 1;
-					}
+				stashImportRange(index, 1);
 				alm.add(index,a);
 				list.setSelectedIndex(index);
 				return true;
@@ -566,11 +571,7 @@ public class ActionList extends JList
 				if (!info.isDrop() || info.getDropAction() == COPY) for (int i = 0; i < a.length; i++)
 					a[i] = a[i].copy();
 				//now add
-				if (indices != null)
-					{
-					addIndex = index;
-					addCount = a.length;
-					}
+				stashImportRange(index, a.length);
 				alm.addAll(index,Arrays.asList(a));
 				list.setSelectionInterval(index,index + a.length - 1);
 				return true;
@@ -589,11 +590,7 @@ public class ActionList extends JList
 					{
 					return false;
 					}
-				if (indices != null)
-					{
-					addIndex = index;
-					addCount = 1;
-					}
+				stashImportRange(index, 1);
 				alm.add(index,a);
 				list.setSelectedIndex(index);
 				return true;


### PR DESCRIPTION
This ticket attempts to address several issues and various exceptions with the lgm16b4 action list. I have tested this as extensively as I could and I believe that this corrects all of the inconsistencies with the transfer handler and fully resolves #170 for the stable branch.

* *.log is added to .gitignore because those are error logs output by the JVM and I almost committed them by accident
* In 16b4 an exception occurs when dragging more than one action over the project tree or over other controls with transfer handlers. The reason for this is because ActionListTransferable was accidentally constructing its flavor array with a null flavor, because of what seems to be a simple typo. The code there [conditionally builds an ArrayList of data flavors](https://github.com/IsmAvatar/LateralGM/blob/5d238f301f959eae42a66a2eb60f0da422f13679/org/lateralgm/components/ActionList.java#L427) and then converts it to an array, so obviously it should construct the array with the size of that ArrayList. The fix is the single change on line 430 of ActionList.java 
* getSelectedValues() is [a deprecated method](https://docs.oracle.com/javase/7/docs/api/javax/swing/JList.html#getSelectedValues%28%29) and getSelectedValuesList() should be used instead. Important to note that the new method was introduced in Java 7, so that may fail in older JVMs. This is addressed by the changes on lines 603-605 or what is now lines 613-615 
  * **NOTE:** We decided against this for now and will later break compatibility with older JVMs when we have more reasons to do so.
* The reason for changing the less than operator on line 487 to less-than-or-equal is to address an issue with discontinuous multiple selections. This is something not accounted for in the official Java Swing examples. What happens in 16b4 if you add 3 actions, select the first and last with CTRL, and then drag and drop them at index 0 is that the third action will come first followed by what was the first and then finally what was the second. Also if you select the first and the second and then try to drag and drop them at the index between each other the first action will become a duplicate of the second one.
* The changes on lines 527-528 correct the behavior of the paste action. When you pasted actions before it always appended them to the end of the list. Now it will append them to just before the action you have selected, or at the end if the list has no current selection. Which we also discussed and agreed upon in #170
* Finally, the changes that check if indices is null fixes an issue regarding dragging and dropping between two different action lists. This is also an issue the official Java drag and drop example does not account for. The issue can be reproduced in 16b4 by creating two objects, adding two actions to the create event of one of the objects, selecting both actions and dragging them to the second object and then back. What happens is that addIndex is set the first time the second object imports data, but is not cleared because exportDone is never called on it since it came from the first object list. Because it is never cleared it causes it to misbehave when you drag back to the original object. addIndex and addCount are only useful when dragging and dropping in the same list, to account for the old actions being removed.