### PR TITLE
Fix GMX POSIX Path Regressions

### DIFF
--- a/org/lateralgm/file/GMXFileReader.java
+++ b/org/lateralgm/file/GMXFileReader.java
@@ -463,7 +463,7 @@ public final class GMXFileReader
 						+ setdoc.getElementsByTagName("option_windows_game_icon").item(0).getTextContent(); //$NON-NLS-1$
 				try
 					{
-					pSet.put(PGameSettings.GAME_ICON,new ICOFile(icopath));
+					pSet.put(PGameSettings.GAME_ICON,new ICOFile(Util.getPOSIXPath(icopath)));
 					}
 				catch (IOException e)
 					{

--- a/org/lateralgm/file/GMXFileReader.java
+++ b/org/lateralgm/file/GMXFileReader.java
@@ -448,10 +448,8 @@ public final class GMXFileReader
 						PGameSettings.TREAT_CLOSE_AS_ESCAPE,
 						Boolean.parseBoolean(setdoc.getElementsByTagName("option_closeesc").item(0).getTextContent())); //$NON-NLS-1$
 				String changed = setdoc.getElementsByTagName("option_lastchanged").item(0).getTextContent(); //$NON-NLS-1$
-				if (changed != "")
-					{
+				if (!changed.isEmpty())
 					pSet.put(PGameSettings.LAST_CHANGED,Double.parseDouble(changed));
-					}
 
 				// TODO: Could not find these properties in GMX
 				//gSet.put(PGameSettings.BACK_LOAD_BAR,

--- a/org/lateralgm/file/GMXFileWriter.java
+++ b/org/lateralgm/file/GMXFileWriter.java
@@ -682,7 +682,7 @@ public final class GMXFileWriter
 					sndroot.appendChild(createElement(doc,"effects",Integer.toString(effects))); //$NON-NLS-1$
 
 					sndroot.appendChild(createElement(doc,"data",fileName)); //$NON-NLS-1$
-					Util.writeFully(fname + "audio\\" + fileName,snd.data); //$NON-NLS-1$
+					Util.writeFully(Util.getPOSIXPath(fname + "audio/" + fileName),snd.data); //$NON-NLS-1$
 
 					FileOutputStream fos = null;
 					try

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -134,7 +134,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.39"; //$NON-NLS-1$
+	public static final String version = "1.8.40"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.


### PR DESCRIPTION
This fixes #361 and #362

The problem arose in #353 because I made some changes to a utility method and it no longer converts the path to POSIX (since, as a utility method, it would then prevent certain filenames, which is less desirable).