### PR TITLE
Patch required Java version 

### DIFF
--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -2072,7 +2072,7 @@ public final class LGM
 		//System.setProperty("com.apple.mrj.application.apple.menu.about.name",Messages.getString("LGM.NAME")); //$NON-NLS-1$ //$NON-NLS-2$
 
 		System.out.format("Java Version: %d (%s)\n",javaVersion,System.getProperty("java.version")); //$NON-NLS-1$
-		if (javaVersion <= 10700)
+		if (javaVersion < 10700)
 			System.out.println("Some program functionality will be limited due to your outdated Java version"); //$NON-NLS-1$
 
 		// Load external look and feels the user has plugged in


### PR DESCRIPTION
We require a minimum of Java 7, this was telling Java 7 users they had an
outdated Java version. I went and checked all uses of this variable, and I
am certain we are not using anything newer than Java 6.