### PR TITLE
Action List Context Menu Deep Copy

### DIFF
--- a/org/lateralgm/components/ActionList.java
+++ b/org/lateralgm/components/ActionList.java
@@ -942,7 +942,7 @@ public static class ActionTransferHandler extends TransferHandler
 				LGM.showDefaultExceptionHandler(e);
 				return false;
 				}
-			//clone properly for drag-copy or clipboard paste
+			// deep copy for drag-copy or clipboard paste
 			if (!info.isDrop() || info.getDropAction() == COPY) a = a.copy();
 			if (info.isDrop() && info.getDropAction() == MOVE && indices != null)
 				{
@@ -967,9 +967,10 @@ public static class ActionTransferHandler extends TransferHandler
 				LGM.showDefaultExceptionHandler(e);
 				return false;
 				}
-			//clone properly for drag-copy or clipboard paste
-			if (!info.isDrop() || info.getDropAction() == COPY) for (int i = 0; i < a.size(); i++)
-				a.set(i,a.get(i).copy());
+			// deep copy for drag-copy or clipboard paste
+			if (!info.isDrop() || info.getDropAction() == COPY)
+				for (int i = 0; i < a.size(); i++)
+					a.set(i,a.get(i).copy());
 			if (info.isDrop() && info.getDropAction() == MOVE && indices != null)
 				{
 				addIndex = index;
@@ -1369,6 +1370,11 @@ public static class ActionTransferHandler extends TransferHandler
 				if (ind < 0) {
 					ind = alm.getSize();
 				}
+				// perform a deep copy of the actions so editing them
+				// does not change the original ones we transferred
+				for (int i = 0; i < actions.size(); i++)
+					actions.set(i,actions.get(i).copy());
+
 				alm.addAll(ind, (List<Action>) actions);
 				list.setSelectionInterval(ind,ind += actions.size() - 1);
 				}

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -134,7 +134,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.42"; //$NON-NLS-1$
+	public static final String version = "1.8.43"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/messages/messages.properties
+++ b/org/lateralgm/messages/messages.properties
@@ -141,7 +141,7 @@ DocumentUndoManager.UNDO=Undo
 DocumentUndoManager.REDO=Redo
 
 AboutBox.TITLE=About LateralGM
-AboutBox.ABOUT=<h1 style="white-space: nowrap">Copyright &copy; 2006-2017</h1>\
+AboutBox.ABOUT=<h1 style="white-space: nowrap">Copyright &copy; 2006-2019</h1>\
 	<p style="white-space: nowrap">Version: {0}<br><br>\
 	IsmAvatar \
 	&lt;<a href="mailto:IsmAvatar@gmail.com">IsmAvatar@gmail.com</a>&gt;<br>\


### PR DESCRIPTION
This set of changes is to address #380 and make the context menu buttons for the action list do a deep copy instead of a shallow copy of the transferred actions.

All I had to do basically was make the `ActionsPaste` method I previously created iterate the action list being transferred and deep copy each of the actions before adding them to the target's model. I also decided to update the comments of the other deep copy locations for clarity and fix the indentation of a for loop which was ambiguous.

With this change I have no problems copying actions between action lists. Editing the pasted actions does not change the original ones that were copied. This is true whether using the keyboard shortcuts, context menu, or doing a drag-copy operation with the mouse while holding CTRL.

This pull request also updates the copyright year to extend through 2018 and into 2019.