### PR TITLE
Small fixes

### DIFF
--- a/org/lateralgm/components/GmMenuBar.java
+++ b/org/lateralgm/components/GmMenuBar.java
@@ -90,11 +90,11 @@ public class GmMenuBar extends JMenuBar
 					{
 					File file = new File(uri).getAbsoluteFile();
 					item = new JMenuItem(String.format("%s %s  [%s]",number,file.getName(),file.getParent()),
-							number.codePointAt(0));
+							number.codePointAt(number.length() - 1));
 					}
 				catch (IllegalArgumentException e)
 					{
-					item = new JMenuItem(String.format("%s %s",number,uri),number.codePointAt(0));
+					item = new JMenuItem(String.format("%s %s",number,uri),number.codePointAt(number.length() - 1));
 					}
 				item.setActionCommand("GmMenuBar.OPENRECENT " + recentStr); //$NON-NLS-1$
 				item.addActionListener(Listener.getInstance());

--- a/org/lateralgm/components/impl/FramePrefsHandler.java
+++ b/org/lateralgm/components/impl/FramePrefsHandler.java
@@ -8,7 +8,6 @@
 
 package org.lateralgm.components.impl;
 
-import java.awt.GraphicsEnvironment;
 import java.awt.event.ComponentEvent;
 import java.awt.event.ComponentListener;
 import java.awt.event.WindowEvent;

--- a/org/lateralgm/file/GMXFileReader.java
+++ b/org/lateralgm/file/GMXFileReader.java
@@ -154,22 +154,36 @@ public final class GMXFileReader
 			}
 		}
 
-	private static Document parseDocument(ProjectFileContext c, String uri)
+	private static Document parseDocumentUnchecked(ProjectFile f, String path) throws GmFormatException
 		{
 		Document doc = null;
 		try
 			{
-			doc = documentBuilder.parse(uri);
+			doc = documentBuilder.parse(path);
 			}
 		catch (SAXException e)
 			{
-			LGM.showDefaultExceptionHandler(new GmFormatException(c.f, "failed to parse: " + uri, e));
+			throw new GmFormatException(f, "failed to parse: " + path, e);
 			}
 		catch (IOException e)
 			{
-			LGM.showDefaultExceptionHandler(new GmFormatException(c.f, "failed to read: " + uri, e));
+			throw new GmFormatException(f, "failed to read: " + path, e);
 			}
 		return doc;
+		}
+
+	private static Document parseDocumentChecked(ProjectFile f, String path)
+		{
+			Document doc = null;
+			try
+				{
+				doc = parseDocumentUnchecked(f, path);
+				}
+			catch (GmFormatException e)
+				{
+				LGM.showDefaultExceptionHandler(e);
+				}
+			return doc;
 		}
 
 	//Workaround for Parameter limit
@@ -231,83 +245,84 @@ public final class GMXFileReader
 				{
 				throw new GmFormatException(file,e1);
 				}
-		Document document = null;
-		try
-			{
-			document = documentBuilder.parse(new File(uri));
-			}
-		catch (SAXException e)
-			{
-			throw new GmFormatException(file,e);
-			}
-		catch (IOException e)
-			{
-			throw new GmFormatException(file,e);
-			}
-
 		RefList<Timeline> timeids = new RefList<Timeline>(Timeline.class); // timeline ids
 		RefList<GmObject> objids = new RefList<GmObject>(GmObject.class); // object ids
 		RefList<Room> rmids = new RefList<Room>(Room.class); // room id
 		long startTime = System.currentTimeMillis();
 
