### PR TITLE
Reverts and fixes from stable

### DIFF
--- a/org/lateralgm/main/FileChooser.java
+++ b/org/lateralgm/main/FileChooser.java
@@ -574,7 +574,7 @@ public class FileChooser
 	public void open(final URI uri, final FileReader reader)
 		{
 		if (uri == null) return;
-		LGM.setProgressDialogVisible(true);
+		LGM.getProgressDialog().setVisible(false);
 		Thread t = new Thread(new Runnable()
 			{
 				public void run()
@@ -613,10 +613,11 @@ public class FileChooser
 					LGM.setProgressDialogVisible(false);
 					OutputManager.append("\n" + Messages.getString("FileChooser.PROJECTLOADED") + ": " +
 							new Date().toString() + " " + uri.getPath());
-					LGM.reload(true);
 					}
 			});
 		t.start();
+		LGM.setProgressDialogVisible(true);
+		LGM.reload(true);
 		}
 
 	public static FileReader findReader(URI uri)
@@ -733,7 +734,7 @@ public class FileChooser
 		{
 		LGM.resetChanges();
 		System.out.println(uri);
-		LGM.setProgressDialogVisible(true);
+		LGM.getProgressDialog().setVisible(false);
 		Thread t = new Thread(new Runnable()
 			{
 				public void run()
@@ -781,6 +782,7 @@ public class FileChooser
 					}
 			});
 		t.start();
+		LGM.setProgressDialogVisible(true);
 		}
 
 	public FileWriter findWriter(FormatFlavor flavor)

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -265,26 +265,19 @@ public final class LGM
 
 	public static JProgressBar getProgressDialogBar()
 		{
-		getProgressDialog();
 		return progressDialogBar;
 		}
 
 	public static void setProgressDialogVisible(final boolean visible)
 		{
-		SwingUtilities.invokeLater(new Runnable() {
-		@Override
-		public void run()
+		if (progressDialog != null)
 			{
-			if (progressDialog != null)
-				{
-				progressTitle = "Progress Dialog";
-				progressDialogBar.setValue(0);
-				progressDialog.setVisible(visible);
-				return;
-				}
-			getProgressDialog().setVisible(visible);
+			progressTitle = "Progress Dialog";
+			progressDialogBar.setValue(0);
+			progressDialog.setVisible(visible);
+			return;
 			}
-		});
+		getProgressDialog().setVisible(visible);
 		}
 
 	public static void setProgressTitle(String title)
@@ -294,14 +287,8 @@ public final class LGM
 
 	public static void setProgress(final int value, final String message)
 		{
-		SwingUtilities.invokeLater(new Runnable() {
-		@Override
-		public void run()
-			{
-			progressDialog.setTitle(progressTitle + " - " + message);
-			progressDialogBar.setValue(value);
-			}
-		});
+		progressDialog.setTitle(progressTitle + " - " + message);
+		progressDialogBar.setValue(value);
 		}
 
 	private static void createMouseCursors()
@@ -2478,12 +2465,14 @@ public final class LGM
 		splashProgress.complete();
 
 		frame.setVisible(true);
+		// this is necessary for the next call to properly center the frame or
+		// the method won't have the width/height of the window and instead use
+		// the top-left corner of the window instead of the center of the window
 		frame.pack();
-		// this makes sure the first time default location of the window
-		// that has not been stored is centered
+		// this makes sure the first time default location of the window that has
+		// not been stored is centered to the monitor
 		frame.setLocationRelativeTo(null);
-		// This needs to be here after the frame is set to visible for some reason,
-		// it was causing the bug with the frame not memorizing its maximized state.
+		// call this after packing the frame and settings its default location
 		new FramePrefsHandler(frame);
 		// Load any projects entered on the command line
 		if (args.length > 0 && args[0].length() > 0)

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -2464,16 +2464,17 @@ public final class LGM
 		loadPlugins();
 		splashProgress.complete();
 
-		frame.setVisible(true);
 		// this is necessary for the next call to properly center the frame or
-		// the method won't have the width/height of the window and instead use
-		// the top-left corner of the window instead of the center of the window
+		// the method won't have the width/height of the window and instead the
+		// top-left corner of the window will be in the exact center of the screen
 		frame.pack();
 		// this makes sure the first time default location of the window that has
-		// not been stored is centered to the monitor
+		// not been stored is centered to the screen
 		frame.setLocationRelativeTo(null);
-		// call this after packing the frame and settings its default location
+		// call this after packing the frame and setting its default location
 		new FramePrefsHandler(frame);
+
+		frame.setVisible(true);
 		// Load any projects entered on the command line
 		if (args.length > 0 && args[0].length() > 0)
 			{


### PR DESCRIPTION
* Reverts changes that I made attempting to fix the progress dialog freezing. It is an issue that can be addressed at a later time, for now the Oracle JDK is sufficient.
* Imports fixes for the event tree in the object from the stable branch that were fixed in #261
* Removes incorrect fixes, and a related comment, for the previous issue.
* Adds comments to clarify the order of creating the main JFrame and preferences handler. pack() should always be called before making a frame visible. This should make the main frame appear more smoothly now without being shown and then jittering to its size and location.
https://docs.oracle.com/javase/tutorial/uiswing/components/frame.html