### PR TITLE
Fix Default Sprite Transparency

### DIFF
--- a/org/lateralgm/file/GMXFileReader.java
+++ b/org/lateralgm/file/GMXFileReader.java
@@ -569,6 +569,7 @@ public final class GMXFileReader
 				Document sprdoc = GMXFileReader.parseDocumentChecked(f, path + ".sprite.gmx"); //$NON-NLS-1$
 				if (sprdoc == null) continue;
 
+				spr.put(PSprite.TRANSPARENT,false);
 				spr.put(PSprite.ORIGIN_X,
 						Integer.parseInt(sprdoc.getElementsByTagName("xorig").item(0).getTextContent())); //$NON-NLS-1$
 				spr.put(PSprite.ORIGIN_Y,

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -134,7 +134,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.45"; //$NON-NLS-1$
+	public static final String version = "1.8.46"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/resources/Sprite.java
+++ b/org/lateralgm/resources/Sprite.java
@@ -468,7 +468,7 @@ public class Sprite extends InstantiableResource<Sprite,Sprite.PSprite> implemen
 				&& LGM.currentFile.format.getOwner() == ProjectFile.FormatFlavor.GM_OWNER)
 				defTransparency = (LGM.currentFile.format.getVersion() <= 600);
 		else
-				defTransparency = false; // GM7, GM8, GMX, YYP
+				defTransparency = false; // GM7, GM8, GMX, YYP or New Project
 		DEFS.put(PSprite.TRANSPARENT,defTransparency);
 		return new PropertyMap<PSprite>(PSprite.class,this,DEFS);
 		}

--- a/org/lateralgm/resources/Sprite.java
+++ b/org/lateralgm/resources/Sprite.java
@@ -461,9 +461,15 @@ public class Sprite extends InstantiableResource<Sprite,Sprite.PSprite> implemen
 	@Override
 	protected PropertyMap<PSprite> makePropertyMap()
 		{
+		// NOTE: this only effects new sprites created after project read
+		// LGM.currentFile is not replaced until after a project is read
+		boolean defTransparency = (boolean)DEFS.get(PSprite.TRANSPARENT);
 		if (LGM.currentFile.format != null
 				&& LGM.currentFile.format.getOwner() == ProjectFile.FormatFlavor.GM_OWNER)
-			DEFS.put(PSprite.TRANSPARENT,LGM.currentFile.format.getVersion() <= 600);
+				defTransparency = (LGM.currentFile.format.getVersion() <= 600);
+		else
+				defTransparency = false; // GM7, GM8, GMX, YYP
+		DEFS.put(PSprite.TRANSPARENT,defTransparency);
 		return new PropertyMap<PSprite>(PSprite.class,this,DEFS);
 		}
 


### PR DESCRIPTION
This pull request tweaks the default sprite transparency to resolve #389 for GMX/GM8 users. It seems this bug is not a regression and has always existed in the GMX reader since I introduced it. It's because IsmAvatar in 3f24292db3597f4849a32732790415de04335d5b made the Sprite resource change the transparency in its default property map depending on LGM's current file version.

Here's where the flaw happens. When a GM6 or older file is loaded, the default property map is changed to have transparency true by default. The GMX reader never bothered to set the transparency, because it is initially false prior to loading a GM6 file. And thus when we load a GMX after a GM6, we have all of our sprites with the transparency property enabled.

So the solution was to simply change the property map construction helper to change the default transparency back to false for newer project files. While this did fix new sprites created after a project is loaded, this did not actually fix the reported SONIGMA issue. We construct the new project file first, read it, all before we assign LGM's current file to it and only if no exception interrupts that. That means that to the sprites being constructed by the GMX reader, the current file is still the GM6 file in their property map construction helper. So, I had to also explicitly set the transparent property to false for all of the sprites added by the GMX reader.

It is because of the trouble I faced fixing this that I disagree with what IsmAvatar did in 3f24292db3597f4849a32732790415de04335d5b. I don't feel there's a need to change that default every time a new sprite is constructed. What would be useful is if a sprite knew the project format it was being added to (since `LGM.currentFile` is not current during a project load). A totally alternative to IsmAvatar way of handling this would be to remove the default changing from the property map construction helper and instead have the project readers change the default property maps where they need to. That would require exposing the default property maps publicly though, but they could be made final.

However, this does fix #389 for now. I am able to load the Game of Life GM6 example, build it, load HitCoder's SONIGMA GMX, build it, and both run fine. I am also able to create new sprites with the transparency option correctly enabled or disabled in both cases regardless of the order I load either project.