-		ProjectFileContext c = new ProjectFileContext(file,document,timeids,objids,rmids);
-
-		JProgressBar progressBar = LGM.getProgressDialogBar();
-		progressBar.setMaximum(160);
-		LGM.setProgressTitle(Messages.getString("ProgressDialog.GMX_LOADING"));
-
-		LGM.setProgress(0,Messages.getString("ProgressDialog.SPRITES"));
-		readSprites(c,root);
-		LGM.setProgress(10,Messages.getString("ProgressDialog.SOUNDS"));
-		readSounds(c,root);
-		LGM.setProgress(20,Messages.getString("ProgressDialog.BACKGROUNDS"));
-		readBackgrounds(c,root);
-		LGM.setProgress(30,Messages.getString("ProgressDialog.PATHS"));
-		readPaths(c,root);
-		LGM.setProgress(40,Messages.getString("ProgressDialog.SCRIPTS"));
-		readScripts(c,root);
-		LGM.setProgress(50,Messages.getString("ProgressDialog.SHADERS"));
-		readShaders(c,root);
-		LGM.setProgress(60,Messages.getString("ProgressDialog.FONTS"));
-		readFonts(c,root);
-		LGM.setProgress(70,Messages.getString("ProgressDialog.TIMELINES"));
-		readTimelines(c,root);
-		LGM.setProgress(80,Messages.getString("ProgressDialog.OBJECTS"));
-		readGmObjects(c,root);
-		LGM.setProgress(90,Messages.getString("ProgressDialog.ROOMS"));
-		readRooms(c,root);
-		LGM.setProgress(100,Messages.getString("ProgressDialog.INCLUDEFILES"));
-		readIncludedFiles(c,root);
-		LGM.setProgress(110,Messages.getString("ProgressDialog.EXTENSIONS"));
-		readExtensions(c,root);
-		LGM.setProgress(120,Messages.getString("ProgressDialog.CONSTANTS"));
-		readDefaultConstants(c,root);
-		LGM.setProgress(130,Messages.getString("ProgressDialog.GAMEINFORMATION"));
-		readGameInformation(c,root);
-		LGM.setProgress(140,Messages.getString("ProgressDialog.SETTINGS"));
-		readConfigurations(c,root);
-		LGM.setProgress(150,Messages.getString("ProgressDialog.PACKAGES"));
-		readPackages(c,root);
-
-		LGM.setProgress(160,Messages.getString("ProgressDialog.POSTPONED"));
-		// All resources read, now we can invoke our postponed references.
-		for (PostponedRef i : postpone)
-			i.invoke();
-
-		System.out.println(Messages.format("ProjectFileReader.LOADTIME",System.currentTimeMillis() //$NON-NLS-1$
-				- startTime));
-
 		try
 			{
-			stream.close();
+			Document document = GMXFileReader.parseDocumentUnchecked(file, uri.toString());
+	
+			ProjectFileContext c = new ProjectFileContext(file,document,timeids,objids,rmids);
+	
+			JProgressBar progressBar = LGM.getProgressDialogBar();
+			progressBar.setMaximum(160);
+			LGM.setProgressTitle(Messages.getString("ProgressDialog.GMX_LOADING")); //$NON-NLS-1$
+	
+			LGM.setProgress(0,Messages.getString("ProgressDialog.SPRITES")); //$NON-NLS-1$
+			readSprites(c,root);
+			LGM.setProgress(10,Messages.getString("ProgressDialog.SOUNDS")); //$NON-NLS-1$
+			readSounds(c,root);
+			LGM.setProgress(20,Messages.getString("ProgressDialog.BACKGROUNDS")); //$NON-NLS-1$
+			readBackgrounds(c,root);
+			LGM.setProgress(30,Messages.getString("ProgressDialog.PATHS")); //$NON-NLS-1$
+			readPaths(c,root);
+			LGM.setProgress(40,Messages.getString("ProgressDialog.SCRIPTS")); //$NON-NLS-1$
+			readScripts(c,root);
+			LGM.setProgress(50,Messages.getString("ProgressDialog.SHADERS")); //$NON-NLS-1$
+			readShaders(c,root);
+			LGM.setProgress(60,Messages.getString("ProgressDialog.FONTS")); //$NON-NLS-1$
+			readFonts(c,root);
+			LGM.setProgress(70,Messages.getString("ProgressDialog.TIMELINES")); //$NON-NLS-1$
+			readTimelines(c,root);
+			LGM.setProgress(80,Messages.getString("ProgressDialog.OBJECTS")); //$NON-NLS-1$
+			readGmObjects(c,root);
+			LGM.setProgress(90,Messages.getString("ProgressDialog.ROOMS")); //$NON-NLS-1$
+			readRooms(c,root);
+			LGM.setProgress(100,Messages.getString("ProgressDialog.INCLUDEFILES")); //$NON-NLS-1$
+			readIncludedFiles(c,root);
+			LGM.setProgress(110,Messages.getString("ProgressDialog.EXTENSIONS")); //$NON-NLS-1$
+			readExtensions(c,root);
+			LGM.setProgress(120,Messages.getString("ProgressDialog.CONSTANTS")); //$NON-NLS-1$
+			readDefaultConstants(c,root);
+			LGM.setProgress(130,Messages.getString("ProgressDialog.GAMEINFORMATION")); //$NON-NLS-1$
+			readGameInformation(c,root);
+			LGM.setProgress(140,Messages.getString("ProgressDialog.SETTINGS")); //$NON-NLS-1$
+			readConfigurations(c,root);
+			LGM.setProgress(150,Messages.getString("ProgressDialog.PACKAGES")); //$NON-NLS-1$
+			readPackages(c,root);
+	
+			LGM.setProgress(160,Messages.getString("ProgressDialog.POSTPONED")); //$NON-NLS-1$
+			// All resources read, now we can invoke our postponed references.
+			for (PostponedRef i : postpone)
+				i.invoke();
+	
+			LGM.setProgress(160,Messages.getString("ProgressDialog.FINISHED")); //$NON-NLS-1$
+			System.out.println(Messages.format("ProjectFileReader.LOADTIME",System.currentTimeMillis() //$NON-NLS-1$
+					- startTime));
 			}
