### PR TITLE
Append Spritesheet Subimages

### DIFF
--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -134,7 +134,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.41"; //$NON-NLS-1$
+	public static final String version = "1.8.42"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/subframes/SpriteFrame.java
+++ b/org/lateralgm/subframes/SpriteFrame.java
@@ -1371,7 +1371,7 @@ public class SpriteFrame extends InstantiableResourceFrame<Sprite,PSprite> imple
 			}
 		else if (e.getSource() == loadStrip)
 			{
-			addFromStrip(true);
+			addFromStrip(false);
 			return;
 			}
 		else if (e.getSource() == loadSubimages)


### PR DESCRIPTION
This is a fix for #390 which adds the spritesheet subimages without clearing the previous subimages. I had intended to do this because I had changed the label since lgm16b4 to say "Add Spritesheet Subimages" instead of "Load Spritesheet Subimages" and I just never updated the behavior. GM8.1 actually provides both options at the same time under its file menu as "Create from Strip" and "Add from Strip" but I see no reason to bother. If somebody wants to do "create", they can just hit the new button first and then add the spritesheet subimages.