### PR TITLE
Fix External Editor Change Monitoring

### DIFF
--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -180,7 +180,7 @@ import org.lateralgm.subframes.TimelineFrame;
 
 public final class LGM
 	{
-	public static final String version = "1.8.27"; //$NON-NLS-1$
+	public static final String version = "1.8.28"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -180,7 +180,7 @@ import org.lateralgm.subframes.TimelineFrame;
 
 public final class LGM
 	{
-	public static final String version = "1.8.28"; //$NON-NLS-1$
+	public static final String version = "1.8.30"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/subframes/BackgroundFrame.java
+++ b/org/lateralgm/subframes/BackgroundFrame.java
@@ -601,14 +601,7 @@ public class BackgroundFrame extends InstantiableResourceFrame<Background,PBackg
 			f = File.createTempFile(res.getName(),
 					"." + Prefs.externalBackgroundExtension,LGM.tempDir); //$NON-NLS-1$
 			f.deleteOnExit();
-			monitor = new FileChangeMonitor(f,SwingExecutor.INSTANCE);
-			monitor.updateSource.addListener(this);
-			editor = this;
-			start();
-			}
 
-		public void start() throws IOException
-			{
 			BufferedImage bi = res.getBackgroundImage();
 			if (bi == null)
 				{
@@ -627,6 +620,15 @@ public class BackgroundFrame extends InstantiableResourceFrame<Background,PBackg
 					out.close();
 					}
 				}
+
+			monitor = new FileChangeMonitor(f,SwingExecutor.INSTANCE);
+			monitor.updateSource.addListener(this);
+			editor = this;
+			start();
+			}
+
+		public void start() throws IOException
+			{
 			if (!Prefs.useExternalBackgroundEditor || Prefs.externalBackgroundEditorCommand == null)
 				try
 					{

--- a/org/lateralgm/subframes/ScriptFrame.java
+++ b/org/lateralgm/subframes/ScriptFrame.java
@@ -154,14 +154,7 @@ public class ScriptFrame extends InstantiableResourceFrame<Script,PScript>
 			{
 			f = File.createTempFile(res.getName(),"." + Prefs.externalScriptExtension,LGM.tempDir); //$NON-NLS-1$
 			f.deleteOnExit();
-			monitor = new FileChangeMonitor(f,SwingExecutor.INSTANCE);
-			monitor.updateSource.addListener(this,true);
-			editor = this;
-			start();
-			}
 
-		public void start() throws IOException
-			{
 			FileWriter out = null;
 			try
 				{
@@ -175,6 +168,15 @@ public class ScriptFrame extends InstantiableResourceFrame<Script,PScript>
 					out.close();
 					}
 				}
+
+			monitor = new FileChangeMonitor(f,SwingExecutor.INSTANCE);
+			monitor.updateSource.addListener(this,true);
+			editor = this;
+			start();
+			}
+
+		public void start() throws IOException
+			{
 			if (!Prefs.useExternalScriptEditor || Prefs.externalScriptEditorCommand == null)
 				try
 					{

--- a/org/lateralgm/subframes/ShaderFrame.java
+++ b/org/lateralgm/subframes/ShaderFrame.java
@@ -248,13 +248,7 @@ public class ShaderFrame extends InstantiableResourceFrame<Shader,PShader>
 			f = File.createTempFile(res.getName(),"." +
 					(type == EditorType.VERTEX ? "vert" : "frag"), LGM.tempDir); //$NON-NLS-1$
 			f.deleteOnExit();
-			monitor = new FileChangeMonitor(f,SwingExecutor.INSTANCE);
-			monitor.updateSource.addListener(this,true);
-			start();
-			}
 
-		public void start() throws IOException
-			{
 			FileWriter out = null;
 			try
 				{
@@ -269,7 +263,13 @@ public class ShaderFrame extends InstantiableResourceFrame<Shader,PShader>
 					}
 				}
 
-			out.close();
+			monitor = new FileChangeMonitor(f,SwingExecutor.INSTANCE);
+			monitor.updateSource.addListener(this,true);
+			start();
+			}
+
+		public void start() throws IOException
+			{
 			if (!Prefs.useExternalScriptEditor || Prefs.externalScriptEditorCommand == null)
 				try
 					{

--- a/org/lateralgm/subframes/SoundFrame.java
+++ b/org/lateralgm/subframes/SoundFrame.java
@@ -710,6 +710,7 @@ public class SoundFrame extends InstantiableResourceFrame<Sound,PSound>
 			File f = File.createTempFile(res.getName(),
 					new File((String) res.get(PSound.FILE_NAME)).getName(),LGM.tempDir);
 			f.deleteOnExit();
+
 			FileOutputStream out = null;
 			try
 				{
@@ -723,6 +724,7 @@ public class SoundFrame extends InstantiableResourceFrame<Sound,PSound>
 					out.close();
 					}
 				}
+
 			monitor = new FileChangeMonitor(f,SwingExecutor.INSTANCE);
 			monitor.updateSource.addListener(this);
 			editor = this;

--- a/org/lateralgm/subframes/SpriteFrame.java
+++ b/org/lateralgm/subframes/SpriteFrame.java
@@ -1123,7 +1123,6 @@ public class SpriteFrame extends InstantiableResourceFrame<Sprite,PSprite> imple
 
 	private static class TransferableImages implements Transferable
 		{
-
 		ClipboardImages ci;
 
 		public TransferableImages(ClipboardImages images)
@@ -1269,6 +1268,10 @@ public class SpriteFrame extends InstantiableResourceFrame<Sprite,PSprite> imple
 					LGM.showDefaultExceptionHandler(e);
 					}
 				imageChanged = true;
+				for (int i = 0; i < images.bi.size(); i++)
+					{
+					images.bi.set(i, Util.cloneImage(images.bi.get(i)));
+					}
 				res.subImages.addAll(pos + 1,images.bi);
 				subList.setSelectionInterval(pos + 1,pos + images.bi.size());
 				}

--- a/org/lateralgm/subframes/SpriteFrame.java
+++ b/org/lateralgm/subframes/SpriteFrame.java
@@ -1270,9 +1270,8 @@ public class SpriteFrame extends InstantiableResourceFrame<Sprite,PSprite> imple
 				imageChanged = true;
 				for (int i = 0; i < images.bi.size(); i++)
 					{
-					images.bi.set(i, Util.cloneImage(images.bi.get(i)));
+					res.subImages.add(pos + 1 + i, Util.cloneImage(images.bi.get(i)));
 					}
-				res.subImages.addAll(pos + 1,images.bi);
 				subList.setSelectionInterval(pos + 1,pos + images.bi.size());
 				}
 			return;

