### PR TITLE
Add a check for Java 7 locale functionality

### DIFF
--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -1964,7 +1964,7 @@ public final class LGM
 	}
 
 	public static void applyPreferences() {
-		if (!Prefs.locale.toLanguageTag().equals("und") && javaVersion >= 10700) {
+		if (javaVersion >= 10700 && !Prefs.locale.toLanguageTag().equals("und")) {
 			Locale.setDefault(Prefs.locale);
 			System.out.println(Locale.getDefault());
 		}

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -1964,10 +1964,10 @@ public final class LGM
 	}
 
 	public static void applyPreferences() {
-		if (!Prefs.locale.toLanguageTag().equals("und")) {
+		if (!Prefs.locale.toLanguageTag().equals("und") && javaVersion >= 10700) {
 			Locale.setDefault(Prefs.locale);
+			System.out.println(Locale.getDefault());
 		}
-		System.out.println(Locale.getDefault());
 
 		if (Prefs.direct3DAcceleration.equals("off")) { //$NON-NLS-1$
 			//java6u10 regression causes graphical xor to be very slow


### PR DESCRIPTION
Locale.setDefault is actually a Java 7 function, currently the only Java 7 function being called that I know of.