### PR TITLE
Fixes Goto Dialog Layout and Cleanup

### DIFF
--- a/org/lateralgm/components/CodeTextArea.java
+++ b/org/lateralgm/components/CodeTextArea.java
@@ -10,10 +10,6 @@
 
 package org.lateralgm.components;
 
-import static java.lang.Integer.MAX_VALUE;
-import static javax.swing.GroupLayout.DEFAULT_SIZE;
-import static javax.swing.GroupLayout.PREFERRED_SIZE;
-
 import java.awt.Color;
 import java.awt.Font;
 import java.awt.Frame;

--- a/org/lateralgm/components/CodeTextArea.java
+++ b/org/lateralgm/components/CodeTextArea.java
@@ -10,6 +10,10 @@
 
 package org.lateralgm.components;
 
+import static java.lang.Integer.MAX_VALUE;
+import static javax.swing.GroupLayout.DEFAULT_SIZE;
+import static javax.swing.GroupLayout.PREFERRED_SIZE;
+
 import java.awt.Color;
 import java.awt.Font;
 import java.awt.Frame;
@@ -275,7 +279,7 @@ public class CodeTextArea extends JoshTextPanel implements UpdateListener,Action
 		/*	*/.addComponent(f))
 		/**/.addComponent(b,Alignment.CENTER));
 		layout.setVerticalGroup(layout.createSequentialGroup()
-		/**/.addGroup(layout.createParallelGroup()
+		/**/.addGroup(layout.createParallelGroup(Alignment.BASELINE)
 		/*	*/.addComponent(l)
 		/*	*/.addComponent(f))
 		/**/.addComponent(b));

--- a/org/lateralgm/subframes/PreferencesFrame.java
+++ b/org/lateralgm/subframes/PreferencesFrame.java
@@ -296,22 +296,22 @@ public class PreferencesFrame extends JDialog implements ActionListener
 		/*	*/.addComponent(localeWarningLabel))
 		/**/.addGroup(gl.createParallelGroup(Alignment.BASELINE)
 		/*	*/.addComponent(documentationLabel)
-		/*	*/.addComponent(documentationURI,PREFERRED_SIZE,DEFAULT_SIZE,PREFERRED_SIZE)
+		/*	*/.addComponent(documentationURI)
 		/*	*/.addComponent(documentationBrowse))
 		/**/.addGroup(gl.createParallelGroup(Alignment.BASELINE)
 		/*	*/.addComponent(websiteLabel)
-		/*	*/.addComponent(websiteURI,PREFERRED_SIZE,DEFAULT_SIZE,PREFERRED_SIZE)
+		/*	*/.addComponent(websiteURI)
 		/*	*/.addComponent(websiteBrowse))
 		/**/.addGroup(gl.createParallelGroup(Alignment.BASELINE)
 		/*	*/.addComponent(communityLabel)
-		/*	*/.addComponent(communityURI,PREFERRED_SIZE,DEFAULT_SIZE,PREFERRED_SIZE)
+		/*	*/.addComponent(communityURI)
 		/*	*/.addComponent(communityBrowse))
 		/**/.addGroup(gl.createParallelGroup(Alignment.BASELINE)
 		/*	*/.addComponent(issueLabel)
-		/*	*/.addComponent(issueURI,PREFERRED_SIZE,DEFAULT_SIZE,PREFERRED_SIZE)
+		/*	*/.addComponent(issueURI)
 		/*	*/.addComponent(issueBrowse))
 		/**/.addGroup(gl.createParallelGroup(Alignment.CENTER)
-		/*	*/.addComponent(backupsPanel,PREFERRED_SIZE,DEFAULT_SIZE,PREFERRED_SIZE)
+		/*	*/.addComponent(backupsPanel)
 		/*	*/.addGroup(gl.createSequentialGroup()
 		/*		*/.addComponent(dndEnable)
 		/*		*/.addComponent(dockEvent)
@@ -518,10 +518,10 @@ public class PreferencesFrame extends JDialog implements ActionListener
 		hardwareAccelerationLayout.setVerticalGroup(hardwareAccelerationLayout.createSequentialGroup()
 		/*	*/.addGroup(hardwareAccelerationLayout.createParallelGroup(Alignment.BASELINE)
 		/*			*/.addComponent(direct3DLabel)
-		/*			*/.addComponent(direct3DCombo,PREFERRED_SIZE,DEFAULT_SIZE,PREFERRED_SIZE))
+		/*			*/.addComponent(direct3DCombo))
 		/*	*/.addGroup(hardwareAccelerationLayout.createParallelGroup(Alignment.BASELINE)
 		/*			*/.addComponent(openGLLabel)
-		/*			*/.addComponent(openGLCombo,PREFERRED_SIZE,DEFAULT_SIZE,PREFERRED_SIZE)));
+		/*			*/.addComponent(openGLCombo)));
 
 		hardwareAccelerationPanel.setLayout(hardwareAccelerationLayout);
 
