### PR TITLE
General Fixes and Improvements

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry excluding="modules/|joshedit/" kind="src" path=""/>
-	<classpathentry kind="src" path="modules/joshedit"/>
+	<classpathentry excluding=".classpath|.git|.gitignore|.project|.settings/" kind="src" path="modules/joshedit"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/description.jardesc
+++ b/description.jardesc
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?xml version="1.0" encoding="WINDOWS-1252" standalone="no"?>
 <jardesc>
     <jar path="LateralGM/lateralgm.jar"/>
     <options buildIfNeeded="true" compress="true" descriptionLocation="/LateralGM/description.jardesc" exportErrors="false" exportWarnings="true" includeDirectoryEntries="false" overwrite="true" saveDescription="true" storeRefactorings="false" useSourceFolders="false"/>

--- a/org/lateralgm/components/AboutBox.java
+++ b/org/lateralgm/components/AboutBox.java
@@ -49,7 +49,7 @@ public class AboutBox extends JDialog implements PropertyChangeListener
 		{
 		super(owner,Messages.getString("AboutBox.TITLE"),true);
 		setResizable(false);
-		JEditorPane ep = new JEditorPane("text/html",Messages.getString("AboutBox.ABOUT"));
+		JEditorPane ep = new JEditorPane("text/html",Messages.format("AboutBox.ABOUT",LGM.version));
 		addSSRules(((HTMLDocument) ep.getDocument()).getStyleSheet());
 		ep.setOpaque(false);
 		ep.setEditable(false);

--- a/org/lateralgm/components/EffectsFrame.java
+++ b/org/lateralgm/components/EffectsFrame.java
@@ -245,7 +245,7 @@ public class EffectsFrame extends JFrame implements ActionListener, EffectOption
 		/*	*/.addComponent(beforePreview)
 		/*	*/.addComponent(afterPreview))
 		/**/.addGroup(gl.createSequentialGroup()
-		/*	*/.addComponent(effectsCombo, PREFERRED_SIZE, PREFERRED_SIZE, effectsCombo.getPreferredSize().width * 2)
+		/*	*/.addComponent(effectsCombo, PREFERRED_SIZE, PREFERRED_SIZE, PREFERRED_SIZE)
 		/*	*/.addComponent(applyButton)
 		/*	*/.addComponent(closeButton))
 		/**/.addComponent(effectsOptions));
@@ -254,8 +254,8 @@ public class EffectsFrame extends JFrame implements ActionListener, EffectOption
 		/**/.addGroup(gl.createParallelGroup()
 		/*	*/.addComponent(beforePreview)
 		/*	*/.addComponent(afterPreview))
-		/**/.addGroup(gl.createParallelGroup(Alignment.CENTER)
-		/*	*/.addComponent(effectsCombo, PREFERRED_SIZE, PREFERRED_SIZE, PREFERRED_SIZE)
+		/**/.addGroup(gl.createParallelGroup(Alignment.BASELINE)
+		/*	*/.addComponent(effectsCombo)
 		/*	*/.addComponent(applyButton)
 		/*	*/.addComponent(closeButton))
 		/**/.addComponent(effectsOptions, PREFERRED_SIZE, PREFERRED_SIZE, PREFERRED_SIZE));

--- a/org/lateralgm/file/GMXFileReader.java
+++ b/org/lateralgm/file/GMXFileReader.java
@@ -863,10 +863,12 @@ public final class GMXFileReader
 						Integer.parseInt(pthdoc.getElementsByTagName("precision").item(0).getTextContent()));
 				pth.put(PPath.CLOSED,
 						Integer.parseInt(pthdoc.getElementsByTagName("closed").item(0).getTextContent()) != 0);
-				final String proptext = pthdoc.getElementsByTagName("backroom").item(0).getTextContent();
+				final int backroom = Integer.parseInt(pthdoc.getElementsByTagName("backroom").item(0).getTextContent());
 
