### PR TITLE
Remove Unnecessary Localization Tags

### DIFF
--- a/org/lateralgm/components/ColorSelect.java
+++ b/org/lateralgm/components/ColorSelect.java
@@ -106,7 +106,7 @@ public class ColorSelect extends JPanel implements ItemSelectable,PropertyEditor
 
 		MaskFormatter formatter = new MaskFormatter();
 		formatter.setPlaceholder("FFFFFFFF"); //$NON-NLS-1$
-		formatter.setPlaceholderCharacter('F'); //$NON-NLS-1$
+		formatter.setPlaceholderCharacter('F');
 
 		try
 		{

--- a/org/lateralgm/components/impl/ResNode.java
+++ b/org/lateralgm/components/impl/ResNode.java
@@ -260,7 +260,7 @@ public class ResNode extends DefaultNode implements Transferable,UpdateListener
 		if (!isInstantiable())
 			{
 			JMenuItem editItem = makeMenuItem("Listener.TREE_PROPERTIES",al,true);
-			popup.add(editItem); //$NON-NLS-1$
+			popup.add(editItem);
 			editItem.setFocusable(true);
 			editItem.setAccelerator(KeyStroke.getKeyStroke(Messages.getKeyboardString("Listener.TREE_PROPERTIES")));
 			popup.show(e.getComponent(),e.getX(),e.getY());
@@ -270,11 +270,11 @@ public class ResNode extends DefaultNode implements Transferable,UpdateListener
 			{
 			JMenuItem insertItem = makeMenuItem("Listener.TREE_INSERT_RESOURCE",al,true);
 			insertItem.setFocusable(true);
-			popup.add(insertItem); //$NON-NLS-1$
+			popup.add(insertItem);
 			insertItem.setAccelerator(KeyStroke.getKeyStroke(Messages.getKeyboardString("Listener.TREE_INSERT_RESOURCE")));
 			JMenuItem duplicateItem = makeMenuItem("Listener.TREE_DUPLICATE_RESOURCE",al,true);
 			duplicateItem.setFocusable(true);
-			popup.add(duplicateItem); //$NON-NLS-1$
+			popup.add(duplicateItem);
 			duplicateItem.setAccelerator(KeyStroke.getKeyStroke(Messages.getKeyboardString("Listener.TREE_DUPLICATE_RESOURCE")));
 			popup.add(makeMenuItem("Listener.TREE_INSERT_GROUP",al,true)); //$NON-NLS-1$
 			}
@@ -290,19 +290,19 @@ public class ResNode extends DefaultNode implements Transferable,UpdateListener
 			JMenuItem deleteItem = makeMenuItem("Listener.TREE_DELETE",al,true);
 			deleteItem.setFocusable(true);
 			deleteItem.requestFocus();
-			popup.add(deleteItem); //$NON-NLS-1$
+			popup.add(deleteItem);
 			// KeyStroke.getKeyStroke("BACK_SPACE"); for delete key on mac
 			deleteItem.setAccelerator(KeyStroke.getKeyStroke(Messages.getKeyboardString("Listener.TREE_DELETE")));
 			JMenuItem renameItem = makeMenuItem("Listener.TREE_RENAME",al,true);
 			renameItem.setFocusable(true);
-			popup.add(renameItem); //$NON-NLS-1$
+			popup.add(renameItem);
 			renameItem.setAccelerator(KeyStroke.getKeyStroke(Messages.getKeyboardString("Listener.TREE_RENAME")));
 			}
 		if (status == ResNode.STATUS_SECONDARY)
 			{
 			JMenuItem editItem = makeMenuItem("Listener.TREE_PROPERTIES",al,true);
 			editItem.setFocusable(true);
-			popup.add(editItem); //$NON-NLS-1$
+			popup.add(editItem);
 			editItem.setAccelerator(KeyStroke.getKeyStroke(Messages.getKeyboardString("Listener.TREE_PROPERTIES")));
 			}
 		popup.show(e.getComponent(),e.getX(),e.getY());

--- a/org/lateralgm/file/GMXFileReader.java
+++ b/org/lateralgm/file/GMXFileReader.java
@@ -722,7 +722,7 @@ public final class GMXFileReader
 					fname = f.getDirectory() + "/sound/audio/" + fname;
 					try
 						{
-						snd.data = Util.readFully(fname); //$NON-NLS-1$
+						snd.data = Util.readFully(fname);
 						}
 					catch (IOException e)
 						{

--- a/org/lateralgm/file/GMXFileWriter.java
+++ b/org/lateralgm/file/GMXFileWriter.java
@@ -286,7 +286,7 @@ public final class GMXFileWriter
 		for (GameSettings gs : LGM.currentFile.gameSettings) {
 			Element setNode = mdom.createElement("Config"); //$NON-NLS-1$
 			String configDir = "Configs\\" + gs.getName();
-			setNode.setTextContent(configDir); //$NON-NLS-1$
+			setNode.setTextContent(configDir);
 			conNode.appendChild(setNode);
 
 			Document dom = documentBuilder.newDocument();

--- a/org/lateralgm/subframes/ConstantsFrame.java
+++ b/org/lateralgm/subframes/ConstantsFrame.java
@@ -132,7 +132,7 @@ public class ConstantsFrame extends ResourceFrame<Constants,PConstants>
 
 	public ConstantsFrame(Constants res, ResNode node)
 		{
-		super(res,node); //$NON-NLS-1$
+		super(res,node);
 		setDefaultCloseOperation(HIDE_ON_CLOSE);
 		setTitle(Messages.getString("ConstantsFrame.TITLE"));
 

--- a/org/lateralgm/subframes/ExtensionFrame.java
+++ b/org/lateralgm/subframes/ExtensionFrame.java
@@ -61,7 +61,7 @@ public class ExtensionFrame extends InstantiableResourceFrame<Extension,Extensio
 	public ExtensionFrame(Extension res, ResNode node)
 		{
 		//,Messages.getString("ExtensionFrame.TITLE"),true
-		super(res,node); //$NON-NLS-1$
+		super(res,node);
 		setDefaultCloseOperation(HIDE_ON_CLOSE);
 		setSize(600,400);
 		JTabbedPane tabPane = new JTabbedPane();
@@ -80,7 +80,7 @@ public class ExtensionFrame extends InstantiableResourceFrame<Extension,Extensio
 			ResNode n = (ResNode) LGM.root.getChildAt(m);
 			if (n.kind == ExtensionPackages.class) return n.getUserObject();
 			}
-		return 0;//Messages.getString("LGM.EXT"); //$NON-NLS-1$
+		return 0;//Messages.getString("LGM.EXT");
 		}
 
 	public void actionPerformed(ActionEvent ev)

--- a/org/lateralgm/subframes/ExtensionPackagesFrame.java
+++ b/org/lateralgm/subframes/ExtensionPackagesFrame.java
@@ -116,18 +116,18 @@ public class ExtensionPackagesFrame extends
 			ResNode n = (ResNode) LGM.root.getChildAt(m);
 			if (n.kind == ExtensionPackages.class) return n.getUserObject();
 			}
-		return 0;//Messages.getString("LGM.EXT"); //$NON-NLS-1$
+		return 0;//Messages.getString("LGM.EXT");
 		}
 
 	public void actionPerformed(ActionEvent ev)
 		{
 		super.actionPerformed(ev);
-		if (ev.getSource() == closeButton) //$NON-NLS-1$
+		if (ev.getSource() == closeButton)
 			{
 			this.setVisible(false);
 			return;
 			}
-		if (ev.getSource() == installButton) //$NON-NLS-1$
+		if (ev.getSource() == installButton)
 			{
 			return;
 			}

--- a/org/lateralgm/subframes/IncludeFrame.java
+++ b/org/lateralgm/subframes/IncludeFrame.java
@@ -58,7 +58,7 @@ public class IncludeFrame extends InstantiableResourceFrame<Include,Include.PInc
 	public IncludeFrame(Include r, ResNode node)
 		{
 		//,Messages.getString("IncludeFrame.TITLE"),true
-		super(r,node); //$NON-NLS-1$
+		super(r,node);
 		setDefaultCloseOperation(HIDE_ON_CLOSE);
 		setSize(300,350);
 		this.setLayout(new BorderLayout());
@@ -100,14 +100,14 @@ public class IncludeFrame extends InstantiableResourceFrame<Include,Include.PInc
 			ResNode n = (ResNode) LGM.root.getChildAt(m);
 			if (n.kind == ExtensionPackages.class) return n.getUserObject();
 			}
-		return 0;//Messages.getString("LGM.EXT"); //$NON-NLS-1$
+		return 0;//Messages.getString("LGM.EXT");
 		}
 
 	public void actionPerformed(ActionEvent ev)
 		{
 		super.actionPerformed(ev);
 		Object source = ev.getSource();
-		if (source == importBut) //$NON-NLS-1$
+		if (source == importBut)
 			{
 			if (fc.showOpenDialog(LGM.frame) != JFileChooser.APPROVE_OPTION) return;
 			File f = fc.getSelectedFile();
@@ -116,7 +116,7 @@ public class IncludeFrame extends InstantiableResourceFrame<Include,Include.PInc
 			res.setName(f.getName());
 			return;
 			}
-		if (source == exportBut) //$NON-NLS-1$
+		if (source == exportBut)
 			{
 			return;
 			}

--- a/org/lateralgm/subframes/SoundFrame.java
+++ b/org/lateralgm/subframes/SoundFrame.java
@@ -263,7 +263,7 @@ public class SoundFrame extends InstantiableResourceFrame<Sound,PSound>
 
 		tool.addSeparator();
 
-		edit = new JButton(EDIT_ICON); //$NON-NLS-1$
+		edit = new JButton(EDIT_ICON);
 		edit.setToolTipText(Messages.getString("SoundFrame.EDIT"));
 		edit.addActionListener(this);
 		tool.add(edit);


### PR DESCRIPTION
We've apparently taken on a lot of warnings about having the `$NON-NLS$` tags in places we no longer needed them. This is likely the result of us refactoring various editors and using more helpers.

> Unnecessary $NON-NLS$ tag

Interestingly, I learned that character literals like `'F'` do not generate any warnings without the tags, but do with the tags. This means they are not considered localization worthy, which I kind of chuckled at, because they very well are.

Other than that, Eclipse can't seem to figure out when the tags are attached to commented code. I had to remove a few more than I wanted to because of that. Regardless, this pull request removes all of the "unnecessary" tags.