### PR TITLE
Non Static Action List Frames

### DIFF
--- a/org/lateralgm/components/ActionList.java
+++ b/org/lateralgm/components/ActionList.java
@@ -88,7 +88,8 @@ public class ActionList extends JList<Action> implements ActionListener,Clipboar
 	{
 	private static final long serialVersionUID = 1L;
 	private static final ActionListKeyListener ALKL = new ActionListKeyListener();
-	private final Map<Action,WeakReference<ActionFrame>> frames = new WeakHashMap<Action,WeakReference<ActionFrame>>();
+	private final Map<Action,WeakReference<ActionFrame>> frames =
+			new WeakHashMap<Action,WeakReference<ActionFrame>>();
 	protected ActionContainer actionContainer;
 	public ActionListModel model;
 	private final ActionRenderer renderer = new ActionRenderer(this);

--- a/org/lateralgm/components/ActionList.java
+++ b/org/lateralgm/components/ActionList.java
@@ -88,7 +88,7 @@ public class ActionList extends JList<Action> implements ActionListener,Clipboar
 	{
 	private static final long serialVersionUID = 1L;
 	private static final ActionListKeyListener ALKL = new ActionListKeyListener();
-	private final Map<Action,WeakReference<ActionFrame>> FRAMES = new WeakHashMap<Action,WeakReference<ActionFrame>>();
+	private final Map<Action,WeakReference<ActionFrame>> frames = new WeakHashMap<Action,WeakReference<ActionFrame>>();
 	protected ActionContainer actionContainer;
 	public ActionListModel model;
 	private final ActionRenderer renderer = new ActionRenderer(this);
@@ -205,7 +205,7 @@ public class ActionList extends JList<Action> implements ActionListener,Clipboar
 	public void save()
 		{
 		if (actionContainer == null) return;
-		for (WeakReference<ActionFrame> a : FRAMES.values())
+		for (WeakReference<ActionFrame> a : frames.values())
 			{
 			if (a != null)
 				{
@@ -228,14 +228,14 @@ public class ActionList extends JList<Action> implements ActionListener,Clipboar
 		LibAction la = a.getLibAction();
 		if ((la.libArguments == null || la.libArguments.length == 0) && !la.canApplyTo
 				&& !la.allowRelative && !la.question) return null;
-		WeakReference<ActionFrame> fr = FRAMES.get(a);
+		WeakReference<ActionFrame> fr = frames.get(a);
 		ActionFrame af = fr == null ? null : fr.get();
 		if (af == null || af.isClosed())
 			{
 			af = new ActionFrame(a);
 			LGM.mdi.add(af);
 			if (parent != null) LGM.mdi.addZChild(parent,af);
-			FRAMES.put(a,new WeakReference<ActionFrame>(af));
+			frames.put(a,new WeakReference<ActionFrame>(af));
 			}
 		af.setVisible(true);
 		//FIXME: Find out why parent is sent to back. This is a workaround.
@@ -256,7 +256,7 @@ public class ActionList extends JList<Action> implements ActionListener,Clipboar
 
 	public void closeFrames()
 		{
-		for (Map.Entry<Action,WeakReference<ActionFrame>> entry : FRAMES.entrySet())
+		for (Map.Entry<Action,WeakReference<ActionFrame>> entry : frames.entrySet())
 			{
 				ActionFrame frame = entry.getValue().get();
 

--- a/org/lateralgm/components/ActionListEditor.java
+++ b/org/lateralgm/components/ActionListEditor.java
@@ -46,8 +46,11 @@ public class ActionListEditor extends JPanel
 	{
 	private static final long serialVersionUID = 1L;
 
+	private final ActionList list;
+
 	public ActionListEditor(ActionList list)
 		{
+		this.list = list;
 		GroupLayout layout = new GroupLayout(this);
 		setLayout(layout);
 
@@ -166,7 +169,7 @@ public class ActionListEditor extends JPanel
 				Action act = new Action(libAction);
 				((ActionListModel) list.getModel()).add(act);
 				list.setSelectedValue(act,true);
-				ActionList.openActionFrame(list.parent.get(),act);
+				list.openActionFrame(list.parent.get(),act);
 				}
 			super.processMouseEvent(e);
 			}
@@ -179,7 +182,7 @@ public class ActionListEditor extends JPanel
 
 	public void dispose()
 		{
-		ActionList.closeFrames();
+		list.dispose();
 		}
 
 	}

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -134,7 +134,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.47"; //$NON-NLS-1$
+	public static final String version = "1.8.48"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/main/Search.java
+++ b/org/lateralgm/main/Search.java
@@ -49,7 +49,6 @@ import javax.swing.tree.TreeNode;
 import javax.swing.tree.TreePath;
 import javax.swing.tree.TreeSelectionModel;
 
-import org.lateralgm.components.ActionList;
 import org.lateralgm.components.CodeTextArea;
 import org.lateralgm.components.CustomJToolBar;
 import org.lateralgm.components.impl.ResNode;
@@ -1026,7 +1025,7 @@ public class Search
 											org.lateralgm.resources.sub.Action act = objframe.actions.getSelectedValue();
 											if (act != null)
 												{
-												ActionFrame af = (ActionFrame) ActionList.openActionFrame(objframe,act);
+												ActionFrame af = (ActionFrame) objframe.actions.openActionFrame(objframe,act);
 												parentdata = new Object[] { af };
 												}
 											}
@@ -1058,7 +1057,7 @@ public class Search
 											org.lateralgm.resources.sub.Action act = tmlframe.actions.getSelectedValue();
 											if (act != null)
 												{
-												ActionFrame af = (ActionFrame) ActionList.openActionFrame(tmlframe,act);
+												ActionFrame af = (ActionFrame) tmlframe.actions.openActionFrame(tmlframe,act);
 												parentdata = new Object[] { af };
 												}
 											}

--- a/org/lateralgm/subframes/GmObjectFrame.java
+++ b/org/lateralgm/subframes/GmObjectFrame.java
@@ -969,7 +969,7 @@ public class GmObjectFrame extends InstantiableResourceFrame<GmObject,PGmObject>
 			actions.setSelectedValue(a,true);
 			}
 
-		MDIFrame af = ActionList.openActionFrame(actions.parent.get(),a);
+		MDIFrame af = actions.openActionFrame(actions.parent.get(),a);
 		EventInstanceNode evnode = (EventInstanceNode) events.getLastSelectedPathComponent();
 		af.setTitle(this.name.getText() + " : " + evnode.toString());
 		af.setFrameIcon(LGM.getIconForKey("EventNode.EVENT" + evnode.getUserObject().mainId));

--- a/org/lateralgm/subframes/TimelineFrame.java
+++ b/org/lateralgm/subframes/TimelineFrame.java
@@ -297,7 +297,10 @@ public class TimelineFrame extends InstantiableResourceFrame<Timeline,PTimeline>
 			{
 			infoFrame.dispose();
 			}
-		((ActionListEditor) editor).dispose();
+		if (editor != null)
+			{
+			((ActionListEditor) editor).dispose();
+			}
 		}
 
 	public void actionPerformed(ActionEvent e)
@@ -486,7 +489,7 @@ public class TimelineFrame extends InstantiableResourceFrame<Timeline,PTimeline>
 			actions.setSelectedValue(a,true);
 			}
 
-		MDIFrame af = ActionList.openActionFrame(actions.parent.get(),a);
+		MDIFrame af = actions.openActionFrame(actions.parent.get(),a);
 		Object momentitem = moments.getSelectedValue();
 		af.setTitle(this.name.getText() + " : " + momentitem.toString());
 		af.setFrameIcon(LGM.getIconForKey("MomentNode.STEP"));


### PR DESCRIPTION
This pull request attempts to address #281 by changing the `FRAMES` list of `ActionList` to not static. This required changing `openActionFrame` and `closeFrames` to also not be static. The reason this works is because most of the code was already assuming that the list wasn't static.

Since each object and timeline frame creates its own `ActionList`, which is a `JList<Action>`, I think it makes more sense for each list to have a list of only its frames that it opened. I don't think it makes sense at this time for the static `ActionList` instance to have a list of all action frames opened across all of the lists.

For clarification, the way I originally added closing of the action frames was by overriding the dispose method (which is a super method from `JInternalFrame`) of the object and timeline frames. From there, I added calls to `ActionListEditor.dispose()` (which I also added) which itself calls `ActionList.dispose()` (also me). Finally, the `ActionList.dispose()` calls `ActionList.closeFrames()` which loops the frames list disposing each action frame.

This should in fact be slightly more efficient as saving an action list now will save only the action frames of that list. This should also be useful to our users who may have been confused by LGM's past behavior to either (1) not close the action frames when closing an object/timeline or (2) close all frames when closing an object/timeline.

PS: I once created this same change for the stable branch in #302.