-				PostponedRef pr = new PostponedRef()
+				if (backroom >= 0)
 					{
+					PostponedRef pr = new PostponedRef()
+						{
 						public boolean invoke()
 							{
 							ResourceList<Room> list = f.resMap.getList(Room.class);
@@ -874,17 +876,19 @@ public final class GMXFileReader
 								{
 								return false;
 								}
-							Room rmn = list.get(proptext);
+
+							Room rmn = list.getUnsafe(backroom);
 							if (rmn == null)
 								{
 								return false;
 								}
-							pth.put(PPath.BACKGROUND_ROOM,rmn.reference);
 
+							pth.put(PPath.BACKGROUND_ROOM,rmn.reference);
 							return true;
 							}
-					};
-				postpone.add(pr);
+						};
+					postpone.add(pr);
+					}
 
 				pth.put(PPath.SNAP_X,
 						Integer.parseInt(pthdoc.getElementsByTagName("hsnap").item(0).getTextContent()));

--- a/org/lateralgm/file/GMXFileReader.java
+++ b/org/lateralgm/file/GMXFileReader.java
@@ -206,26 +206,27 @@ public final class GMXFileReader
 		file.format = ProjectFile.FormatFlavor.getVersionFlavor(1200); // GMX will have version numbers in the future
 		if (documentBuilderFactory == null)
 			documentBuilderFactory = DocumentBuilderFactory.newInstance();
+		if (documentBuilder == null)
+			try
+				{
+				documentBuilder = documentBuilderFactory.newDocumentBuilder();
+				}
+			catch (ParserConfigurationException e1)
+				{
+				throw new GmFormatException(file,e1);
+				}
 		Document document = null;
 		try
 			{
-			documentBuilder = documentBuilderFactory.newDocumentBuilder();
-			try
-				{
-				document = documentBuilder.parse(new File(uri));
-				}
-			catch (SAXException e)
-				{
-				throw new GmFormatException(file,e);
-				}
-			catch (IOException e)
-				{
-				throw new GmFormatException(file,e);
-				}
+			document = documentBuilder.parse(new File(uri));
 			}
-		catch (ParserConfigurationException e1)
+		catch (SAXException e)
 			{
-			throw new GmFormatException(file,e1);
+			throw new GmFormatException(file,e);
+			}
+		catch (IOException e)
+			{
+			throw new GmFormatException(file,e);
 			}
 
 		RefList<Timeline> timeids = new RefList<Timeline>(Timeline.class); // timeline ids

--- a/org/lateralgm/file/GMXFileReader.java
+++ b/org/lateralgm/file/GMXFileReader.java
@@ -119,9 +119,8 @@ import com.sun.org.apache.xerces.internal.impl.dv.util.HexBin;
 // There is a downside to SAX such as incompatibility with UTF-8
 public final class GMXFileReader
 	{
-
-	static DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-	static DocumentBuilder documentBuilder;
+	private static DocumentBuilderFactory documentBuilderFactory;
+	private static DocumentBuilder documentBuilder;
 
 	private GMXFileReader()
 		{
@@ -205,6 +204,8 @@ public final class GMXFileReader
 			Charset forceCharset) throws GmFormatException
 		{
 		file.format = ProjectFile.FormatFlavor.getVersionFlavor(1200); // GMX will have version numbers in the future
+		if (documentBuilderFactory == null)
+			documentBuilderFactory = DocumentBuilderFactory.newInstance();
 		Document document = null;
 		try
 			{

--- a/org/lateralgm/file/GMXFileReader.java
+++ b/org/lateralgm/file/GMXFileReader.java
@@ -1503,7 +1503,6 @@ public final class GMXFileReader
 				node.add(rnode);
 				}
 			}
-
 		}
 
 	private static void readGmObjects(ProjectFileContext c, ResNode root) throws IOException,

