### PR TITLE
Cleanup Project File Filters

### DIFF
--- a/org/lateralgm/components/impl/CustomFileFilter.java
+++ b/org/lateralgm/components/impl/CustomFileFilter.java
@@ -49,9 +49,10 @@ public class CustomFileFilter extends FileFilter implements FilenameFilter
 		{
 		if (ext.size() == 0) return true;
 		//if (f.isDirectory()) return true;
-		String s = getExtension(name);
-		if (s == null) return false;
-		return ext.contains(s);
+		for (String e : ext)
+			if (name.endsWith(e))
+				return true;
+		return false;
 		}
 
 	public String getDescription()

--- a/org/lateralgm/file/GMXFileReader.java
+++ b/org/lateralgm/file/GMXFileReader.java
@@ -236,7 +236,7 @@ public final class GMXFileReader
 	public static void readProjectFile(InputStream stream, ProjectFile file, URI uri, ResNode root,
 			Charset forceCharset) throws GmFormatException
 		{
-		file.format = ProjectFile.FormatFlavor.getVersionFlavor(1200); // GMX will have version numbers in the future
+		file.format = ProjectFile.FormatFlavor.GMX;
 		if (documentBuilderFactory == null)
 			documentBuilderFactory = DocumentBuilderFactory.newInstance();
 		if (documentBuilder == null)

--- a/org/lateralgm/file/GMXFileReader.java
+++ b/org/lateralgm/file/GMXFileReader.java
@@ -463,7 +463,7 @@ public final class GMXFileReader
 						+ setdoc.getElementsByTagName("option_windows_game_icon").item(0).getTextContent(); //$NON-NLS-1$
 				try
 					{
-					pSet.put(PGameSettings.GAME_ICON,new ICOFile(icopath));
+					pSet.put(PGameSettings.GAME_ICON,new ICOFile(Util.getPOSIXPath(icopath)));
 					}
 				catch (IOException e)
 					{

--- a/org/lateralgm/file/GMXFileReader.java
+++ b/org/lateralgm/file/GMXFileReader.java
@@ -448,10 +448,8 @@ public final class GMXFileReader
 						PGameSettings.TREAT_CLOSE_AS_ESCAPE,
 						Boolean.parseBoolean(setdoc.getElementsByTagName("option_closeesc").item(0).getTextContent())); //$NON-NLS-1$
 				String changed = setdoc.getElementsByTagName("option_lastchanged").item(0).getTextContent(); //$NON-NLS-1$
-				if (changed != "")
-					{
+				if (!changed.isEmpty())
 					pSet.put(PGameSettings.LAST_CHANGED,Double.parseDouble(changed));
-					}
 
 				// TODO: Could not find these properties in GMX
 				//gSet.put(PGameSettings.BACK_LOAD_BAR,

--- a/org/lateralgm/file/GMXFileWriter.java
+++ b/org/lateralgm/file/GMXFileWriter.java
@@ -138,10 +138,10 @@ public final class GMXFileWriter
 			}
 		}
 
