### PR TITLE
Fix SpriteFrame Subimage Transfer

### DIFF
--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -180,7 +180,7 @@ import org.lateralgm.subframes.TimelineFrame;
 
 public final class LGM
 	{
-	public static final String version = "1.8.27"; //$NON-NLS-1$
+	public static final String version = "1.8.28"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/subframes/SpriteFrame.java
+++ b/org/lateralgm/subframes/SpriteFrame.java
@@ -1123,7 +1123,6 @@ public class SpriteFrame extends InstantiableResourceFrame<Sprite,PSprite> imple
 
 	private static class TransferableImages implements Transferable
 		{
-
 		ClipboardImages ci;
 
 		public TransferableImages(ClipboardImages images)
@@ -1269,6 +1268,10 @@ public class SpriteFrame extends InstantiableResourceFrame<Sprite,PSprite> imple
 					LGM.showDefaultExceptionHandler(e);
 					}
 				imageChanged = true;
+				for (int i = 0; i < images.bi.size(); i++)
+					{
+					images.bi.set(i, Util.cloneImage(images.bi.get(i)));
+					}
 				res.subImages.addAll(pos + 1,images.bi);
 				subList.setSelectionInterval(pos + 1,pos + images.bi.size());
 				}

--- a/org/lateralgm/subframes/SpriteFrame.java
+++ b/org/lateralgm/subframes/SpriteFrame.java
@@ -1270,9 +1270,8 @@ public class SpriteFrame extends InstantiableResourceFrame<Sprite,PSprite> imple
 				imageChanged = true;
 				for (int i = 0; i < images.bi.size(); i++)
 					{
-					images.bi.set(i, Util.cloneImage(images.bi.get(i)));
+					res.subImages.add(pos + 1 + i, Util.cloneImage(images.bi.get(i)));
 					}
-				res.subImages.addAll(pos + 1,images.bi);
 				subList.setSelectionInterval(pos + 1,pos + images.bi.size());
 				}
 			return;

--- a/org/lateralgm/subframes/SpriteFrame.java
+++ b/org/lateralgm/subframes/SpriteFrame.java
@@ -1270,9 +1270,9 @@ public class SpriteFrame extends InstantiableResourceFrame<Sprite,PSprite> imple
 				imageChanged = true;
 				for (int i = 0; i < images.bi.size(); i++)
 					{
-					res.subImages.add(pos + 1 + i, Util.cloneImage(images.bi.get(i)));
+					res.subImages.add(pos + i, Util.cloneImage(images.bi.get(i)));
 					}
-				subList.setSelectionInterval(pos + 1,pos + images.bi.size());
+				subList.setSelectionInterval(pos, pos + images.bi.size() - 1);
 				}
 			return;
 			}


### PR DESCRIPTION
This fixes the main part of #304. I managed to track it down to paste being a shallow copy of the clipboard contents, hence, whenever the pasted duplicate subframes were edited, they were actually editing the same subimage. This bug only occurred if you had pasted the subimage more than one time, because each subsequent paste was an additional shallow copy of the same clipboard contents.

There seems to be no need to do a deep copy for cut or copy however, as the following steps seem to indicate:
1) Create a new project
2) Create a new sprite
3) Add a subimage
4) Copy the new subimage to your clipboard
5) Now edit the subimage (just fill it in with a solid color)
6) Save the subimage
7) Now paste the original subimage copied from your clipboard

LGM has the correct behavior (that the pasted subimage should be the way the subimage was when copied) for this even before these changes.