### PR TITLE
External Editor Error Handling

### DIFF
--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -134,7 +134,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.44"; //$NON-NLS-1$
+	public static final String version = "1.8.45"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/main/Util.java
+++ b/org/lateralgm/main/Util.java
@@ -14,6 +14,7 @@ package org.lateralgm.main;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Container;
+import java.awt.Desktop;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
@@ -1198,6 +1199,28 @@ public final class Util
 			BitmapDescriptor bmd = ico.getDescriptor(maxind);
 			ico.getDescriptors().clear();
 			ico.getDescriptors().add(bmd);
+			}
+		}
+	
+	public static void OpenDesktopEditor(File file)
+		{
+		try
+			{
+			Desktop.getDesktop().edit(file);
+			}
+		catch (UnsupportedOperationException e)
+			{
+			JOptionPane.showMessageDialog(LGM.frame,
+					Messages.getString("ExternalEditorDialog.NOT_SUPPORTED_MESSAGE"), //$NON-NLS-1$
+					Messages.getString("ExternalEditorDialog.NOT_SUPPORTED_TITLE"), //$NON-NLS-1$
+					JOptionPane.ERROR_MESSAGE);
+			}
+		catch (IOException e)
+			{
+			JOptionPane.showMessageDialog(LGM.frame,
+					Messages.getString("ExternalEditorDialog.FAILED_MESSAGE"), //$NON-NLS-1$
+					Messages.getString("ExternalEditorDialog.FAILED_TITLE"), //$NON-NLS-1$
+					JOptionPane.ERROR_MESSAGE);
 			}
 		}
 	}

--- a/org/lateralgm/messages/messages.properties
+++ b/org/lateralgm/messages/messages.properties
@@ -1,12 +1,23 @@
 ### Package components ###
 
 HelpDialog.MALFORMED_TITLE=Malformed URI
-HelpDialog.MALFORMED_MESSAGE=<html>"{0}"<br/><p>The URI specified in preferences appears to be \
-	malformed.<br/> Verify that you have entered a valid URI and try again.</p></html>
+HelpDialog.MALFORMED_MESSAGE=<html>"{0}"<br><p>The URI specified in preferences appears to be \
+	malformed.<br> Verify that you have entered a valid URI and try again.</p></html>
 
 HelpDialog.UNAVAILABLE_TITLE=Unavailable URI
-HelpDialog.UNAVAILABLE_MESSAGE=<html>"{0}"<br/><p>The URI specified in preferences appears to be \
-	unavailable.<br/> Verify that you have entered a valid URI or try again later.</p></html>
+HelpDialog.UNAVAILABLE_MESSAGE=<html>"{0}"<br><p>The URI specified in preferences appears to be \
+	unavailable.<br> Verify that you have entered a valid URI or try again later.</p></html>
+
+ExternalEditorDialog.NOT_SUPPORTED_TITLE=Desktop Editing Unsupported
+ExternalEditorDialog.NOT_SUPPORTED_MESSAGE=<html><p>The current platform does not support the desktop \
+	edit operation.<br><br>Configure an external editor command for this resource in preferences.\
+	</p></html>
+ExternalEditorDialog.FAILED_TITLE=External Editing Failed
+ExternalEditorDialog.FAILED_MESSAGE=<html><p style='width: 500px;'>The desktop either does not \
+	have an associated editor installed or the associated editor failed to be launched.<br><br>\
+	Verify that you have installed a compatible external editor and registered it for the \
+	appropriate MIME type or configure an external editor command for this resource in \
+	preferences.</p></html>
 
 ColorSelect.CHOOSE_TITLE=Choose a Color
 

--- a/org/lateralgm/subframes/BackgroundFrame.java
+++ b/org/lateralgm/subframes/BackgroundFrame.java
@@ -626,14 +626,7 @@ public class BackgroundFrame extends InstantiableResourceFrame<Background,PBackg
 			monitor.updateSource.addListener(this);
 
 			if (!Prefs.useExternalBackgroundEditor || Prefs.externalBackgroundEditorCommand == null)
-				try
-					{
-					Desktop.getDesktop().edit(monitor.file);
-					}
-				catch (UnsupportedOperationException e)
-					{
-					LGM.showDefaultExceptionHandler(e);
-					}
+				Util.OpenDesktopEditor(monitor.file);
 			else
 				Runtime.getRuntime().exec(
 						String.format(Prefs.externalBackgroundEditorCommand,monitor.file.getAbsolutePath()));

--- a/org/lateralgm/subframes/BackgroundFrame.java
+++ b/org/lateralgm/subframes/BackgroundFrame.java
@@ -15,7 +15,6 @@ import static javax.swing.GroupLayout.PREFERRED_SIZE;
 
 import java.awt.BorderLayout;
 import java.awt.Cursor;
-import java.awt.Desktop;
 import java.awt.Dimension;
 import java.awt.GridLayout;
 import java.awt.Point;

--- a/org/lateralgm/subframes/ScriptFrame.java
+++ b/org/lateralgm/subframes/ScriptFrame.java
@@ -13,7 +13,6 @@
 package org.lateralgm.subframes;
 
 import java.awt.BorderLayout;
-import java.awt.Desktop;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.event.ActionEvent;

--- a/org/lateralgm/subframes/ScriptFrame.java
+++ b/org/lateralgm/subframes/ScriptFrame.java
@@ -40,6 +40,7 @@ import org.lateralgm.file.FileChangeMonitor;
 import org.lateralgm.file.FileChangeMonitor.FileUpdateEvent;
 import org.lateralgm.main.LGM;
 import org.lateralgm.main.Prefs;
+import org.lateralgm.main.Util;
 import org.lateralgm.main.UpdateSource.UpdateEvent;
 import org.lateralgm.main.UpdateSource.UpdateListener;
 import org.lateralgm.messages.Messages;