--- a/org/lateralgm/file/GMXFileWriter.java
+++ b/org/lateralgm/file/GMXFileWriter.java
@@ -113,8 +113,7 @@ import com.sun.org.apache.xerces.internal.impl.dv.util.HexBin;
 
 public final class GMXFileWriter
 	{
-
-	private static DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+	private static DocumentBuilderFactory documentBuilderFactory;
 	private static DocumentBuilder documentBuilder;
 
 	private GMXFileWriter()
@@ -145,6 +144,8 @@ public final class GMXFileWriter
 		f.format = ProjectFile.FormatFlavor.getVersionFlavor(ver);
 		long savetime = System.currentTimeMillis();
 
+		if (documentBuilderFactory == null)
+			documentBuilderFactory = DocumentBuilderFactory.newInstance();
 		Document dom = null;
 		try
 			{
@@ -629,8 +630,8 @@ public final class GMXFileWriter
 					doc.appendChild(sndroot);
 
 					// GMX uses double nested tags for volume, bit rate, sample rate, type, and bit depth
-					// There is an exception here. In every one of those tags after volume the nested
-					// tag is singular, where its parent is plural.
+					// There is an exception to this however. In every one of those tags after volume the
+					// nested tag is singular, where its parent is plural.
 					String ftype = snd.get(PSound.FILE_TYPE).toString();
 					sndroot.appendChild(createElement(doc,"extension",ftype));
 					sndroot.appendChild(createElement(doc,"origname",snd.get(PSound.FILE_NAME).toString()));

--- a/org/lateralgm/file/GMXFileWriter.java
+++ b/org/lateralgm/file/GMXFileWriter.java
@@ -536,7 +536,10 @@ public final class GMXFileWriter
 						frameNode.setAttribute("index",Integer.toString(j));
 						frameroot.appendChild(frameNode);
 						BufferedImage sub = spr.subImages.get(j);
-						ImageIO.write(sub,"png",outputfile);
+						// GMX does have a backwards compatibility property for transparency pixel so we write
+						// the image with the transparency removed when that setting is checked
+						ImageIO.write((Boolean) spr.get(
+								PSprite.TRANSPARENT) ? Util.getTransparentImage(sub) : sub,"png",outputfile);
 						}
 					sprroot.appendChild(frameroot);
 

--- a/org/lateralgm/file/GMXFileWriter.java
+++ b/org/lateralgm/file/GMXFileWriter.java
@@ -246,6 +246,34 @@ public final class GMXFileWriter
 			return bool ? "-1" : "0";
 		}
 
