### PR TITLE
Eclipse and Java 9 related cleanup

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry excluding="modules/|joshedit/" kind="src" path=""/>
+	<classpathentry excluding="modules/" including="javax/|org/" kind="src" path=""/>
 	<classpathentry kind="src" path="modules/joshedit"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/.classpath
+++ b/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry excluding="modules/" including="javax/|org/" kind="src" path=""/>
+	<classpathentry excluding="modules/" kind="src" path=""/>
 	<classpathentry kind="src" path="modules/joshedit"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
 		<attributes>

--- a/.classpath
+++ b/.classpath
@@ -1,11 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry excluding="modules/|modules/joshedit/" including="javax/|org/" kind="src" path=""/>
+	<classpathentry excluding="modules/|joshedit/" kind="src" path=""/>
 	<classpathentry kind="src" path="modules/joshedit"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
-		<attributes>
-			<attribute name="module" value="true"/>
-		</attributes>
-	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/.classpath
+++ b/.classpath
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry excluding="modules/|joshedit/" kind="src" path=""/>
-	<classpathentry excluding=".classpath|.git|.gitignore|.project|.settings/" kind="src" path="modules/joshedit"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry excluding="modules/|modules/joshedit/" including="javax/|org/" kind="src" path=""/>
+	<classpathentry kind="src" path="modules/joshedit"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/.project
+++ b/.project
@@ -20,15 +20,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1514772203258</id>
-			<name></name>
-			<type>14</type>
-			<matcher>
-				<id>org.eclipse.ui.ide.multiFilter</id>
-				<arguments>1.0-projectRelativePath-matches-false-false-modules</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/.project
+++ b/.project
@@ -20,4 +20,11 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
 	</natures>
+	<linkedResources>
+		<link>
+			<name>joshedit</name>
+			<type>2</type>
+			<location>C:/Users/Owner/Documents/Eclipse Workspace/LateralGM/modules/joshedit</location>
+		</link>
+	</linkedResources>
 </projectDescription>

--- a/.project
+++ b/.project
@@ -20,11 +20,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
 	</natures>
-	<linkedResources>
-		<link>
-			<name>joshedit</name>
-			<type>2</type>
-			<location>C:/Users/Owner/Documents/Eclipse Workspace/LateralGM/modules/joshedit</location>
-		</link>
-	</linkedResources>
 </projectDescription>

--- a/.project
+++ b/.project
@@ -20,4 +20,15 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1514772203258</id>
+			<name></name>
+			<type>14</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-projectRelativePath-matches-false-false-modules</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 LateralGM
 =========
-A Java Swing based cross-platform editor for Game Maker project files.
-The source code is doxygen commented but more documentation of the internals including format specifications are available online at http://enigma-dev.org/docs/Wiki/LateralGM
+A cross-platform editor for Game Maker project files written in Java using Swing. You can find the latest build on the releases page.
 
