### PR TITLE
Action List Empty Selection Cast Exception Fix

### DIFF
--- a/org/lateralgm/components/ActionList.java
+++ b/org/lateralgm/components/ActionList.java
@@ -1334,9 +1334,7 @@ public static class ActionTransferHandler extends TransferHandler
 	public void ActionsCopy(JList<Action> list)
 		{
 		if (list.isSelectionEmpty()) return;
-		int[] indices = list.getSelectedIndices();
 		ArrayList<Action> actions = (ArrayList<Action>) list.getSelectedValuesList();
-		if (indices.length <= 0) return;
 		Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
 
 		ActionTransferable at = new ActionTransferable(actions);

--- a/org/lateralgm/components/ActionList.java
+++ b/org/lateralgm/components/ActionList.java
@@ -1014,8 +1014,8 @@ public static class ActionTransferHandler extends TransferHandler
 	@Override
 	protected Transferable createTransferable(JComponent c)
 		{
-		indices = list.getSelectedIndices();
 		if (list.isSelectionEmpty()) return null;
+		indices = list.getSelectedIndices();
 		return new ActionTransferable((ArrayList<Action>) list.getSelectedValuesList());
 		}
 	}

--- a/org/lateralgm/components/ActionList.java
+++ b/org/lateralgm/components/ActionList.java
@@ -1015,6 +1015,7 @@ public static class ActionTransferHandler extends TransferHandler
 	protected Transferable createTransferable(JComponent c)
 		{
 		indices = list.getSelectedIndices();
+		if (list.isSelectionEmpty()) return null;
 		return new ActionTransferable((ArrayList<Action>) list.getSelectedValuesList());
 		}
 	}

--- a/org/lateralgm/components/ActionList.java
+++ b/org/lateralgm/components/ActionList.java
@@ -1325,12 +1325,14 @@ public static class ActionTransferHandler extends TransferHandler
 
 	public void ActionsCut(JList<Action> list)
 		{
+		if (list.isSelectionEmpty()) return;
 		ActionsCopy(list);
 		ActionsDelete(list);
 		}
 
 	public void ActionsCopy(JList<Action> list)
 		{
+		if (list.isSelectionEmpty()) return;
 		int[] indices = list.getSelectedIndices();
 		ArrayList<Action> actions = (ArrayList<Action>) list.getSelectedValuesList();
 		if (indices.length <= 0) return;


### PR DESCRIPTION
This pull request addresses issues raised in #277 with respect to action lists having an empty selection. I basically just check if the JList selection is empty and return early to avoid the cast which causes the exception.

I did this first for the context menu cut and copy options before tackling the keyboard shortcut versions. As I've explained before, the keyboard shortcuts are actually being handled by Java internally, it's built into the transfer handling support. Those use the transfer handler to do the copy and pasting. That is why I have my own logic for the context menu options.

After I corrected the context menu, I then corrected the issue for the keyboard shortcuts. I did this by checking the same condition and returning null when a request is made to create a transferable. This is the acceptable way to say that there is nothing to transfer according to the Java documentation.

>Returns the representation of the data to be transferred, or **null** if the component's property is null
https://docs.oracle.com/javase/7/docs/api/javax/swing/TransferHandler.html#createTransferable(javax.swing.JComponent)

With these changes I no longer get any exception when attempting to cut or copy an action list that has an empty selection. This is true whether I attempted to cut or copy from the context menu or using the keyboard shortcuts. This correction also fixes the issue whereby pasting an empty transferable adds an undo operation. Since the empty transferable is prevented from ever being created now, it's impossible for an empty undo action to be registered.

I suppose I can also mention that an alternative to this would be to just disable the cut and copy actions when there isn't a selection in the ActionList. However, Java Swing just really isn't equipped well to bind those properties and keep the UI synchronized in that way. It would require some extra work to do that.