-		catch (Exception ex) //IOException
+		catch (Exception e)
 			{
-			String key = Messages.getString("GmFileReader.ERROR_CLOSEFAILED"); //$NON-NLS-1$
-			throw new GmFormatException(file,key);
+			if ((e instanceof GmFormatException)) throw (GmFormatException) e;
+			throw new GmFormatException(file,e);
 			}
-
-		LGM.setProgress(160,Messages.getString("ProgressDialog.FINISHED"));
+		finally
+			{
+			try
+				{
+				if (stream != null)
+					{
+					stream.close();
+					stream = null;
+					}
+				}
+			catch (IOException ex)
+				{
+				String key = Messages.getString("GmFileReader.ERROR_CLOSEFAILED"); //$NON-NLS-1$
+				throw new GmFormatException(file,key);
+				}
+			}
 		}
 
 	private static void readConfigurations(ProjectFileContext c, ResNode root)
@@ -344,7 +359,7 @@ public final class GMXFileReader
 
 				String path = c.f.getDirectory() + '/' + Util.getPOSIXPath(cNode.getTextContent());
 
-				Document setdoc = GMXFileReader.parseDocument(c, path + ".config.gmx");
+				Document setdoc = GMXFileReader.parseDocumentChecked(c.f, path + ".config.gmx");
 				if (setdoc == null) continue;
 
 				pSet.put(
@@ -551,7 +566,7 @@ public final class GMXFileReader
 				node.add(rnode);
 				String path = f.getDirectory() + '/' + Util.getPOSIXPath(cNode.getTextContent());
 
-				Document sprdoc = GMXFileReader.parseDocument(c, path + ".sprite.gmx");
+				Document sprdoc = GMXFileReader.parseDocumentChecked(f, path + ".sprite.gmx");
 				if (sprdoc == null) continue;
 
 				spr.put(PSprite.ORIGIN_X,
@@ -670,7 +685,7 @@ public final class GMXFileReader
 				snd.setNode(rnode);
 				String path = f.getDirectory() + '/' + Util.getPOSIXPath(cNode.getTextContent());
 
-				Document snddoc = GMXFileReader.parseDocument(c, path + ".sound.gmx");
+				Document snddoc = GMXFileReader.parseDocumentChecked(f, path + ".sound.gmx");
 				if (snddoc == null) continue;
 
 				snd.put(PSound.FILE_NAME,snddoc.getElementsByTagName("origname").item(0).getTextContent());
@@ -762,7 +777,7 @@ public final class GMXFileReader
 				node.add(rnode);
 				String path = f.getDirectory() + '/' + Util.getPOSIXPath(cNode.getTextContent());
 
-				Document bkgdoc = GMXFileReader.parseDocument(c, path + ".background.gmx");
+				Document bkgdoc = GMXFileReader.parseDocumentChecked(f, path + ".background.gmx");
 				if (bkgdoc == null) continue;
 
 				bkg.put(PBackground.USE_AS_TILESET,
@@ -864,7 +879,7 @@ public final class GMXFileReader
 				node.add(rnode);
 				String path = f.getDirectory() + '/' + Util.getPOSIXPath(cNode.getTextContent());
 
-				Document pthdoc = GMXFileReader.parseDocument(c, path + ".path.gmx");
+				Document pthdoc = GMXFileReader.parseDocumentChecked(f, path + ".path.gmx");
 				if (pthdoc == null) continue;
 
 				pth.put(PPath.SMOOTH,
@@ -1141,7 +1156,7 @@ public final class GMXFileReader
 				node.add(rnode);
 				String path = f.getDirectory() + '/' + Util.getPOSIXPath(cNode.getTextContent());
 
-				Document fntdoc = GMXFileReader.parseDocument(c, path + ".font.gmx");
+				Document fntdoc = GMXFileReader.parseDocumentChecked(f, path + ".font.gmx");
 				if (fntdoc == null) continue;
 
 				fnt.put(PFont.FONT_NAME,fntdoc.getElementsByTagName("name").item(0).getTextContent());
@@ -1242,7 +1257,7 @@ public final class GMXFileReader
 				node.add(rnode);
 				String path = f.getDirectory() + '/' + Util.getPOSIXPath(cNode.getTextContent());
 
-				Document tmldoc = GMXFileReader.parseDocument(c, path + ".timeline.gmx");
+				Document tmldoc = GMXFileReader.parseDocumentChecked(f, path + ".timeline.gmx");
 				if (tmldoc == null) continue;
 
 				//Iterate the moments and load the actions
@@ -1330,7 +1345,7 @@ public final class GMXFileReader
 
 				String path = f.getDirectory() + '/' + Util.getPOSIXPath(cNode.getTextContent());
 
-				Document objdoc = GMXFileReader.parseDocument(c, path + ".object.gmx");
+				Document objdoc = GMXFileReader.parseDocumentChecked(f, path + ".object.gmx");
 				if (objdoc == null) continue;
 
 				final String sprname = objdoc.getElementsByTagName("spriteName").item(0).getTextContent();
@@ -1518,7 +1533,7 @@ public final class GMXFileReader
 				node.add(rnode);
 				String path = f.getDirectory() + '/' + Util.getPOSIXPath(cNode.getTextContent());
 
-				Document rmndoc = GMXFileReader.parseDocument(c, path + ".room.gmx");
+				Document rmndoc = GMXFileReader.parseDocumentChecked(f, path + ".room.gmx");
 				if (rmndoc == null) continue;
 
 				String caption = rmndoc.getElementsByTagName("caption").item(0).getTextContent();

--- a/org/lateralgm/file/GmFileReader.java
+++ b/org/lateralgm/file/GmFileReader.java
@@ -155,7 +155,7 @@ public final class GmFileReader
 			int ver)
 		{
 		return new GmFormatException(f,Messages.format(
-				"ProjectFileReader.ERROR_UNSUPPORTED",Messages.format(//$NON-NLS-1$
+				"ProjectFileReader.ERROR_UNSUPPORTED",Messages.format( //$NON-NLS-1$
 						"ProjectFileReader." + error,Messages.getString("LGM." + res),i),ver)); //$NON-NLS-1$  //$NON-NLS-2$
 		}
 
@@ -185,7 +185,7 @@ public final class GmFileReader
 			file.format = ProjectFile.FormatFlavor.getVersionFlavor(ver);
 			if (ver != 530 && ver != 600 && ver != 701 && ver != 800 && ver != 810)
 				{
-				String msg = Messages.format("ProjectFileReader.ERROR_UNSUPPORTED",uri,ver); //$NON-NLS-1$ //$NON-NLS-2$
+				String msg = Messages.format("ProjectFileReader.ERROR_UNSUPPORTED",uri,ver); //$NON-NLS-1$
 				throw new GmFormatException(file,msg);
 				}
 
@@ -202,11 +202,11 @@ public final class GmFileReader
 			//TODO: fix exception here caused by trying to open file too soon after loading LGM
 			JProgressBar progressBar = LGM.getProgressDialogBar();
 			progressBar.setMaximum(200);
-			LGM.setProgressTitle(Messages.getString("ProgressDialog.GMK_LOADING"));
+			LGM.setProgressTitle(Messages.getString("ProgressDialog.GMK_LOADING")); //$NON-NLS-1$
 
 			GameSettings gs = c.f.gameSettings.get(0);
 
-			LGM.setProgress(0,Messages.getString("ProgressDialog.SETTINGS"));
+			LGM.setProgress(0,Messages.getString("ProgressDialog.SETTINGS")); //$NON-NLS-1$
 			if (ver == 530) in.skip(4); //reserved 0
 			if (ver == 701)
 				{
@@ -228,32 +228,32 @@ public final class GmFileReader
 
 			if (ver >= 800)
 				{
-				LGM.setProgress(10,Messages.getString("ProgressDialog.TRIGGERS"));
+				LGM.setProgress(10,Messages.getString("ProgressDialog.TRIGGERS")); //$NON-NLS-1$
 				readTriggers(c);
-				LGM.setProgress(20,Messages.getString("ProgressDialog.CONSTANTS"));
+				LGM.setProgress(20,Messages.getString("ProgressDialog.CONSTANTS")); //$NON-NLS-1$
 				readConstants(c,gs);
 				}
 
-			LGM.setProgress(30,Messages.getString("ProgressDialog.SOUNDS"));
+			LGM.setProgress(30,Messages.getString("ProgressDialog.SOUNDS")); //$NON-NLS-1$
 			readSounds(c);
-			LGM.setProgress(40,Messages.getString("ProgressDialog.SPRITES"));
+			LGM.setProgress(40,Messages.getString("ProgressDialog.SPRITES")); //$NON-NLS-1$
 			readSprites(c);
-			LGM.setProgress(50,Messages.getString("ProgressDialog.BACKGROUNDS"));
+			LGM.setProgress(50,Messages.getString("ProgressDialog.BACKGROUNDS")); //$NON-NLS-1$
 			int bgVer = readBackgrounds(c);
-			LGM.setProgress(60,Messages.getString("ProgressDialog.PATHS"));
+			LGM.setProgress(60,Messages.getString("ProgressDialog.PATHS")); //$NON-NLS-1$
 			readPaths(c);
-			LGM.setProgress(70,Messages.getString("ProgressDialog.SCRIPTS"));
+			LGM.setProgress(70,Messages.getString("ProgressDialog.SCRIPTS")); //$NON-NLS-1$
 			readScripts(c);
-			LGM.setProgress(80,Messages.getString("ProgressDialog.SHADERS"));
+			LGM.setProgress(80,Messages.getString("ProgressDialog.SHADERS")); //$NON-NLS-1$
 			//TODO: GMK 820 reads shaders first
-			LGM.setProgress(90,Messages.getString("ProgressDialog.FONTS"));
+			LGM.setProgress(90,Messages.getString("ProgressDialog.FONTS")); //$NON-NLS-1$
 			int rver = in.read4();
 			readFonts(c,rver);
-			LGM.setProgress(100,Messages.getString("ProgressDialog.TIMELINES"));
+			LGM.setProgress(100,Messages.getString("ProgressDialog.TIMELINES")); //$NON-NLS-1$
 			readTimelines(c);
-			LGM.setProgress(110,Messages.getString("ProgressDialog.OBJECTS"));
+			LGM.setProgress(110,Messages.getString("ProgressDialog.OBJECTS")); //$NON-NLS-1$
 			readGmObjects(c);
-			LGM.setProgress(120,Messages.getString("ProgressDialog.ROOMS"));
+			LGM.setProgress(120,Messages.getString("ProgressDialog.ROOMS")); //$NON-NLS-1$
 			readRooms(c);
 
 			//If the "use as tileset" flag was not part of this version, try to infer it from the backgrounds used in room tiles.
@@ -273,16 +273,16 @@ public final class GmFileReader
 
 			if (ver >= 700)
 				{
-				LGM.setProgress(130,Messages.getString("ProgressDialog.INCLUDEFILES"));
+				LGM.setProgress(130,Messages.getString("ProgressDialog.INCLUDEFILES")); //$NON-NLS-1$
 				readIncludedFiles(c);
-				LGM.setProgress(140,Messages.getString("ProgressDialog.PACKAGES"));
+				LGM.setProgress(140,Messages.getString("ProgressDialog.PACKAGES")); //$NON-NLS-1$
 				readPackages(c);
 				}
 
-			LGM.setProgress(150,Messages.getString("ProgressDialog.GAMEINFORMATION"));
+			LGM.setProgress(150,Messages.getString("ProgressDialog.GAMEINFORMATION")); //$NON-NLS-1$
 			readGameInformation(c);
 
-			LGM.setProgress(160,Messages.getString("ProgressDialog.POSTPONED"));
+			LGM.setProgress(160,Messages.getString("ProgressDialog.POSTPONED")); //$NON-NLS-1$
 			//Resources read. Now we can invoke our postpones.
 			int percent = 0;
 			for (PostponedRef i : postpone)
@@ -290,10 +290,10 @@ public final class GmFileReader
 				i.invoke();
 				percent += 1;
 				LGM.setProgress(160 + percent / postpone.size(),
-						Messages.getString("ProgressDialog.POSTPONED"));
+						Messages.getString("ProgressDialog.POSTPONED")); //$NON-NLS-1$
 				}
 
-			LGM.setProgress(170,Messages.getString("ProgressDialog.LIBRARYCREATION"));
+			LGM.setProgress(170,Messages.getString("ProgressDialog.LIBRARYCREATION")); //$NON-NLS-1$
 			//Library Creation Code
 			ver = in.read4();
 			if (ver != 500)
@@ -303,7 +303,7 @@ public final class GmFileReader
 			for (int j = 0; j < no; j++)
 				in.skip(in.read4());
 
-			LGM.setProgress(180,Messages.getString("ProgressDialog.ROOMEXECUTION"));
+			LGM.setProgress(180,Messages.getString("ProgressDialog.ROOMEXECUTION")); //$NON-NLS-1$
 			//Room Execution Order
 			ver = in.read4();
 			if (ver != 500 && ver != 540 && ver != 700)
@@ -311,8 +311,10 @@ public final class GmFileReader
 						Messages.getString("ProjectFileReader.AFTERINFO2"),ver)); //$NON-NLS-1$
 			in.skip(in.read4() * 4);
 
-			LGM.setProgress(190,Messages.getString("ProgressDialog.FILETREE"));
+			LGM.setProgress(190,Messages.getString("ProgressDialog.FILETREE")); //$NON-NLS-1$
 			readTree(c,root,ver);
+
+			LGM.setProgress(200,Messages.getString("ProgressDialog.FINISHED")); //$NON-NLS-1$
 			System.out.println(Messages.format("ProjectFileReader.LOADTIME",System.currentTimeMillis() //$NON-NLS-1$
 					- startTime));
 			}