-A C++11 compliant library for reading LGM's Action Library format is also available online at https://github.com/enigma-dev/ActionLibraryReader
+The source code is doxygen commented but [online documentation](http://enigma-dev.org/docs/Wiki/LateralGM) of the internals is available, including format specification details.
 
 License
 -------
-This project is licensed under the GNU GPL v3 License for more information please read the included LICENSE file or visit http://www.gnu.org/licenses
+This project is licensed under the GNU GPL v3 License. Please read the included LICENSE file or visit http://www.gnu.org/licenses for more information.
 
 Contributors
 -------

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 LateralGM
 =========
-A cross-platform editor for Game Maker project files written in Java using Swing. You can find the latest build on the releases page.
-
-The source code is doxygen commented but [online documentation](http://enigma-dev.org/docs/Wiki/LateralGM) of the internals is available, including format specification details.
+A cross-platform editor for Game Maker project files written in Java using Swing. You can find the latest build on the releases page. The source code is doxygen commented but [online documentation](http://enigma-dev.org/docs/Wiki/LateralGM) of the internals is available, including format specification details.
 
 License
 -------

--- a/javax/swing/text/rtf/RTFEditorKit.java
+++ b/javax/swing/text/rtf/RTFEditorKit.java
@@ -35,7 +35,7 @@ import javax.swing.text.*;
  *
  * @author  Timothy Prinzing (of this class, not the package!)
  */
-public class RTFEditorKitExt extends StyledEditorKit {
+public class RTFEditorKit extends StyledEditorKit {
 
    /**
     * NOTE: Default UID generated, change if necessary.
@@ -45,7 +45,7 @@ public class RTFEditorKitExt extends StyledEditorKit {
     /**
      * Constructs an RTFEditorKit.
      */
-    public RTFEditorKitExt() {
+    public RTFEditorKit() {
         super();
     }
 

--- a/org/lateralgm/components/impl/ResNode.java
+++ b/org/lateralgm/components/impl/ResNode.java
@@ -357,7 +357,7 @@ public class ResNode extends DefaultNode implements Transferable,UpdateListener
 	//generic tree node children.
 	public Vector<ResNode> getChildren()
 		{
-		return children;
+		return (Vector)children;
 		}
 
 	public ResourceReference<? extends Resource<?,?>> getRes()

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -180,7 +180,7 @@ import org.lateralgm.subframes.TimelineFrame;
 
 public final class LGM
 	{
-	public static final String version = "1.8.7.18"; //$NON-NLS-1$
+	public static final String version = "1.8.8"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -203,7 +203,10 @@ public final class LGM
 		String jv = System.getProperty("java.version"); //$NON-NLS-1$
 		Scanner s = new Scanner(jv);
 		s.useDelimiter("[\\._-]"); //$NON-NLS-1$
-		javaVersion = s.nextInt() * 10000 + s.nextInt() * 100 + s.nextInt();
+		int major = s.hasNextInt() ? s.nextInt() * 10000 : 0;
+		int minor = s.hasNextInt() ? s.nextInt() * 100 : 0;
+		int patch = s.hasNextInt() ? s.nextInt() : 0;
+		javaVersion = major + minor + patch;
 		s.close();
 
 		try

--- a/org/lateralgm/main/Listener.java
+++ b/org/lateralgm/main/Listener.java
@@ -32,6 +32,7 @@ import java.util.Comparator;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 
 import javax.swing.JComponent;
 import javax.swing.JOptionPane;
@@ -43,6 +44,7 @@ import javax.swing.event.ChangeEvent;
 import javax.swing.text.Position;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeModel;
+import javax.swing.tree.TreeNode;
 import javax.swing.tree.TreePath;
 
 import org.lateralgm.components.AboutBox;
@@ -268,14 +270,14 @@ public class Listener extends TransferHandler implements ActionListener,CellEdit
 			}
 		}
 
-	public DefaultMutableTreeNode findNode(DefaultMutableTreeNode parent, String name,
+	public TreeNode findNode(DefaultMutableTreeNode parent, String name,
 			boolean recursive)
 		{
-		Enumeration<DefaultMutableTreeNode> enumeration =
+		Enumeration<TreeNode> enumeration =
 				recursive ? parent.preorderEnumeration() : parent.children();
 		while (enumeration.hasMoreElements())
 			{
-			DefaultMutableTreeNode child = enumeration.nextElement();
+			TreeNode child = enumeration.nextElement();
 			if (child.toString().equals(name)) return child;
 			}
 
@@ -646,23 +648,25 @@ public class Listener extends TransferHandler implements ActionListener,CellEdit
 		return true;
 		}
 
-	public static void sortNodeChildrenAlphabetically(DefaultMutableTreeNode node, boolean recursive)
+	public static void sortNodeChildrenAlphabetically(TreeNode node, boolean recursive)
 		{
-		ArrayList<DefaultMutableTreeNode> children = (ArrayList<DefaultMutableTreeNode>) Collections.list(node.children());
-		Comparator<DefaultMutableTreeNode> comp = new Comparator<DefaultMutableTreeNode>()
+		DefaultMutableTreeNode defaultNode = (DefaultMutableTreeNode) node;
+		List<TreeNode> children = (List<TreeNode>) Collections.list(node.children());
+		Comparator<TreeNode> comp = new Comparator<TreeNode>()
 			{
-				public int compare(DefaultMutableTreeNode o1, DefaultMutableTreeNode o2)
+				public int compare(TreeNode o1, TreeNode o2)
 					{
 					return o1.toString().compareTo(o2.toString());
 					}
 			};
 		Collections.sort(children,comp);
-		node.removeAllChildren();
-		Iterator<DefaultMutableTreeNode> childrenIterator = children.iterator();
+
+		defaultNode.removeAllChildren();
+		Iterator<TreeNode> childrenIterator = children.iterator();
 		while (childrenIterator.hasNext())
 			{
-			DefaultMutableTreeNode child = childrenIterator.next();
-			node.add(child);
+			TreeNode child = childrenIterator.next();
+			defaultNode.add((DefaultMutableTreeNode)child);
 			if (recursive && child.getChildCount() > 0)
 				{
 				sortNodeChildrenAlphabetically(child,recursive);

--- a/org/lateralgm/messages/messages.properties
+++ b/org/lateralgm/messages/messages.properties
@@ -230,7 +230,7 @@ FileChooser.UNRECOGNIZED=<html>Unable to read file "{0}"<br/>\
 						It is either corrupt or incompatible.</html>
 
 FileChooser.ERROR_LOAD_TITLE=Error Loading File
-FileChooser.ERROR_LOAD= <html><style>p {margin-top: 5px; margin-bottom: 5px;}</style>\
+FileChooser.ERROR_LOAD=<html><style>p {margin-top: 5px; margin-bottom: 5px;}</style>\
 						<p>Your file appears to be corrupted. You can still use what LGM has managed to read, but<br>\
 						the tree has been rebuilt, so all grouping and order has been lost.<br>\
 						If you think this was caused by a bug in LGM, please submit this error report, and we<br>\
@@ -1023,7 +1023,11 @@ FontFrame.FROMFILE=File
 FontFrame.DIGITS=Digits
 FontFrame.LETTERS=Letters
 FontFrame.PREVIEW=Preview:
-FontFrame.PREVIEW_DEFAULT=Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+FontFrame.PREVIEW_DEFAULT=	abcdefghijklmnopqrstuvwxyz\n\
+							ABCDEFGHIJKLMNOPQRSTUVWXYZ\n\
+							0123456789\n\
+							~!@#$%^&*()_+{}|:"<>?`-=[]\;',./\n\
+							The quick brown fox jumps over the lazy dog.
 FontFrame.SAVE=Save
 FontFrame.CUT=Cut
 FontFrame.COPY=Copy

--- a/org/lateralgm/subframes/FontFrame.java
+++ b/org/lateralgm/subframes/FontFrame.java
@@ -101,6 +101,8 @@ public class FontFrame extends InstantiableResourceFrame<Font,PFont> implements
 	public FontFrame(Font res, ResNode node)
 		{
 		super(res,node);
+
+		this.getRootPane().setDefaultButton(save);
 		((JComponent) getContentPane()).setBorder(new EmptyBorder(4,4,4,4));
 
 		propUpdateListener = new PropertyUpdateListener<PFont>()

--- a/org/lateralgm/subframes/GameInformationFrame.java
+++ b/org/lateralgm/subframes/GameInformationFrame.java
@@ -64,7 +64,7 @@ import javax.swing.text.BadLocationException;
 import javax.swing.text.SimpleAttributeSet;
 import javax.swing.text.StyleConstants;
 import javax.swing.text.StyledDocument;
-import javax.swing.text.rtf.RTFEditorKitExt;
+import javax.swing.text.rtf.RTFEditorKit;
 
 import org.lateralgm.components.CustomFileChooser;
 import org.lateralgm.components.NumberField;
@@ -82,7 +82,7 @@ public class GameInformationFrame extends ResourceFrame<GameInformation,PGameInf
 	private static final long serialVersionUID = 1L;
 	protected SettingsFrame settings;
 	protected JEditorPane editor;
-	private RTFEditorKitExt rtf = new RTFEditorKitExt();
+	private RTFEditorKit rtf = new RTFEditorKit();
 	protected JMenuBar menubar;
 	protected JToolBar toolbar;
 	protected JComboBox<String> cbFonts;

--- a/org/lateralgm/subframes/GmObjectFrame.java
+++ b/org/lateralgm/subframes/GmObjectFrame.java
@@ -142,6 +142,7 @@ public class GmObjectFrame extends InstantiableResourceFrame<GmObject,PGmObject>
 		{
 		super(res,node);
 
+		this.getRootPane().setDefaultButton(save);
 		GroupLayout layout = new GroupLayout(getContentPane());
 		setLayout(layout);
 
@@ -579,7 +580,7 @@ public class GmObjectFrame extends InstantiableResourceFrame<GmObject,PGmObject>
 		public void sortChildren()
 			{
 			// This doesn't seem to have any unwanted effects (directly sorting the protected field)
-			Collections.sort((java.util.Vector<EventInstanceNode>) children);
+			Collections.sort((List)children);
 			}
 
 		public TreePath childPath(Event e)

--- a/org/lateralgm/subframes/TimelineFrame.java
+++ b/org/lateralgm/subframes/TimelineFrame.java
@@ -75,6 +75,8 @@ public class TimelineFrame extends InstantiableResourceFrame<Timeline,PTimeline>
 	public TimelineFrame(Timeline res, ResNode node)
 		{
 		super(res,node);
+
+		this.getRootPane().setDefaultButton(save);
 		GroupLayout layout = new GroupLayout(getContentPane());
 		setLayout(layout);
 


### PR DESCRIPTION
* Removed a useless rule to exclude the `.classpath` and other important stuff from the JoshEdit submodule. I think this may be the reason why @rpjohnst and @fundies have not been able to build.
* Renamed my patched RTFEditKitExt class to match the internal one so it will continue to be found at runtime in Java 9.
* Fixed an exception in the static initializer of the main class where the scanner sometimes didn't have a `nextInt()` preventing LGM from running. I just broke it up into 3 separate lines and used a ternary operator to check `hasNextInt()`. This allows it to grab the correct version (i.e. 90000) with something like an Early Access release where the `java.version` just reports the major number 9 only.
* Fixed 4 errors regarding casts from supertypes to subtypes. Apparently it used to be possible, using whatever configuration we had at the time, to cast something like `Vector<TreeNode>` down to a vector of objects that implement the `TreeNode` interface like `Vector<ResNode>`.
* For the object, timeline, and font editor I have set the save button as the root pane's default button. This is the way it has always been in GM from GM4 to GMS 1.4. It lets you just hit the enter button to save and close the editor. I thought it strange that LGM overlooked that. I also added this change to the 3 editors directly because doing so for other editors like the script editor break their behavior closing them when the user wants to enter a textual new line.
* Picked a new default for the font editor preview that is a little more helpful. It displays a huge variety of symbols and characters now, much more sensible.
* Also switches to semantic versioning because this is closer to what the project started with and I generally prefer simpler version numbers. This release will be marked 1.8.8.

![Default Save Button and Default Font Preview Text](https://user-images.githubusercontent.com/3212801/34465249-cb7409c0-ee73-11e7-9afe-9e2ff306d016.png)
