### PR TITLE
Fixes

### DIFF
--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -1,4 +1,3 @@
 Manifest-Version: 1.0
 Main-Class: org.lateralgm.main.LGM
-Class-Path:
 SplashScreen-Image: org/lateralgm/main/lgm-splash.png

--- a/org/lateralgm/components/ActionListEditor.java
+++ b/org/lateralgm/components/ActionListEditor.java
@@ -164,10 +164,8 @@ public class ActionListEditor extends JPanel
 					&& list.getActionContainer() != null)
 				{
 				Action act = new Action(libAction);
-				int index = list.getSelectedIndex();
-				if (index < 0) index = list.getModel().getSize();
-				((ActionListModel) list.getModel()).add(index, act);
-				list.setSelectedIndex(index);
+				((ActionListModel) list.getModel()).add(act);
+				list.setSelectedValue(act,true);
 				ActionList.openActionFrame(list.parent.get(),act);
 				}
 			super.processMouseEvent(e);


### PR DESCRIPTION
Removes class-path completely from the manifest because it won't build
otherwise, apparently you have to actually put a jar there or nothing.
Undoes #266 because the way GM does it is better. Right clicking is useful
when initially building the list because you expect them to go
sequentially. Inserting at specific locations can be handled by paste and
left click and drag.