-	public static void writeProjectFile(OutputStream os, ProjectFile f, ResNode rootRes, int ver)
+	public static void writeProjectFile(OutputStream os, ProjectFile f, ResNode rootRes)
 			throws IOException,GmFormatException,TransformerException
 		{
-		f.format = ProjectFile.FormatFlavor.getVersionFlavor(ver);
+		f.format = ProjectFile.FormatFlavor.GMX;
 		long savetime = System.currentTimeMillis();
 
 		if (documentBuilderFactory == null)

--- a/org/lateralgm/file/GMXFileWriter.java
+++ b/org/lateralgm/file/GMXFileWriter.java
@@ -682,7 +682,7 @@ public final class GMXFileWriter
 					sndroot.appendChild(createElement(doc,"effects",Integer.toString(effects))); //$NON-NLS-1$
 
 					sndroot.appendChild(createElement(doc,"data",fileName)); //$NON-NLS-1$
-					Util.writeFully(fname + "audio\\" + fileName,snd.data); //$NON-NLS-1$
+					Util.writeFully(Util.getPOSIXPath(fname + "audio/" + fileName),snd.data); //$NON-NLS-1$
 
 					FileOutputStream fos = null;
 					try

--- a/org/lateralgm/file/ProjectFile.java
+++ b/org/lateralgm/file/ProjectFile.java
@@ -290,12 +290,13 @@ public class ProjectFile implements UpdateListener
 	public static class FormatFlavor
 		{
 		public static final String GM_OWNER = "GM";
+		public static final String GMX_OWNER = "GMX";
 		public static final FormatFlavor GM_530 = new FormatFlavor(GM_OWNER,530);
 		public static final FormatFlavor GM_600 = new FormatFlavor(GM_OWNER,600);
 		public static final FormatFlavor GM_701 = new FormatFlavor(GM_OWNER,701);
 		public static final FormatFlavor GM_800 = new FormatFlavor(GM_OWNER,800);
 		public static final FormatFlavor GM_810 = new FormatFlavor(GM_OWNER,810);
-		public static final FormatFlavor GMX_1200 = new FormatFlavor(GM_OWNER,1200);
+		public static final FormatFlavor GMX = new FormatFlavor(GMX_OWNER,1);
 
 		protected Object owner;
 		protected int version;
@@ -320,8 +321,6 @@ public class ProjectFile implements UpdateListener
 					return FormatFlavor.GM_800;
 				case 810:
 					return FormatFlavor.GM_810;
-				case 1200:
-					return FormatFlavor.GMX_1200;
 				default:
 					return null;
 				}

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -134,7 +134,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.39"; //$NON-NLS-1$
+	public static final String version = "1.8.40"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -134,7 +134,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.40"; //$NON-NLS-1$
+	public static final String version = "1.8.41"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/messages/messages.properties
+++ b/org/lateralgm/messages/messages.properties
@@ -211,15 +211,13 @@ FileChooser.PROJECTLOADED=Project Loaded
 FileChooser.PROJECTSAVED=Project Saved
 
 FileChooser.ALL_SUPPORTED=All supported files
-FileChooser.FORMAT_READERS_GM=All Game Maker Files (gm81, gmk, gm6, gmd)
-FileChooser.FORMAT_WRITERS_GM=All Game Maker Files (gm81, gmk, gm6)
-FileChooser.FORMAT_READERS_GMX=Game Maker XML Files (gmx)
-FileChooser.FORMAT_WRITERS_GMX=Game Maker XML Files (gmx)
-FileChooser.FORMAT_GM81=Game Maker 8.1 Files (gm81)
-FileChooser.FORMAT_GMK=Game Maker 7/8 Files (gmk)
-FileChooser.FORMAT_GMX=Game Maker Project Files (gmx)
-FileChooser.FORMAT_GM6=Game Maker 6 Files (gm6)
-FileChooser.FORMAT_GMD=Game Maker 5.3 Files (gmd)
+FileChooser.FORMAT_GMX=Game Maker Studio Files (*.project.gmx)
+FileChooser.FORMAT_READERS_GM=Old Game Maker Files (*.gm81;*.gmk;*.gm6;*.gmd)
+FileChooser.FORMAT_WRITERS_GM=Old Game Maker Files (*.gm81;*.gmk;*.gm6)
+FileChooser.FORMAT_GM81=Game Maker 8.1 Files (*.gm81)
+FileChooser.FORMAT_GMK=Game Maker 7/8 Files (*.gmk)
+FileChooser.FORMAT_GM6=Game Maker 6 Files (*.gm6)
+FileChooser.FORMAT_GMD=Game Maker 5.3 Files (*.gmd)
 
 FileChooser.UNRECOGNIZED_TITLE=Unrecognized File
 FileChooser.UNRECOGNIZED=<html>Unable to read file "{0}"<br/>\


### PR DESCRIPTION
I basically detached the GMX filters from the old GM ones. Even though GMX does not have version numbers, this allows me to put it in its own line of versioning (which it technically should be anyway). I modeled GMXIO after EgmIO from the plugin.

- I no longer refer to the GMX format by "1200" since that was just the GMS version at the time I originally wrote the GMX reader.
- I moved GMX up to the top to make it sort of the "default" file format. Which it should be because it's the format of modern/current GM and it's also human-readable and more fail safe.
- I did decide to change the group filters to call the old formats "Old Game Maker" because it is true that they are the old formats, and again, GMX really is a much better format, despite some controversy.
- I added "*." to all the file filter extensions as well as delimited them with semicolons instead of commas. I looked at a ton of programs, including VS Code, Paint.NET, Notepad++, JavaFX Scene Builder, Game Maker, etc. All of them use this style, but I did notice that Paint.NET will delimit multiple extensions with a semicolon followed by a space instead of just the semicolon. Two programs I found that don't follow this style are Dolphin (wxWidgets) and Audacity.
- I added a few missing NON-NLS comments where it's obvious, such as literal file extensions.

![Project Open Dialog](https://user-images.githubusercontent.com/3212801/37506694-746c384a-28c1-11e8-84db-9e3ad7636178.png)
![Project Save Dialog](https://user-images.githubusercontent.com/3212801/37506684-66e129e2-28c1-11e8-9c47-148c9318ea05.png)


