### PR TITLE
Fix File Reader Leaks

### DIFF
--- a/org/lateralgm/file/GMXFileReader.java
+++ b/org/lateralgm/file/GMXFileReader.java
@@ -127,7 +127,7 @@ public final class GMXFileReader
 		{
 		}
 
-	static Queue<PostponedRef> postpone = new LinkedList<PostponedRef>();
+	private static Queue<PostponedRef> postpone = new LinkedList<PostponedRef>();
 
 	static interface PostponedRef
 		{
@@ -300,6 +300,7 @@ public final class GMXFileReader
 			// All resources read, now we can invoke our postponed references.
 			for (PostponedRef i : postpone)
 				i.invoke();
+			postpone.clear();
 
 			LGM.setProgress(160,Messages.getString("ProgressDialog.FINISHED")); //$NON-NLS-1$
 			System.out.println(Messages.format("ProjectFileReader.LOADTIME",System.currentTimeMillis() //$NON-NLS-1$

--- a/org/lateralgm/file/GmFileReader.java
+++ b/org/lateralgm/file/GmFileReader.java
@@ -91,7 +91,7 @@ public final class GmFileReader
 		{
 		}
 
-	static Queue<PostponedRef> postpone = new LinkedList<PostponedRef>();
+	private static Queue<PostponedRef> postpone = new LinkedList<PostponedRef>();
 
 	static interface PostponedRef
 		{
@@ -292,6 +292,7 @@ public final class GmFileReader
 				LGM.setProgress(160 + percent / postpone.size(),
 						Messages.getString("ProgressDialog.POSTPONED")); //$NON-NLS-1$
 				}
+			postpone.clear();
 
 			LGM.setProgress(170,Messages.getString("ProgressDialog.LIBRARYCREATION")); //$NON-NLS-1$
 			//Library Creation Code

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -134,7 +134,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.49"; //$NON-NLS-1$
+	public static final String version = "1.8.50"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.


### PR DESCRIPTION
This pull request fixes the same leak in the GMK and GMX reader. It is not a regression and has existed in the GMK reader since lgm16b4. Basically, the postponed references queue is static state and it only grows as we load more projects. Since we never clear it, project loading becomes progressively slower. While I was in here, I decided to also make the postponed queue private-by-default to prevent data type dependence.