### PR TITLE
Cleanup and fixes GMX reader

### DIFF
--- a/org/lateralgm/file/GMXFileReader.java
+++ b/org/lateralgm/file/GMXFileReader.java
@@ -290,7 +290,7 @@ public final class GMXFileReader
 		readPackages(c,root);
 
 		LGM.setProgress(160,Messages.getString("ProgressDialog.POSTPONED"));
-		// Resources read, now we can invoke our postponed references.
+		// All resources read, now we can invoke our postponed references.
 		for (PostponedRef i : postpone)
 			i.invoke();
 
@@ -299,7 +299,6 @@ public final class GMXFileReader
 
 		try
 			{
-			// close up the stream and release the lock on the file
 			stream.close();
 			}
 		catch (Exception ex) //IOException

--- a/org/lateralgm/file/GmFileReader.java
+++ b/org/lateralgm/file/GmFileReader.java
@@ -1259,7 +1259,7 @@ public final class GmFileReader
 				la.id = actid;
 				la.parentId = libid;
 				la.actionKind = (byte) in.read4();
-				//XXX: Maybe make this more agnostic?"
+				//TODO: Maybe make this more agnostic?"
 				if (la.actionKind == Action.ACT_CODE)
 					{
 					la = LibManager.codeAction;

--- a/org/lateralgm/file/GmFormatException.java
+++ b/org/lateralgm/file/GmFormatException.java
@@ -14,11 +14,19 @@ public class GmFormatException extends ProjectFormatException
 	private static final long serialVersionUID = 1L;
 	public ProjectFile file;
 	public Exception e;
+	public Throwable cause;
 
 	public GmFormatException(ProjectFile file, String message)
 		{
 		super(file,message);
 		this.file = file;
+		}
+
+	public GmFormatException(ProjectFile file, String message, Throwable cause)
+		{
+		super(file,message,cause);
+		this.file = file;
+		this.cause = cause;
 		}
 
 	public GmFormatException(ProjectFile file, Exception e)

--- a/org/lateralgm/file/ProjectFormatException.java
+++ b/org/lateralgm/file/ProjectFormatException.java
@@ -28,11 +28,19 @@ public class ProjectFormatException extends Exception
 	private static final long serialVersionUID = 1L;
 	public ProjectFile file;
 	public Exception e;
+	public Throwable cause;
 
 	public ProjectFormatException(ProjectFile file, String message)
 		{
 		super(message);
 		this.file = file;
+		}
+
+	public ProjectFormatException(ProjectFile file, String message, Throwable cause)
+		{
+		super(message, cause);
+		this.file = file;
+		this.cause = cause;
 		}
 
 	public ProjectFormatException(ProjectFile file, Exception e)

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -180,7 +180,7 @@ import org.lateralgm.subframes.TimelineFrame;
 
 public final class LGM
 	{
-	public static final String version = "1.8.7.11";
+	public static final String version = "1.8.7.14";
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.
@@ -1968,7 +1968,6 @@ public final class LGM
 	public static void applyPreferences() {
 		if (javaVersion >= 10700 && !Prefs.locale.toLanguageTag().equals("und")) {
 			Locale.setDefault(Prefs.locale);
-			System.out.println(Locale.getDefault());
 		}
 
 		if (Prefs.direct3DAcceleration.equals("off")) { //$NON-NLS-1$
@@ -2922,7 +2921,7 @@ public final class LGM
 	// to submit a bug report.
 	public static void showDefaultExceptionHandler(Throwable e)
 		{
-		System.out.println(Thread.currentThread().getName() + ": ");
+		System.err.println(Thread.currentThread().getName() + ": ");
 		e.printStackTrace();
 		ErrorDialog errorDialog = ErrorDialog.getInstance();
 		if (!errorDialog.isVisible())

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -756,12 +756,7 @@ public final class LGM
 			catch (Exception e)
 				{
 				String msgInd = "LGM.PLUGIN_LOAD_ERROR"; //$NON-NLS-1$
-				System.out.println(Messages.format(msgInd,f.getName(),e.getClass().getName(),e.getMessage()));
-				// not sure about this one it helped me catch an error
-				// in the plugin don't know what to do really
-				//LGM.showDefaultExceptionHandler(e);
-				//TODO: lgm extensions need to be found another way perhaps with a local copy of some sort
-				//of digest or somthing like ENIGMA extensions
+				LGM.showDefaultExceptionHandler(new Exception(Messages.format(msgInd,f.getName()), e));
 				continue;
 				}
 			}

--- a/org/lateralgm/messages/messages.properties
+++ b/org/lateralgm/messages/messages.properties
@@ -411,7 +411,7 @@ LGM.NO_WORKDIR=Unable to determine the Working Directory. \
  Plugins and default User Libraries directory will be unavailable. \
  Caused by: {0}: {1}
 LGM.PLUGIN_MISSING_ENTRY=No plugin entry point ({0})
-LGM.PLUGIN_LOAD_ERROR=Info: {0} is not an LGM plugin: {1}: {2}
+LGM.PLUGIN_LOAD_ERROR=Failed to load plugin: {0}
 
 # JFileChooser filter descriptions
 Util.ALL_SPI_IMAGES=All SPI Supported Images


### PR DESCRIPTION
The most important change here is that I have made the GMX reader finally more fault tolerant than the GMK file reader. No longer do I just lob all exceptions up and exit as early as possible, I attempt to handle errors as they occur. For example, if the subframe image for some sprite can't be read, an error dialog will be displayed but the file reader will continue reading other resources. So the user is still informed of the error but it doesn't stop you from loading the whole project.

Also if the XML parser fails to parse a resource's XML file, you will still get the resource added to the tree, but none of its data is loaded.

I also used the DefaultPostponedRef class in a few places to reduce the code bloat since they were all doing the same thing anyway. That was the purpose of that class.

I also fixed an issue where the default exception handler was printing the thread name after the exception stack trace. The thread name should have been printed to the error stream not the standard output stream.

