### PR TITLE
Fix Delete Icons

### DIFF
--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -134,7 +134,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.48"; //$NON-NLS-1$
+	public static final String version = "1.8.49"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/main/icons.properties
+++ b/org/lateralgm/main/icons.properties
@@ -179,7 +179,7 @@ SpriteFrame.NEXT=actions/next.png
 SpriteFrame.PLAY=actions/sound-play.png
 SpriteFrame.STOP=actions/sound-stop.png
 SpriteFrame.ADD=actions/new.png
-SpriteFrame.REMOVE=actions/cancel.png
+SpriteFrame.REMOVE=actions/delete.png
 
 ScriptFrame.EDIT=actions/edit.png
 
@@ -220,7 +220,7 @@ RoomFrame.ZOOM_IN=actions/zoom-in.png
 RoomFrame.ZOOM_OUT=actions/zoom-out.png
 RoomFrame.UNDO=actions/undo.png
 RoomFrame.REDO=actions/redo.png
-RoomFrame.DELETE=actions/cancel.png
+RoomFrame.DELETE=actions/delete.png
 RoomFrame.SHIFT=actions/shift.png
 RoomFrame.CUT=actions/cut.png
 RoomFrame.COPY=actions/copy.png


### PR DESCRIPTION
GM is very consistent about this and so were we until we made two mistakes. The `+` icons are used for adding resources and the `-` icons are used for removing/deleting stuff. The `X` icon is only supposed to be used for canceling operations or exit.