### PR TITLE
Cleanup GMX Group Writing

### DIFF
--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -134,7 +134,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.51"; //$NON-NLS-1$
+	public static final String version = "1.8.52"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.


### PR DESCRIPTION
I am pulling this out of an earlier pull request I had closed. I prefer making these changes incrementally to the GMX reader and writer. This pull request refactors all of the duplicate group writing methods and extracts a common group writing method where the kind is passed as a parameter. I then refactored all of the recursive methods to use the names of the old group writing methods. I had to tweak each of the recursive methods a bit so they create group/primary elements up front.

Obviously this is quite a few net deletions which should make the GMX writer easier to maintain. The next refactor can actually deduplicate the tree walking altogether and extract each individual resource write method to a helper.

Finally, I tested converting some GMKs (Game of Life and FPS by Mark Overmars) to GMX, reloading, then building them in ENIGMA and didn't see any issues.