### PR TITLE
Resource Name Completions

### DIFF
--- a/org/lateralgm/components/CodeTextArea.java
+++ b/org/lateralgm/components/CodeTextArea.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -97,7 +98,7 @@ public class CodeTextArea extends JoshTextPanel implements UpdateListener,Action
 
 	protected static Timer timer;
 	protected Integer lastUpdateTaskID = 0;
-	private Set<SortedSet<String>> resourceKeywords = new HashSet<SortedSet<String>>();
+	private static Set<SortedSet<String>> resourceKeywords = new HashSet<SortedSet<String>>();
 	protected Completion[] completions;
 	protected DefaultTokenMarker tokenMarker;
 
@@ -325,13 +326,25 @@ public class CodeTextArea extends JoshTextPanel implements UpdateListener,Action
 		{
 		resNames.words.clear();
 		scrNames.words.clear();
+		resourceKeywords.clear();
 		for (Entry<Class<?>,ResourceHolder<?>> e : LGM.currentFile.resMap.entrySet())
 			{
 			if (!(e.getValue() instanceof ResourceList<?>)) continue;
 			ResourceList<?> rl = (ResourceList<?>) e.getValue();
 			KeywordSet ks = e.getKey() == Script.class ? scrNames : resNames;
+
+			if (rl.isEmpty()) continue;
+
+			// create a set used for the completion window
+			SortedSet<String> resSet = new TreeSet<String>();
+
 			for (Resource<?,?> r : rl)
+				{
 				ks.words.add(r.getName());
+				resSet.add(r.getName());
+				}
+
+			resourceKeywords.add(resSet);
 			}
 		}
 
@@ -504,7 +517,7 @@ public class CodeTextArea extends JoshTextPanel implements UpdateListener,Action
 				String lt = getLineText(row);
 				int x1 = pos - find(lt.substring(0,pos),W_BEFORE).length();
 				int x2 = pos + find(lt.substring(pos),W_AFTER).length();
-				if (completions == null) updateCompletions(tokenMarker);
+				updateCompletions(tokenMarker);
 				new CompletionMenu(LGM.frame,text,row,x1,x2,pos,completions);
 				}
 		};

--- a/org/lateralgm/components/CodeTextArea.java
+++ b/org/lateralgm/components/CodeTextArea.java
@@ -331,9 +331,9 @@ public class CodeTextArea extends JoshTextPanel implements UpdateListener,Action
 			{
 			if (!(e.getValue() instanceof ResourceList<?>)) continue;
 			ResourceList<?> rl = (ResourceList<?>) e.getValue();
-			KeywordSet ks = e.getKey() == Script.class ? scrNames : resNames;
-
 			if (rl.isEmpty()) continue;
+			
+			KeywordSet ks = e.getKey() == Script.class ? scrNames : resNames;
 
 			// create a set used for the completion window
 			SortedSet<String> resSet = new TreeSet<String>();

--- a/org/lateralgm/components/CodeTextArea.java
+++ b/org/lateralgm/components/CodeTextArea.java
@@ -99,7 +99,7 @@ public class CodeTextArea extends JoshTextPanel implements UpdateListener,Action
 	protected static Timer timer;
 	protected Integer lastUpdateTaskID = 0;
 	private static Set<SortedSet<String>> resourceKeywords = new HashSet<SortedSet<String>>();
-	protected Completion[] completions;
+	protected static Completion[] completions;
 	protected DefaultTokenMarker tokenMarker;
 
 	private static final Color PURPLE = new Color(138,54,186);
@@ -346,6 +346,7 @@ public class CodeTextArea extends JoshTextPanel implements UpdateListener,Action
 
 			resourceKeywords.add(resSet);
 			}
+		if (!resourceKeywords.isEmpty()) completions = null;
 		}
 
 	protected void updateCompletions(DefaultTokenMarker tokenMarker2)
@@ -517,7 +518,7 @@ public class CodeTextArea extends JoshTextPanel implements UpdateListener,Action
 				String lt = getLineText(row);
 				int x1 = pos - find(lt.substring(0,pos),W_BEFORE).length();
 				int x2 = pos + find(lt.substring(pos),W_AFTER).length();
-				updateCompletions(tokenMarker);
+				if (completions == null) updateCompletions(tokenMarker);
 				new CompletionMenu(LGM.frame,text,row,x1,x2,pos,completions);
 				}
 		};

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -134,7 +134,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.46"; //$NON-NLS-1$
+	public static final String version = "1.8.47"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.


### PR DESCRIPTION
This pull request fixes #371 which was a regression caused by me merging the JoshEdit branch when I first joined.

Basically, `CodeTextArea` did not fully update the logic from `GMLTextArea` to keep the resource keywords used for the completion menu. We can see very clearly in the old `GMLTextArea.java` class that the method `updateResourceKeywords` does in fact mutate and update `resourceKeywords`.
https://github.com/IsmAvatar/LateralGM/blob/6f577619afb4a5c85dc23d04a0c829b4284ce9c7/org/lateralgm/components/GMLTextArea.java#L216
It also marks the completions dirty so that they are updated the next time the completion menu is requested.
https://github.com/IsmAvatar/LateralGM/blob/6f577619afb4a5c85dc23d04a0c829b4284ce9c7/org/lateralgm/components/GMLTextArea.java#L218

The main big difference here between the JEdit and JoshEdit versions of this class seem to be that the keywords are kept statically. You'll see that to make these changes I had to make `completions` static. That's fine for now since LGM still only loads a single project at a time, and does not have multi-project support yet. Even if it did, we wouldn't want an instance of these completions and keyword lists per code text area, we'd want one per project to save memory.

Another difference is that this version here is maintaining multiple copies of the resource keywords. We can see that `resourceKeywords` is a set of sorted sets because it's used for the completion menu and wants the resource keywords in sorted order, unlike JoshEdit does internally. This could maybe be addressed later by having JoshEdit maintain its keywords in sorted order, or doing the sorting when updating the completions and eliminating `resourceKeywords` altogether.

That said, it's back to working again and I can complete resource names in the code editors again.
![Fixed JoshEdit/CodeTextArea Resource Completions](https://user-images.githubusercontent.com/3212801/56399461-17d5ba80-621c-11e9-98e3-18d228a37b8e.png)