@@ -622,22 +622,22 @@ public class PreferencesFrame extends JDialog implements ActionListener
 		gl.setVerticalGroup(gl.createSequentialGroup()
 		/**/.addGroup(gl.createParallelGroup(Alignment.BASELINE)
 		/* */.addComponent(themeLabel)
-		/* */.addComponent(themeCombo,PREFERRED_SIZE,DEFAULT_SIZE,PREFERRED_SIZE)
+		/* */.addComponent(themeCombo)
 		/* */.addComponent(iconLabel)
-		/* */.addComponent(iconCombo,PREFERRED_SIZE,DEFAULT_SIZE,PREFERRED_SIZE)
+		/* */.addComponent(iconCombo)
 		/* */.addComponent(antialiasLabel)
-		/* */.addComponent(antialiasCombo,PREFERRED_SIZE,DEFAULT_SIZE,PREFERRED_SIZE)
+		/* */.addComponent(antialiasCombo)
 		/* */.addComponent(decorateWindowBordersCheckBox))
 		/**/.addGroup(gl.createParallelGroup(Alignment.BASELINE)
 		/* */.addComponent(themePathLabel)
-		/* */.addComponent(themePath,PREFERRED_SIZE,DEFAULT_SIZE,PREFERRED_SIZE))
+		/* */.addComponent(themePath))
 		/**/.addGroup(gl.createParallelGroup(Alignment.BASELINE)
 		/* */.addComponent(iconPathLabel)
-		/* */.addComponent(iconPath,PREFERRED_SIZE,DEFAULT_SIZE,PREFERRED_SIZE))
+		/* */.addComponent(iconPath))
 		/**/.addGroup(gl.createParallelGroup(Alignment.BASELINE)
 		/* */.addComponent(imagePreviewPanel)
-		/* */.addComponent(hardwareAccelerationPanel,PREFERRED_SIZE,PREFERRED_SIZE,PREFERRED_SIZE))
-		/**/.addComponent(searchResultsPanel,PREFERRED_SIZE,DEFAULT_SIZE,PREFERRED_SIZE));
+		/* */.addComponent(hardwareAccelerationPanel))
+		/**/.addComponent(searchResultsPanel));
 
 		gl.linkSize(SwingConstants.VERTICAL, imagePreviewPanel, hardwareAccelerationPanel);
 
@@ -680,7 +680,7 @@ public class PreferencesFrame extends JDialog implements ActionListener
 				labelGroup.addComponent(label);
 				textfieldGroup.addComponent(textfield);
 				vg.addComponent(label);
-				vg.addComponent(textfield,PREFERRED_SIZE,PREFERRED_SIZE,PREFERRED_SIZE);
+				vg.addComponent(textfield);
 
 				verticalGroup.addGroup(vg);
 				}
@@ -1058,11 +1058,11 @@ public class PreferencesFrame extends JDialog implements ActionListener
 		/**/gl.createSequentialGroup()
 		/*	*/.addGroup(gl.createParallelGroup(Alignment.BASELINE)
 		/*		*/.addComponent(undoHistorySizeLabel)
-		/*		*/.addComponent(undoHistorySize,PREFERRED_SIZE,PREFERRED_SIZE,PREFERRED_SIZE))
+		/*		*/.addComponent(undoHistorySize))
 		/*	*/.addGroup(gl.createParallelGroup()
-		/*		*/.addComponent(selectionPanel,PREFERRED_SIZE,PREFERRED_SIZE,PREFERRED_SIZE)
-		/*		*/.addComponent(multipleSelectionPanel,PREFERRED_SIZE,PREFERRED_SIZE,PREFERRED_SIZE))
-		/*	*/.addComponent(viewsPanel,PREFERRED_SIZE,PREFERRED_SIZE,PREFERRED_SIZE));
+		/*		*/.addComponent(selectionPanel)
+		/*		*/.addComponent(multipleSelectionPanel))
+		/*	*/.addComponent(viewsPanel));
 
 		return roomEditorPanel;
 		}


### PR DESCRIPTION
I noticed the goto dialog had the text field a little too high and went to fix it the same way I fixed the preferences frame. I noticed that by setting the alignment to baseline, it is not necessary to add all of the preferred_size crap, and that's why the official Oracle examples for GroupLayout work without adding that crap. So I also removed all of that crap from the preferences frame where it is not needed. I then tested all look and feels on Linux and Windows and the layouts seem to work great.