--- a/org/lateralgm/subframes/SpriteFrame.java
+++ b/org/lateralgm/subframes/SpriteFrame.java
@@ -1270,9 +1270,9 @@ public class SpriteFrame extends InstantiableResourceFrame<Sprite,PSprite> imple
 				imageChanged = true;
 				for (int i = 0; i < images.bi.size(); i++)
 					{
-					res.subImages.add(pos + 1 + i, Util.cloneImage(images.bi.get(i)));
+					res.subImages.add(pos + i, Util.cloneImage(images.bi.get(i)));
 					}
-				subList.setSelectionInterval(pos + 1,pos + images.bi.size());
+				subList.setSelectionInterval(pos, pos + images.bi.size() - 1);
 				}
 			return;
 			}

--- a/org/lateralgm/subframes/SpriteFrame.java
+++ b/org/lateralgm/subframes/SpriteFrame.java
@@ -113,7 +113,7 @@ import org.lateralgm.util.PropertyMap.PropertyUpdateEvent;
 import org.lateralgm.util.PropertyMap.PropertyUpdateListener;
 
 public class SpriteFrame extends InstantiableResourceFrame<Sprite,PSprite> implements
-		UpdateListener,ValueChangeListener,ClipboardOwner, EffectsFrameListener
+		UpdateListener,ValueChangeListener,ClipboardOwner,EffectsFrameListener
 	{
 	private static final long serialVersionUID = 1L;
 	private static final ImageIcon LOAD_ICON = LGM.getIconForKey("SpriteFrame.LOAD"); //$NON-NLS-1$
@@ -152,7 +152,7 @@ public class SpriteFrame extends InstantiableResourceFrame<Sprite,PSprite> imple
 	public JScrollPane previewScroll, subimagesScroll;
 	public SubimagePreview preview;
 	public NumberField show, speed;
-	public JButton subLeft, subRight, play, cut, copy, paste, undo, redo;
+	public JButton subLeft, subRight, play, cut, copy, paste;
 	public JLabel showLab;
 	public int currSub;
 	public JCheckBox showBbox, showOrigin;
@@ -820,12 +820,6 @@ public class SpriteFrame extends InstantiableResourceFrame<Sprite,PSprite> imple
 
 		tool.addSeparator();
 
-		// TODO: Implement undo/redo
-		//tool.add(makeJButton("SpriteFrame.UNDO"));
-		//tool.add(makeJButton("SpriteFrame.REDO"));
-
-		//tool.addSeparator();
-
 		subLeft = new JButton(LGM.getIconForKey("SpriteFrame.PREVIOUS")); //$NON-NLS-1$
 		subLeft.addActionListener(this);
 		tool.add(subLeft);
@@ -1200,17 +1194,8 @@ public class SpriteFrame extends InstantiableResourceFrame<Sprite,PSprite> imple
 	public void editActionsPerformed(String cmd)
 		{
 		int pos = subList.getSelectedIndex();
-		if (cmd.endsWith(".UNDO"))
-			{
-
-			return;
-			}
-		else if (cmd.endsWith(".REDO"))
-			{
-
-			return;
-			}
-		else if (cmd.endsWith(".SELECT_ALL"))
+		pos = pos >= 0 ? pos + 1 : res.subImages.size();
+		if (cmd.endsWith(".SELECT_ALL"))
 			{
 			subList.setSelectionInterval(0,res.subImages.size() - 1);
 			return;
@@ -1232,7 +1217,6 @@ public class SpriteFrame extends InstantiableResourceFrame<Sprite,PSprite> imple
 			Clipboard clip = Toolkit.getDefaultToolkit().getSystemClipboard();
 			clip.setContents(new TransferableImages(new ClipboardImages(images)),this);
 			imageChanged = true;
-			subList.setSelectedIndex(pos - 1);
 			return;
 			}
 		else if (cmd.endsWith(".COPY"))
@@ -1281,7 +1265,6 @@ public class SpriteFrame extends InstantiableResourceFrame<Sprite,PSprite> imple
 			BufferedImage bi = createNewImage(res.subImages.size() == 0);
 			if (bi != null)
 				{
-				pos = pos >= 0 ? pos + 1 : res.subImages.size();
 				imageChanged = true;
 				res.subImages.add(pos,bi);
 				subList.setSelectedIndex(pos);
@@ -1313,7 +1296,7 @@ public class SpriteFrame extends InstantiableResourceFrame<Sprite,PSprite> imple
 				res.subImages.remove(selections[i] - i);
 				if (ie != null) ie.stop();
 				}
-			subList.setSelectedIndex(Math.min(res.subImages.size() - 1,pos));
+			subList.setSelectedIndex(Math.min(res.subImages.size() - 1, pos));
 			return;
 			}
 		}
