### PR TITLE
Fixes behavior of ActionList FRAMES

### DIFF
--- a/org/lateralgm/components/ActionList.java
+++ b/org/lateralgm/components/ActionList.java
@@ -62,18 +62,14 @@ import org.lateralgm.subframes.ActionFrame;
 public class ActionList extends JList
 	{
 	private static final long serialVersionUID = 1L;
-	private static final WeakHashMap<Action,WeakReference<ActionFrame>> FRAMES;
 	private static final ActionListKeyListener ALKL = new ActionListKeyListener();
+	private final WeakHashMap<Action,WeakReference<ActionFrame>> FRAMES =
+			new WeakHashMap<Action,WeakReference<ActionFrame>>();
 	protected ActionContainer actionContainer;
 	private ActionListModel model;
 	private final ActionRenderer renderer = new ActionRenderer();
 	public final WeakReference<MDIFrame> parent;
 	private final ActionListMouseListener alml;
-
-	static
-		{
-		FRAMES = new WeakHashMap<Action,WeakReference<ActionFrame>>();
-		}
 
 	public ActionList(MDIFrame parent)
 		{
@@ -125,7 +121,7 @@ public class ActionList extends JList
 
 		if (codeAction.getLibAction().actionKind == Action.ACT_CODE) 
 			{
-			ActionList.openActionFrame(this.parent.get(),codeAction);
+			openActionFrame(this.parent.get(),codeAction);
 			}
 		}
 
@@ -150,7 +146,7 @@ public class ActionList extends JList
 	 * @return The frame opened or <code>null</code> if no
 	 * frame was opened.
 	 */
-	public static MDIFrame openActionFrame(MDIFrame parent, Action a)
+	public MDIFrame openActionFrame(MDIFrame parent, Action a)
 		{
 		LibAction la = a.getLibAction();
 		if ((la.libArguments == null || la.libArguments.length == 0) && !la.canApplyTo
@@ -204,7 +200,7 @@ public class ActionList extends JList
 				}
 
 			if (o == null || !(o instanceof Action)) return;
-			openActionFrame(parent.get(),(Action) o);
+			l.openActionFrame(parent.get(),(Action) o);
 			}
 		}
 
@@ -584,7 +580,7 @@ public class ActionList extends JList
 					{
 					la = (LibAction) t.getTransferData(LIB_ACTION_FLAVOR);
 					a = new Action(la);
-					ActionList.openActionFrame(parent.get(),a);
+					list.openActionFrame(parent.get(),a);
 					}
 				catch (Exception e)
 					{

--- a/org/lateralgm/components/ActionListEditor.java
+++ b/org/lateralgm/components/ActionListEditor.java
@@ -152,7 +152,7 @@ public class ActionListEditor extends JPanel
 				Action act = new Action(libAction);
 				((ActionListModel) list.getModel()).add(act);
 				list.setSelectedValue(act,true);
-				ActionList.openActionFrame(list.parent.get(),act);
+				list.openActionFrame(list.parent.get(),act);
 				}
 			super.processMouseEvent(e);
 			}


### PR DESCRIPTION
FRAMES was set up to work as a static map of all the open action frames. However, the action list was accessing it in a non-static way in save() by iterating and saving all frames when an instance of an action list is saved. This caused every action list to save every action frame of every other action list, which was redundant.

It is likely more useful to have the map non static to know specifically the action frames opened only by a single action list. This would allow you to close the action frames associated with a specific action list, for example when an object frame closes you can ask the user if they want to close the open action frames. There is still a reference to all of the open MDI frames so that the MDI menu in the JMenuBar can do its job when the user wants to close all MDI frames.

This means you can no longer open an action frame without an associated action list however. The alternatives to this solution include saving a second map that associates every action frame with its parent (if it has one) or to save a static and a non-static map. Currently there is no foreseeable need to open orphaned action frames or to iterate all open action frames.