@@ -337,7 +339,6 @@ public final class GmFileReader
 				throw new GmFormatException(file,key);
 				}
 			}
-		LGM.setProgress(200,Messages.getString("ProgressDialog.FINISHED"));
 		}
 
 	private static void readSettings(ProjectFileContext c, GameSettings g) throws IOException,GmFormatException,

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -180,7 +180,7 @@ import org.lateralgm.subframes.TimelineFrame;
 
 public final class LGM
 	{
-	public static final String version = "1.8.7.15"; //$NON-NLS-1$
+	public static final String version = "1.8.7.17"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/subframes/ResourceInfoFrame.java
+++ b/org/lateralgm/subframes/ResourceInfoFrame.java
@@ -24,6 +24,7 @@ package org.lateralgm.subframes;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
+import java.awt.Font;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.FocusEvent;
@@ -358,8 +359,7 @@ public class ResourceInfoFrame extends JFrame implements ActionListener
 		JScrollPane scrollable = new JScrollPane(editor);
 		add(scrollable,BorderLayout.CENTER);
 		setFocusTraversalPolicy(new TextAreaFocusTraversalPolicy(editor));
-		//NOTE: Use monospaced font
-		editor.setFont(editor.getFont().deriveFont(12.0f));
+		editor.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 12));
 		editor.setText("object info will be displayed here when loaded");
 		editor.setEditable(false);
 		editor.getCaret().setVisible(true); // show the caret anyway


### PR DESCRIPTION
For recent files menu, we should use the last code point of the number for if there's ever more than 10 recent files. We may at some point add a setting for it, Notepad++ allows 15 recent files. It also uses the last code point so the mnemonic keys for recent files 10-15 would be 0-5 instead of 1 for all of them.

Also changed the resource info frame to use a monospaced font as was originally intended since it displays code.

I've also corrected more issues with the GMX reader. One such issue was that I was calling the document builder's parse method with a file name with no protocol and I didn't realize that parse actually takes a String of a URI. Oddly enough this works fine on some JVM implementations, but in reality the function takes a URI. I have actually fixed this by passing a File to an overload of the parse method because everywhere it's called I only the String handy. This fully fixes the original issue reported in #246.