@@ -178,14 +179,7 @@ public class ScriptFrame extends InstantiableResourceFrame<Script,PScript>
 			monitor.updateSource.addListener(this,true);
 
 			if (!Prefs.useExternalScriptEditor || Prefs.externalScriptEditorCommand == null)
-				try
-					{
-					Desktop.getDesktop().edit(monitor.file);
-					}
-				catch (UnsupportedOperationException e)
-					{
-					LGM.showDefaultExceptionHandler(e);
-					}
+				Util.OpenDesktopEditor(monitor.file);
 			else
 				Runtime.getRuntime().exec(
 						String.format(Prefs.externalScriptEditorCommand,monitor.file.getAbsolutePath()));

--- a/org/lateralgm/subframes/ShaderFrame.java
+++ b/org/lateralgm/subframes/ShaderFrame.java
@@ -24,7 +24,6 @@
 package org.lateralgm.subframes;
 
 import java.awt.BorderLayout;
-import java.awt.Desktop;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.event.ActionEvent;

--- a/org/lateralgm/subframes/ShaderFrame.java
+++ b/org/lateralgm/subframes/ShaderFrame.java
@@ -66,6 +66,7 @@ import org.lateralgm.joshedit.lexers.GLSLTokenMarker;
 import org.lateralgm.joshedit.lexers.HLSLTokenMarker;
 import org.lateralgm.main.LGM;
 import org.lateralgm.main.Prefs;
+import org.lateralgm.main.Util;
 import org.lateralgm.main.UpdateSource.UpdateEvent;
 import org.lateralgm.main.UpdateSource.UpdateListener;
 import org.lateralgm.messages.Messages;
@@ -277,14 +278,7 @@ public class ShaderFrame extends InstantiableResourceFrame<Shader,PShader>
 			monitor.updateSource.addListener(this,true);
 
 			if (!Prefs.useExternalScriptEditor || Prefs.externalScriptEditorCommand == null)
-				try
-					{
-					Desktop.getDesktop().edit(monitor.file);
-					}
-				catch (UnsupportedOperationException e)
-					{
-					LGM.showDefaultExceptionHandler(e);
-					}
+				Util.OpenDesktopEditor(monitor.file);
 			else
 				Runtime.getRuntime().exec(
 						String.format(Prefs.externalScriptEditorCommand,monitor.file.getAbsolutePath()));

--- a/org/lateralgm/subframes/SoundFrame.java
+++ b/org/lateralgm/subframes/SoundFrame.java
@@ -709,14 +709,7 @@ public class SoundFrame extends InstantiableResourceFrame<Sound,PSound>
 			monitor.updateSource.addListener(this);
 
 			if (!Prefs.useExternalSoundEditor || Prefs.externalSoundEditorCommand == null)
-				try
-					{
-					Desktop.getDesktop().edit(monitor.file);
-					}
-				catch (UnsupportedOperationException e)
-					{
-					LGM.showDefaultExceptionHandler(e);
-					}
+				Util.OpenDesktopEditor(monitor.file);
 			else
 				Runtime.getRuntime().exec(
 						String.format(Prefs.externalSoundEditorCommand,monitor.file.getAbsolutePath()));

--- a/org/lateralgm/subframes/SoundFrame.java
+++ b/org/lateralgm/subframes/SoundFrame.java
@@ -13,7 +13,6 @@ package org.lateralgm.subframes;
 import static javax.swing.GroupLayout.PREFERRED_SIZE;
 
 import java.awt.BorderLayout;
-import java.awt.Desktop;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.event.ActionEvent;

--- a/org/lateralgm/subframes/SpriteFrame.java
+++ b/org/lateralgm/subframes/SpriteFrame.java
@@ -1752,14 +1752,7 @@ public class SpriteFrame extends InstantiableResourceFrame<Sprite,PSprite> imple
 			monitor.updateSource.addListener(this,true);
 
 			if (!Prefs.useExternalSpriteEditor || Prefs.externalSpriteEditorCommand == null)
-				try
-					{
-					Desktop.getDesktop().edit(monitor.file);
-					}
-				catch (UnsupportedOperationException e)
-					{
-					LGM.showDefaultExceptionHandler(e);
-					}
+				Util.OpenDesktopEditor(monitor.file);
 			else
 				Runtime.getRuntime().exec(
 						String.format(Prefs.externalSpriteEditorCommand,monitor.file.getAbsolutePath()));

--- a/org/lateralgm/subframes/SpriteFrame.java
+++ b/org/lateralgm/subframes/SpriteFrame.java
@@ -17,7 +17,6 @@ import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Cursor;
-import java.awt.Desktop;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.Graphics;


### PR DESCRIPTION
This is a proposal to stop people from posting issues like #386 repeatedly. We can't do anything about these issues, they simply need to configure their Java installation or use a custom external editor command.

I basically changed all of the external editing calls to use a new utility method which checks the exceptions according to the Java documentation. I check both `UnsupportedOperationException` and `IOException` since those are the responsibility of the user to address.

>    UnsupportedOperationException - if the current platform does not support the Desktop.Action.EDIT action
    IOException - if the specified file has no associated editor, or the associated application fails to be launched
https://docs.oracle.com/javase/7/docs/api/java/awt/Desktop.html#edit(java.io.File)

![UnsupportedOperationException from Desktop Edit](https://user-images.githubusercontent.com/3212801/56177741-b6b8a780-5fcd-11e9-97aa-17743574a916.png)
![IOException Dialog from Desktop Edit](https://user-images.githubusercontent.com/3212801/56177724-a7d1f500-5fcd-11e9-86ed-3b408cbf97d8.png)