@@ -1747,6 +1730,19 @@ public class SpriteFrame extends InstantiableResourceFrame<Sprite,PSprite> imple
 			image = i;
 			f = File.createTempFile(res.getName(),"." + Prefs.externalSpriteExtension,LGM.tempDir); //$NON-NLS-1$
 			f.deleteOnExit();
+
+			FileOutputStream out = null;
+			try
+				{
+				out = new FileOutputStream(f);
+				ImageIO.write(image,Prefs.externalSpriteExtension,out);
+				}
+			finally
+				{
+				if (out != null)
+					out.close();
+				}
+
 			monitor = new FileChangeMonitor(f,SwingExecutor.INSTANCE);
 			monitor.updateSource.addListener(this,true);
 			if (editors == null) editors = new HashMap<BufferedImage,ImageEditor>();
@@ -1756,18 +1752,6 @@ public class SpriteFrame extends InstantiableResourceFrame<Sprite,PSprite> imple
 
 		public void start() throws IOException,UnsupportedOperationException
 			{
-			FileOutputStream out = null;
-			try
-				{
-				out = new FileOutputStream(f);
-				ImageIO.write(image,Prefs.externalSpriteExtension,out); //$NON-NLS-1$
-				}
-			finally
-				{
-				if (out != null) {
-					out.close();
-				}
-				}
 			if (!Prefs.useExternalSpriteEditor || Prefs.externalSpriteEditorCommand == null)
 				try
 					{
@@ -1844,7 +1828,7 @@ public class SpriteFrame extends InstantiableResourceFrame<Sprite,PSprite> imple
 	protected void cleanup()
 		{
 		if (editors != null)
-			for (ImageEditor ie : editors.values().toArray(new ImageEditor[editors.size()]))
+			for (ImageEditor ie : editors.values())
 				ie.stop();
 		}
 


### PR DESCRIPTION
Ok, so I made a critical mistake in my original fixes to the external editors. I moved their write code into the `start()` method after the FileChangeMonitor was already created, and had recorded the last modified time and length. This caused slight lag when opening a resource for external editing because the first write was being recognized as a change, and immediately read back in. I went back and reviewed the old LateralGM source just before I  started committing and this is the way it used to be. I've noticed no side effects and it does appear that external editing happens a little quicker now.