+	public static <R extends Resource<R,?>> String getName(ResourceReference<R> ref)
+		{
+		return getName(ref,"<undefined>");
+		}
+
+	public static <R extends Resource<R,?>> String getName(ResourceReference<R> ref, String noneval)
+		{
+		Resource<?,?> res = deRef(ref);
+		if (res != null && res instanceof InstantiableResource<?,?>)
+			return ((InstantiableResource<?,?>) res).getName();
+		else
+			return noneval;
+		}
+
+	public static <R extends Resource<R,?>> int getId(ResourceReference<R> ref)
+		{
+		return getId(ref,-1);
+		}
+
+	public static <R extends Resource<R,?>> int getId(ResourceReference<R> ref, int noneval)
+		{
+		Resource<?,?> res = deRef(ref);
+		if (res != null && res instanceof InstantiableResource<?,?>)
+			return ((InstantiableResource<?,?>) res).getId();
+		else
+			return noneval;
+		}
+
 	public static void writeConfigurations(ProjectFileContext c, Element root) throws IOException,
 			TransformerException
 		{
@@ -857,17 +885,8 @@ public final class GMXFileWriter
 					int closed = path.get(PPath.CLOSED) ? -1 : 0;
 					pathroot.appendChild(createElement(doc,"closed",Integer.toString(closed)));
 					pathroot.appendChild(createElement(doc,"precision",path.get(PPath.PRECISION).toString()));
-
-					ResourceReference<Room> bgroom = path.get(PPath.BACKGROUND_ROOM);
-					if (bgroom != null)
-						{
-						pathroot.appendChild(createElement(doc,"backroom",bgroom.get().getName()));
-						}
-					else
-						{
-						pathroot.appendChild(createElement(doc,"backroom","-1"));
-						}
-
+					pathroot.appendChild(createElement(doc,"backroom",
+							Integer.toString(getId((ResourceReference<?>)path.get(PPath.BACKGROUND_ROOM)))));
 					pathroot.appendChild(createElement(doc,"hsnap",path.get(PPath.SNAP_X).toString()));
 					pathroot.appendChild(createElement(doc,"vsnap",path.get(PPath.SNAP_Y).toString()));
 
@@ -1333,16 +1352,8 @@ public final class GMXFileWriter
 
 					Element objroot = doc.createElement("object");
 					doc.appendChild(objroot);
-
-					ResourceReference<?> spr = object.get(PGmObject.SPRITE);
-					if (spr != null)
-						{
-						objroot.appendChild(createElement(doc,"spriteName",spr.get().getName()));
-						}
-					else
-						{
-						objroot.appendChild(createElement(doc,"spriteName","<undefined>"));
-						}
+					objroot.appendChild(createElement(doc,"spriteName",
+							getName((ResourceReference<?>)object.get(PGmObject.SPRITE))));
 					objroot.appendChild(createElement(doc,"solid",
 							boolToString((Boolean) object.get(PGmObject.SOLID))));
 					objroot.appendChild(createElement(doc,"visible",
@@ -1350,25 +1361,10 @@ public final class GMXFileWriter
 					objroot.appendChild(createElement(doc,"depth",object.get(PGmObject.DEPTH).toString()));
 					objroot.appendChild(createElement(doc,"persistent",
 							boolToString((Boolean) object.get(PGmObject.PERSISTENT))));
-					spr = object.get(PGmObject.MASK);
-					if (spr != null)
-						{
-						objroot.appendChild(createElement(doc,"maskName",spr.get().getName()));
-						}
-					else
-						{
-						objroot.appendChild(createElement(doc,"maskName","<undefined>"));
-						}
-
-					ResourceReference<?> par = object.get(PGmObject.PARENT);
-					if (par != null)
-						{
-						objroot.appendChild(createElement(doc,"parentName",par.get().getName()));
-						}
-					else
-						{
-						objroot.appendChild(createElement(doc,"parentName","<undefined>"));
-						}
+					objroot.appendChild(createElement(doc,"maskName",
+							getName((ResourceReference<?>)object.get(PGmObject.MASK))));
+					objroot.appendChild(createElement(doc,"parentName",
+							getName((ResourceReference<?>)object.get(PGmObject.PARENT))));
 
 					Element evtroot = doc.createElement("events");
 					for (int i = 0; i < object.mainEvents.size(); i++)
@@ -1381,15 +1377,8 @@ public final class GMXFileWriter
 							evtelement.setAttribute("eventtype",Integer.toString(ev.mainId));
 							if (ev.mainId == MainEvent.EV_COLLISION)
 								{
-								ResourceReference<GmObject> other = ev.other;
-								if (other != null)
-									{
-									evtelement.setAttribute("ename",other.get().getName());
-									}
-								else
-									{
-									evtelement.setAttribute("ename","<undefined>");
-									}
+								evtelement.setAttribute("ename",
+										getName((ResourceReference<GmObject>)ev.other));
 								}
 							else
 								{
@@ -1578,15 +1567,8 @@ public final class GMXFileWriter
 								boolToString((Boolean) props.get(PBackgroundDef.VISIBLE)));
 						bckelement.setAttribute("foreground",
 								boolToString((Boolean) props.get(PBackgroundDef.FOREGROUND)));
-						ResourceReference<?> br = props.get(PBackgroundDef.BACKGROUND);
-						if (br != null)
-							{
-							bckelement.setAttribute("name",br.get().getName());
-							}
-						else
-							{
-							bckelement.setAttribute("name","");
-							}
+						bckelement.setAttribute("name",
+								getName((ResourceReference<?>)props.get(PBackgroundDef.BACKGROUND),""));
 						bckelement.setAttribute("x",Integer.toString((Integer) props.get(PBackgroundDef.X)));
 						bckelement.setAttribute("y",Integer.toString((Integer) props.get(PBackgroundDef.Y)));
 						bckelement.setAttribute("htiled",
@@ -1611,15 +1593,8 @@ public final class GMXFileWriter
 						viewroot.appendChild(vwelement);
 
 						vwelement.setAttribute("visible",boolToString((Boolean) props.get(PView.VISIBLE)));
-						ResourceReference<?> or = (ResourceReference<?>) props.get(PView.OBJECT);
-						if (or != null)
-							{
-							vwelement.setAttribute("objName",or.get().getName());
-							}
-						else
-							{
-							vwelement.setAttribute("objName","<undefined>");
-							}
+						vwelement.setAttribute("objName",
+								getName((ResourceReference<?>) props.get(PView.OBJECT)));
 						vwelement.setAttribute("xview",Integer.toString((Integer) props.get(PView.VIEW_X)));
 						vwelement.setAttribute("yview",Integer.toString((Integer) props.get(PView.VIEW_Y)));
 						vwelement.setAttribute("wview",Integer.toString((Integer) props.get(PView.VIEW_W)));
@@ -1641,15 +1616,8 @@ public final class GMXFileWriter
 						{
 						Element inselement = doc.createElement("instance");
 						insroot.appendChild(inselement);
-						ResourceReference<GmObject> or = in.properties.get(PInstance.OBJECT);
-						if (or != null)
-							{
-							inselement.setAttribute("objName",or.get().getName());
-							}
-						else
-							{
-							inselement.setAttribute("objName","<undefined>");
-							}
+						inselement.setAttribute("objName",
+								getName((ResourceReference<?>) in.properties.get(PInstance.OBJECT)));
 						inselement.setAttribute("x",Integer.toString(in.getPosition().x));
 						inselement.setAttribute("y",Integer.toString(in.getPosition().y));
 						inselement.setAttribute("name",in.getName());
@@ -1672,15 +1640,8 @@ public final class GMXFileWriter
 						Element tileelement = doc.createElement("tile");
 						tileroot.appendChild(tileelement);
 
-						ResourceReference<?> br = props.get(PTile.BACKGROUND);
-						if (br != null)
-							{
-							tileelement.setAttribute("bgName",br.get().getName());
-							}
-						else
-							{
-							tileelement.setAttribute("bgName","");
-							}
+						tileelement.setAttribute("bgName",
+								getName((ResourceReference<?>) props.get(PTile.BACKGROUND),""));
 						tileelement.setAttribute("x",Integer.toString((Integer) props.get(PTile.ROOM_X)));
 						tileelement.setAttribute("y",Integer.toString((Integer) props.get(PTile.ROOM_Y)));
 						tileelement.setAttribute("w",Integer.toString((Integer) props.get(PTile.WIDTH)));
@@ -1827,7 +1788,7 @@ public final class GMXFileWriter
 				else if (at == GmObject.OBJECT_SELF)
 					actelement.appendChild(createElement(doc,"whoName","self"));
 				else
-					actelement.appendChild(createElement(doc,"whoName",at.get().getName()));
+					actelement.appendChild(createElement(doc,"whoName",getName(at)));
 				}
 			else
 				actelement.appendChild(createElement(doc,"whoName","self"));
@@ -1849,13 +1810,8 @@ public final class GMXFileWriter
 				Class<? extends Resource<?,?>> kind = Argument.getResourceKind(arg.kind);
 				if (kind != null && InstantiableResource.class.isAssignableFrom(kind))
 					{
-					Resource<?,?> r = deRef((ResourceReference<?>) arg.getRes());
-					String name = "<undefined>";
-					if (r != null && r instanceof InstantiableResource<?,?>)
-						{
-						name = ((InstantiableResource<?,?>) r).getName();
-						}
-					argelement.appendChild(createElement(doc,Resource.kindNames.get(kind).toLowerCase(),name));
+					argelement.appendChild(createElement(doc,Resource.kindNames.get(kind).toLowerCase(),
+							getName((ResourceReference<?>)arg.getRes())));
 					}
 				else
 					{

--- a/org/lateralgm/file/GMXFileWriter.java
+++ b/org/lateralgm/file/GMXFileWriter.java
@@ -146,16 +146,16 @@ public final class GMXFileWriter
 
 		if (documentBuilderFactory == null)
 			documentBuilderFactory = DocumentBuilderFactory.newInstance();
-		Document dom = null;
-		try
-			{
-			documentBuilder = documentBuilderFactory.newDocumentBuilder();
-			dom = documentBuilder.newDocument();
-			}
-		catch (ParserConfigurationException pce)
-			{
-			throw new GmFormatException(f,pce);
-			}
+		if (documentBuilder == null)
+			try
+				{
+				documentBuilder = documentBuilderFactory.newDocumentBuilder();
+				}
+			catch (ParserConfigurationException pce)
+				{
+				throw new GmFormatException(f,pce);
+				}
+		Document dom = documentBuilder.newDocument();
 
 		JProgressBar progressBar = LGM.getProgressDialogBar();
 		progressBar.setMaximum(160);
@@ -164,7 +164,7 @@ public final class GMXFileWriter
 		ProjectFileContext c = new ProjectFileContext(f,dom);
 		Element root = dom.createElement("assets");
 		LGM.setProgress(0,Messages.getString("ProgressDialog.SETTINGS"));
-		writeConfigurations(c,root);
+		writeConfigurations(c,root,savetime);
 
 		LGM.setProgress(10,Messages.getString("ProgressDialog.SPRITES"));
 		writeSprites(c,root);
@@ -275,7 +275,7 @@ public final class GMXFileWriter
 			return noneval;
 		}
 
-	public static void writeConfigurations(ProjectFileContext c, Element root) throws IOException,
+	public static void writeConfigurations(ProjectFileContext c, Element root, long savetime) throws IOException,
 			TransformerException
 		{
 		Document mdom = c.dom;
@@ -359,6 +359,7 @@ public final class GMXFileWriter
 					gs.get(PGameSettings.SCALING).toString()));
 			optNode.appendChild(createElement(dom,"option_closeesc",
 					gs.get(PGameSettings.TREAT_CLOSE_AS_ESCAPE).toString()));
+			gs.put(PGameSettings.LAST_CHANGED,ProjectFile.longTimeToGmTime(savetime));
 			optNode.appendChild(createElement(dom,"option_lastchanged",
 					gs.get(PGameSettings.LAST_CHANGED).toString()));
 

--- a/org/lateralgm/file/GMXFileWriter.java
+++ b/org/lateralgm/file/GMXFileWriter.java
@@ -114,8 +114,8 @@ import com.sun.org.apache.xerces.internal.impl.dv.util.HexBin;
 public final class GMXFileWriter
 	{
 
-	static DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-	static DocumentBuilder documentBuilder;
+	private static DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+	private static DocumentBuilder documentBuilder;
 
 	private GMXFileWriter()
 		{
@@ -538,8 +538,9 @@ public final class GMXFileWriter
 						BufferedImage sub = spr.subImages.get(j);
 						// GMX does have a backwards compatibility property for transparency pixel so we write
 						// the image with the transparency removed when that setting is checked
-						ImageIO.write((Boolean) spr.get(
-								PSprite.TRANSPARENT) ? Util.getTransparentImage(sub) : sub,"png",outputfile);
+						ImageIO.write(
+								(Boolean) spr.get(PSprite.TRANSPARENT) ? Util.getTransparentImage(sub) : sub,
+								"png",outputfile);
 						}
 					sprroot.appendChild(frameroot);
 
@@ -628,7 +629,7 @@ public final class GMXFileWriter
 					doc.appendChild(sndroot);
 
 					// GMX uses double nested tags for volume, bit rate, sample rate, type, and bit depth
-					// There is a special clause here, every one of those tags after volume, the nested
+					// There is an exception here. In every one of those tags after volume the nested
 					// tag is singular, where its parent is plural.
 					String ftype = snd.get(PSound.FILE_TYPE).toString();
 					sndroot.appendChild(createElement(doc,"extension",ftype));
@@ -907,7 +908,6 @@ public final class GMXFileWriter
 						Transformer tr = TransformerFactory.newInstance().newTransformer();
 						tr.setOutputProperty(OutputKeys.INDENT,"yes");
 						tr.setOutputProperty(OutputKeys.METHOD,"xml");
-						;
 						tr.setOutputProperty("{http://xml.apache.org/xslt}indent-amount","2");
 
 						// send DOM to file

--- a/org/lateralgm/file/GmFileReader.java
+++ b/org/lateralgm/file/GmFileReader.java
@@ -122,7 +122,7 @@ public final class GmFileReader
 		}
 
 	//Workaround for Parameter limit
-	public static class ProjectFileContext
+	private static class ProjectFileContext
 		{
 		ProjectFile f;
 		GmStreamDecoder in;

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -143,7 +143,6 @@ import org.lateralgm.file.ProjectFile.ResourceHolder;
 import org.lateralgm.file.ProjectFile.SingletonResourceHolder;
 import org.lateralgm.file.ResourceList;
 import org.lateralgm.file.iconio.ICOFile;
-import org.lateralgm.joshedit.Runner;
 import org.lateralgm.messages.Messages;
 import org.lateralgm.resources.Constants;
 import org.lateralgm.resources.GameSettings;
@@ -181,6 +180,8 @@ import org.lateralgm.subframes.TimelineFrame;
 
 public final class LGM
 	{
+	public static final String version = "1.8.7.11";
+
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.
 	public static ArrayList<URLClassLoader> classLoaders = new ArrayList<URLClassLoader>();

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -185,9 +185,11 @@ public final class LGM
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.
 	public static ArrayList<URLClassLoader> classLoaders = new ArrayList<URLClassLoader>();
+
 	public static boolean LOADING_PROJECT = false;
 	public static JDialog progressDialog = null;
 	public static JProgressBar progressDialogBar = null;
+
 	public static String iconspath = "org/lateralgm/icons/";
 	public static String iconspack = "Calico";
 	public static String themename = "Swing";

--- a/org/lateralgm/main/lgm-splash.svg
+++ b/org/lateralgm/main/lgm-splash.svg
@@ -1011,7 +1011,7 @@
          id="tspanVersion"
          style="font-size:24px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;font-family:Liberation Serif;-inkscape-font-specification:Liberation Serif Bold"
          x="0"
-         y="0">v1.6.0 beta4 $rev$</tspan>
+         y="0">v1.8.7.11 beta4 $rev$</tspan>
     </text>
   </g>
 </svg>

--- a/org/lateralgm/messages/messages.properties
+++ b/org/lateralgm/messages/messages.properties
@@ -145,7 +145,7 @@ DocumentUndoManager.REDO=Redo
 
 AboutBox.TITLE=About LateralGM
 AboutBox.ABOUT=<h1 style="white-space: nowrap">Copyright &copy; 2006-2016</h1>\
-	<p style="white-space: nowrap">Version: 1.8.7<br><br>\
+	<p style="white-space: nowrap">Version: {0}<br><br>\
 	IsmAvatar \
 	&lt;<a href="mailto:IsmAvatar@gmail.com">IsmAvatar@gmail.com</a>&gt;<br>\
 	Clam \

--- a/org/lateralgm/messages/messages_da_DK.properties
+++ b/org/lateralgm/messages/messages_da_DK.properties
@@ -76,7 +76,7 @@ GMLTextArea.PASTE=Indsæt
 GMLTextArea.GOTO_LINE=Gå til linje
 
 AboutBox.TITLE=Om LateralGM
-AboutBox.ABOUT=<h1 style="white-space: nowrap">LateralGM version 1.8.7 (r$rev$)</h1>\
+AboutBox.ABOUT=<h1 style="white-space: nowrap">LateralGM version {0} (r$rev$)</h1>\
 	<p style="white-space: nowrap">Copyright &copy; 2006-2011 IsmAvatar \
 	&lt;<a href="mailto: IsmAvatar@gmail.com">IsmAvatar@gmail.com</a>&gt;<br>\
 	Copyright &copy; 2006, 2007, 2008, 2009 Clam \

--- a/org/lateralgm/messages/messages_fr.properties
+++ b/org/lateralgm/messages/messages_fr.properties
@@ -76,7 +76,7 @@ GMLTextArea.PASTE=Coller
 GMLTextArea.GOTO_LINE=Aller
 
 AboutBox.TITLE=À propos de LateralGM
-AboutBox.ABOUT=<h1 style="white-space: nowrap">LateralGM version 1.8.7 (r516)</h1>\
+AboutBox.ABOUT=<h1 style="white-space: nowrap">LateralGM version {0} (r516)</h1>\
 	<p style="white-space: nowrap">Copyright &copy; 2006-2011 IsmAvatar \
 	&lt;<a href="mailto:IsmAvatar@gmail.com">IsmAvatar@gmail.com</a>&gt;<br>\
 	Copyright &copy; 2006, 2007, 2008, 2009 Clam \

--- a/org/lateralgm/messages/messages_tr_TR.properties
+++ b/org/lateralgm/messages/messages_tr_TR.properties
@@ -76,7 +76,7 @@ GMLTextArea.PASTE=Yapýþtýr
 GMLTextArea.GOTO_LINE=Alana git
 
 AboutBox.TITLE=LateralGM Hakkýnda
-AboutBox.ABOUT=<h1 style="white-space: nowrap">LateralGM versiyon 1.8.7 (r$rev$)</h1>\
+AboutBox.ABOUT=<h1 style="white-space: nowrap">LateralGM versiyon {0} (r$rev$)</h1>\
 	<p style="white-space: nowrap">Copyright &copy; 2006-2011 IsmAvatar  \
 	&lt;<a href="mailto:IsmAvatar@gmail.com">IsmAvatar@gmail.com</a>&gt;<br>\
 	<p style="white-space: nowrap">Türkçe Çeviri 2011 <a href='http://www.xtraphp.com'>Orkun ÇAKILKAYA</A>  \

--- a/org/lateralgm/subframes/GmObjectFrame.java
+++ b/org/lateralgm/subframes/GmObjectFrame.java
@@ -797,7 +797,6 @@ public class GmObjectFrame extends InstantiableResourceFrame<GmObject,PGmObject>
 					}
 			};
 		events.addMouseListener(ml);
-
 		}
 
 	public void showInfoFrame()


### PR DESCRIPTION
The GMX reader was not handling potentially null ResourceReferences properly. This solution follows the same solution as the GMK Reader/Writer by using a static helper method to dereference the resource and then obtain its name or id and return it. In the future this could be replaced with a functional interface that would take a lambda.

Path's were also saving the background room reference incorrectly, GMS saves the id of the background room, not the name of the background room.

This fully addresses #297