### PR TITLE
Cleanup GMX Writer Document Transformation

### DIFF
--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -134,7 +134,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.50"; //$NON-NLS-1$
+	public static final String version = "1.8.51"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.


### PR DESCRIPTION
I am pulling this out of an earlier pull request that I closed and didn't merge. I actually learned some new things along the way, such as the fact that I can simply reuse the document transformer once it's created. This allows me to consistently enforce that all of the documents are UTF-8 encoded. I also removed the class static document builder factory since it's only used to create the reusable document builder.

I made a helper method to transform the documents of the GMX resources so I could deal with the exceptions in a single place. This prevents transformation failure of one resource to not preclude successful transformation of another. This also allows me to add the file path to the stack trace for debugging purposes.

Another change I made was to rename the configuration write method's `mdom` and `dom` variables to `dom` and `doc` respectively. That makes it consistent with the other write methods where I use `dom` to refer to the main manifest of the GMX (the tree), and `doc` to refer to the resource's metadata document we are currently building.