### PR TITLE
Get LateralGM building on my machine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,24 @@
-JC = ecj -1.6 -nowarn -cp .
-JFLAGS = -cp /usr/share/java/eclipse-ecj.jar:/usr/share/java/ecj.jar
+JC = javac
+JFLAGS = -source 1.7 -target 1.7 -cp .:modules/joshedit
 OUTPUT_FILE = lateralgm.jar
 
-.SUFFIXES: .java .class
-
-.java.class:
+%.class: %.java
 	$(JC) $(JFLAGS) $*.java
 
 JAVA_FILES = $(shell find org -name "*.java")
-JAR_INC_FILES = $(shell find org -type f \( -not -wholename '*/.git/*' \) -a \( -not -name "*.java" \) | sed 's/\$$/\\\$$/g')
+JAR_INC_FILES = $(shell find org -type f \( -not -wholename '*/.git/*' \) -a \( -not -name "*.java" \))
+BASE_CLASSES = $(JAVA_FILES:.java=.class)
 
 default: classes jar
 
-classes: $(JAVA_FILES:.java=.class)
+classes: $(BASE_CLASSES)
 
 clean:
 	find org/lateralgm -name "*.class" -exec rm {} \;
 	rm -f $(OUTPUT_FILE)
 
-jar:
-	@jar cfm $(OUTPUT_FILE) META-INF/MANIFEST.MF COPYING README LICENSE $(JAR_INC_FILES)
+jar: $(BASE_CLASSES)
+	@echo JAR $(OUTPUT_FILE)
+	@jar cfm $(OUTPUT_FILE) META-INF/MANIFEST.MF COPYING README.md LICENSE $(subst $$,\$$,$(JAR_INC_FILES))
+
+.PHONY: clean jar default classes

--- a/org/lateralgm/components/ImageEffects.java
+++ b/org/lateralgm/components/ImageEffects.java
@@ -871,7 +871,7 @@ public class ImageEffects
 		private JSlider brightnessSlider;
 		private JSlider contrastSlider;
 
-			//from David Fichtmüller
+			//from David FichtmÃ¼ller
 			public BufferedImage applyBrightnessAndContrast(BufferedImage bi, double brightness,
 					double contrast) {
 				final double gamma = 0.25;

--- a/org/lateralgm/ui/swing/visuals/RoomVisual.java
+++ b/org/lateralgm/ui/swing/visuals/RoomVisual.java
@@ -600,9 +600,9 @@ public class RoomVisual extends AbstractVisual implements BoundedVisual,UpdateLi
 	@SuppressWarnings("unchecked")
 	private static <P extends Piece, V extends PieceVisual<P>>Class<V> getVisualClass(Class<P> p)
 		{
-		if (p == Piece.class) return (Class<V>) PieceVisual.class;
-		if (p == Instance.class) return (Class<V>) InstanceVisual.class;
-		if (p == Tile.class) return (Class<V>) TileVisual.class;
+		if (p == Piece.class) return (Class<V>) (Class) PieceVisual.class;
+		if (p == Instance.class) return (Class<V>) (Class) InstanceVisual.class;
+		if (p == Tile.class) return (Class<V>) (Class) TileVisual.class;
 		throw new IllegalArgumentException();
 		}
 


### PR DESCRIPTION
Gentoo 17.0 Hardened, OpenJDK 1.8.0_181a / IcedTea 3.9.0, no Eclipse

- Remove ECJ requirement in Makefile, use javac instead
- README -> README.md in jar command of Makefile
- Ensure jar is only created after all classes are built (for parallel
  make)
- Convert ImageEffects source from WINDOWS-1252 to UTF-8
- Cast to bare Class before casting to Class\<V\> to sidestep some extra
  type checks in newer Java compilers

----

Probably best to take the maven commit over this one, which is a little more minimal and focused on just un-breaking it.