### PR TITLE
Move WeakArrayList to Util Package

### DIFF
--- a/org/lateralgm/components/mdi/MDIPane.java
+++ b/org/lateralgm/components/mdi/MDIPane.java
@@ -21,8 +21,8 @@ import javax.swing.JDesktopPane;
 import javax.swing.JInternalFrame;
 import javax.swing.JScrollPane;
 
-import org.lateralgm.main.WeakArrayList;
 import org.lateralgm.subframes.InstantiableResourceFrame;
+import org.lateralgm.util.WeakArrayList;
 
 public class MDIPane extends JDesktopPane
 	{

--- a/org/lateralgm/util/WeakArrayList.java
+++ b/org/lateralgm/util/WeakArrayList.java
@@ -1,4 +1,4 @@
-package org.lateralgm.main;
+package org.lateralgm.util;
 
 import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;


### PR DESCRIPTION
It doesn't really belong in main because it's only used by the MDIPane class from the components package. Also, consider that most of our other custom collections are already in the util package.