### PR TITLE
Safe Varargs Annotation

### DIFF
--- a/org/lateralgm/file/GmStreamDecoder.java
+++ b/org/lateralgm/file/GmStreamDecoder.java
@@ -151,25 +151,29 @@ public class GmStreamDecoder extends StreamDecoder
 		return val == 0 ? false : true;
 		}
 
-	public <P extends Enum<P>>void read4(PropertyMap<P> map, P...keys) throws IOException
+	@SafeVarargs
+	public final <P extends Enum<P>>void read4(PropertyMap<P> map, P...keys) throws IOException
 		{
 		for (P key : keys)
 			map.put(key,read4());
 		}
 
-	public <P extends Enum<P>>void readStr(PropertyMap<P> map, P...keys) throws IOException
+	@SafeVarargs
+	public final <P extends Enum<P>>void readStr(PropertyMap<P> map, P...keys) throws IOException
 		{
 		for (P key : keys)
 			map.put(key,readStr());
 		}
 
-	public <P extends Enum<P>>void readBool(PropertyMap<P> map, P...keys) throws IOException
+	@SafeVarargs
+	public final <P extends Enum<P>>void readBool(PropertyMap<P> map, P...keys) throws IOException
 		{
 		for (P key : keys)
 			map.put(key,readBool());
 		}
 
-	public <P extends Enum<P>>void readD(PropertyMap<P> map, P...keys) throws IOException
+	@SafeVarargs
+	public final <P extends Enum<P>>void readD(PropertyMap<P> map, P...keys) throws IOException
 		{
 		for (P key : keys)
 			map.put(key,readD());

--- a/org/lateralgm/file/GmStreamEncoder.java
+++ b/org/lateralgm/file/GmStreamEncoder.java
@@ -114,25 +114,29 @@ public class GmStreamEncoder extends StreamEncoder
 		write4(val ? 1 : 0);
 		}
 
-	public <P extends Enum<P>>void write4(PropertyMap<P> map, P...keys) throws IOException
+	@SafeVarargs
+	public final <P extends Enum<P>>void write4(PropertyMap<P> map, P...keys) throws IOException
 		{
 		for (P key : keys)
 			write4((Integer) map.get(key));
 		}
 
-	public <P extends Enum<P>>void writeStr(PropertyMap<P> map, P...keys) throws IOException
+	@SafeVarargs
+	public final <P extends Enum<P>>void writeStr(PropertyMap<P> map, P...keys) throws IOException
 		{
 		for (P key : keys)
 			writeStr((String) map.get(key));
 		}
 
-	public <P extends Enum<P>>void writeBool(PropertyMap<P> map, P...keys) throws IOException
+	@SafeVarargs
+	public final <P extends Enum<P>>void writeBool(PropertyMap<P> map, P...keys) throws IOException
 		{
 		for (P key : keys)
 			writeBool((Boolean) map.get(key));
 		}
 
-	public <P extends Enum<P>>void writeD(PropertyMap<P> map, P...keys) throws IOException
+	@SafeVarargs
+	public final <P extends Enum<P>>void writeD(PropertyMap<P> map, P...keys) throws IOException
 		{
 		for (P key : keys)
 			writeD((Double) map.get(key));


### PR DESCRIPTION
This pull request uses the `@SafeVarargs` annotation to suppress some warnings in the GMK encoder and decoder.

>Type safety: Potential heap pollution via varargs parameter keys

https://github.com/IsmAvatar/LateralGM/blob/6283ce38b1b1c067455bc0a5b1e227f87522526f/org/lateralgm/file/GmStreamDecoder.java#L154

The annotation required that I also make the methods final.
https://docs.oracle.com/javase/7/docs/api/java/lang/SafeVarargs.html

I will need @JoshDreamland or somebody who can make sense of Java to review this for me. I want to make sure that my use of the annotation is a safe assumption and that the methods are in fact not doing any potentially unsafe operations.

I must also point out that `@SafeVarargs` is a Java 7 feature and would be a compile error in JDK 6. However, Java 6 and 7 are supposed to be binary compatible other than a few exceptions. I am not sure if that means that merging this only stops us from compiling with JDK 6 or if it also means you can't run LGM in Java 6 if this is compiled from JDK 7.