### PR TITLE
Fixes path editor snap fields

### DIFF
--- a/org/lateralgm/subframes/PathFrame.java
+++ b/org/lateralgm/subframes/PathFrame.java
@@ -130,10 +130,10 @@ public class PathFrame extends InstantiableResourceFrame<Path,PPath>
 		tool.setLayout(layout);
 		tool.setFloatable(false);
 		JLabel lsx = new JLabel(Messages.getString("PathFrame.SNAP_X"));
-		NumberField sx = new NumberField(0,999);
+		NumberField sx = new NumberField(1,999);
 		plf.make(sx,PPath.SNAP_X);
 		JLabel lsy = new JLabel(Messages.getString("PathFrame.SNAP_Y"));
-		NumberField sy = new NumberField(0,999);
+		NumberField sy = new NumberField(1,999);
 		plf.make(sy,PPath.SNAP_Y);
 		// For some reason, JToolBar + GroupLayout makes the button too small to show all the text.
 		// Using a JCheckBox instead. This also mathces the other components better.


### PR DESCRIPTION
The minimum was supposed to be 1 like it is in the room editor. GameMaker and GMS have always limited the minimum for the path and room editors to 1.

This fully addresses #306