### PR TITLE
Cleanup some code

### DIFF
--- a/org/lateralgm/components/PackageResourcesDialog.java
+++ b/org/lateralgm/components/PackageResourcesDialog.java
@@ -54,7 +54,7 @@ public class PackageResourcesDialog extends JDialog
 	 */
 	private static final long serialVersionUID = 3642639396173517907L;
 
-	private static PackageResourcesDialog instance = new PackageResourcesDialog(LGM.frame);
+	private static PackageResourcesDialog instance;
 
 	public class TypeCheckBox extends JCheckBox {
 	/**
@@ -78,6 +78,7 @@ public class PackageResourcesDialog extends JDialog
 			TypeCheckBox cb =	model.getElementAt(i);
 			cb.setSelected(selected);
 		}
+
 		typeList.repaint();
 	}
 
@@ -111,14 +112,17 @@ public class PackageResourcesDialog extends JDialog
 
 	public void populateKindList() {
 		DefaultListModel<TypeCheckBox> model = new DefaultListModel<TypeCheckBox>();
+
 		for (Class<?> kind : Resource.kinds) {
 			model.addElement(new TypeCheckBox(kind));
 		}
+
 		typeList.setModel(model);
 	}
 
 	public void setVisible(boolean visible) {
 		super.setVisible(visible);
+
 		if (visible) {
 			populateKindList();
 		}
@@ -128,10 +132,11 @@ public class PackageResourcesDialog extends JDialog
 		super(parent);
 		this.setTitle(Messages.getString("PackageResources.TITLE"));
 		this.setIconImage(LGM.getIconForKey("PackageResources.ICON").getImage());
-		//setResizable(false);
+		this.setResizable(false);
 
 		typeList = new JList<TypeCheckBox>();
 		typeList.setCellRenderer(new CheckBoxListCellRenderer());
+		typeList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
 
 		typeList.addMouseListener(new MouseAdapter()
 			 {
@@ -140,17 +145,13 @@ public class PackageResourcesDialog extends JDialog
 						 int index = typeList.locationToIndex(e.getPoint());
 
 						 if (index != -1) {
-								TypeCheckBox checkbox = (TypeCheckBox)
-														typeList.getModel().getElementAt(index);
-								checkbox.setSelected(
-																	 !checkbox.isSelected());
+								TypeCheckBox checkbox = (TypeCheckBox) typeList.getModel().getElementAt(index);
+								checkbox.setSelected(!checkbox.isSelected());
 								repaint();
 						 }
 					}
 			 }
 		);
-
-		typeList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
 
 		JScrollPane typeScroll = new JScrollPane(typeList);
 
@@ -222,17 +223,12 @@ public class PackageResourcesDialog extends JDialog
 		this.setLayout(gl);
 
 		this.pack();
-		setLocationRelativeTo(parent);
+		this.setLocationRelativeTo(parent);
 	}
 
 	public static PackageResourcesDialog getInstance()
 		{
-			return instance;
-		}
-
-	public static void setInstance(PackageResourcesDialog instance)
-		{
-			PackageResourcesDialog.instance = instance;
+			return instance == null ? instance = new PackageResourcesDialog(LGM.frame) : instance;
 		}
 
 	protected class CheckBoxListCellRenderer implements ListCellRenderer<JCheckBox>

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -196,7 +196,6 @@ public final class LGM
 	public static File tempDir, workDir;
 	static
 		{
-
 		//Get Java Version
 		String jv = System.getProperty("java.version"); //$NON-NLS-1$
 		Scanner s = new Scanner(jv);
@@ -2006,40 +2005,45 @@ public final class LGM
 		// this is necessary to make sure open/save dialogs get fixed
 		JFrame.setDefaultLookAndFeelDecorated(Prefs.decorateWindowBorders);
 		JDialog.setDefaultLookAndFeelDecorated(Prefs.decorateWindowBorders);
-		// all this code is necessary to make sure toggling window decorations
-		// do not cause frameless borders
+
 		Window[] windows = Window.getWindows();
+		LookAndFeel laf = UIManager.getLookAndFeel();
 		for (Window window : windows) {
-			boolean visible = window.isVisible();
-			LookAndFeel laf = UIManager.getLookAndFeel();
-			boolean decorate = Prefs.decorateWindowBorders && laf.getSupportsWindowDecorations();
+			final boolean visible = window.isVisible();
+			final boolean decorate = Prefs.decorateWindowBorders && laf.getSupportsWindowDecorations();
 			if (window instanceof Frame) {
-				Frame decframe = (Frame) window;
+				final Frame decframe = (Frame) window;
 				if (decorate != decframe.isUndecorated()) {
-					//System.out.println(decframe.getTitle() + " : " + visible);
-					decframe.dispose();
-					decframe.setShape(null);
-					decframe.setUndecorated(decorate);
-					decframe.setVisible(visible);
-					// check cast to make sure we don't screw with the MDI frames.
-					if (decframe instanceof RootPaneContainer) {
-						((RootPaneContainer) decframe).getRootPane().setWindowDecorationStyle(decorate ? JRootPane.FRAME : JRootPane.NONE);
-					}
+					SwingUtilities.invokeLater(new Runnable() {
+						@Override
+						public void run()
+							{
+							decframe.dispose();
+							decframe.setShape(null);
+							decframe.setUndecorated(decorate);
+							if (decframe instanceof RootPaneContainer)
+								((RootPaneContainer) decframe).getRootPane().setWindowDecorationStyle(
+										decorate ? JRootPane.FRAME : JRootPane.NONE);
+							decframe.setVisible(visible);
+							}
+					});
 				}
 			} else if (window instanceof Dialog) {
-				Dialog decdialog = (Dialog) window;
+				final Dialog decdialog = (Dialog) window;
 				if (decorate != decdialog.isUndecorated()) {
-					//TODO: isVisible()/isShowing() for Dialog does not work at all
-					visible = decdialog.isVisible();
-					//System.out.println(decdialog.getTitle() + " : " + visible);
-					decdialog.dispose();
-					decdialog.setShape(null);
-					decdialog.setUndecorated(decorate);
-					decdialog.setVisible(visible);
-					// check cast to make sure we don't screw with the MDI frames.
-					if (decdialog instanceof RootPaneContainer) {
-						((RootPaneContainer) decdialog).getRootPane().setWindowDecorationStyle(decorate ? JRootPane.FRAME : JRootPane.NONE);
-					}
+					SwingUtilities.invokeLater(new Runnable() {
+						@Override
+						public void run()
+							{
+							decdialog.dispose();
+							decdialog.setShape(null);
+							decdialog.setUndecorated(decorate);
+							if (decdialog instanceof RootPaneContainer)
+								((RootPaneContainer) decdialog).getRootPane().setWindowDecorationStyle(
+										decorate ? JRootPane.PLAIN_DIALOG : JRootPane.NONE);
+							decdialog.setVisible(visible);
+							}
+					});
 				}
 			}
 		}


### PR DESCRIPTION
Fixes changing window decorations at runtime so that isVisible will report correctly for owned dialogs by wrapping the decoration change in a SwingUtilities runnable. Important to mention that the code still has a bug for dialogs because it does not remember their window decoration style, which can be different than PLAIN_DIALOG for error and warning messages as well as file choosers.