### PR TITLE
Font Editor Improvements

### DIFF
--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -134,7 +134,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.53"; //$NON-NLS-1$
+	public static final String version = "1.8.54"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/main/Util.java
+++ b/org/lateralgm/main/Util.java
@@ -60,6 +60,7 @@ import javax.imageio.stream.ImageInputStream;
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
 import javax.swing.ImageIcon;
+import javax.swing.JComponent;
 import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
@@ -97,6 +98,18 @@ public final class Util
 	public static DataFlavor createJVMLocalDataFlavor(String className) throws ClassNotFoundException
 		{
 		return new DataFlavor(DataFlavor.javaJVMLocalObjectMimeType + ";class=" + className); //$NON-NLS-1$
+		}
+
+	public static void setComponentTreeEnabled(JComponent comp, boolean enabled)
+		{
+		comp.setIgnoreRepaint(true);
+		comp.setEnabled(enabled);
+		for (Component child: comp.getComponents())
+			{
+			child.setEnabled(enabled);
+			}
+		comp.setIgnoreRepaint(false);
+		comp.repaint();
 		}
 
 	public static JPanel makeLabelPane(String name)

--- a/org/lateralgm/main/icons.properties
+++ b/org/lateralgm/main/icons.properties
@@ -212,6 +212,8 @@ ResourceInfoFrame.FILESAVE=actions/save.png
 ResourceInfoFrame.COPY=actions/copy.png
 ResourceInfoFrame.CONFIRM=actions/accept.png
 
+FontFrame.ADD_RANGE=actions/add.png
+FontFrame.REMOVE_RANGE=actions/delete.png
 FontFrame.CUT=actions/cut.png
 FontFrame.COPY=actions/copy.png
 FontFrame.PASTE=actions/paste.png

--- a/org/lateralgm/messages/Messages.java
+++ b/org/lateralgm/messages/Messages.java
@@ -24,6 +24,8 @@ import java.text.MessageFormat;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 
+import javax.swing.KeyStroke;
+
 public final class Messages
 	{
 	private static final String LANGUAGE_BUNDLE_NAME = "org.lateralgm.messages.messages"; //$NON-NLS-1$
@@ -71,6 +73,12 @@ public final class Messages
 			{
 			return '!' + key + '!';
 			}
+		}
+
+	public static KeyStroke getKeyboardStroke(String key)
+		{
+		String keyString = getKeyboardString(key);
+		return KeyStroke.getKeyStroke(keyString);
 		}
 
 	public static String format(String key, Object...arguments)

--- a/org/lateralgm/messages/keyboard.properties
+++ b/org/lateralgm/messages/keyboard.properties
@@ -15,6 +15,7 @@ ActionList.REDO=control Y
 ActionList.SELECTALL=control A
 ActionList.DELETE=DELETE
 
+FontFrame.REM_RANGE=DELETE
 FontFrame.CUT=control X
 FontFrame.COPY=control C
 FontFrame.PASTE=control V

--- a/org/lateralgm/messages/messages.properties
+++ b/org/lateralgm/messages/messages.properties
@@ -1042,6 +1042,7 @@ FontFrame.AA1=1
 FontFrame.AA2=2
 FontFrame.AA3=3
 FontFrame.CHARRANGE=Character Range
+FontFrame.CHARRANGE_FORMAT={0} to {1}
 FontFrame.TO=to
 FontFrame.NORMAL=Normal
 FontFrame.ASCII=ASCII

--- a/org/lateralgm/messages/messages_da_DK.properties
+++ b/org/lateralgm/messages/messages_da_DK.properties
@@ -659,6 +659,7 @@ FontFrame.AA1=1
 FontFrame.AA2=2
 FontFrame.AA3=3
 FontFrame.CHARRANGE=Bogstav udvalg
+FontFrame.CHARRANGE_FORMAT={0} til {1}
 FontFrame.TO=til
 FontFrame.NORMAL=Normal
 FontFrame.ALL=Alle

--- a/org/lateralgm/messages/messages_fr.properties
+++ b/org/lateralgm/messages/messages_fr.properties
@@ -647,6 +647,7 @@ FontFrame.AA1=1
 FontFrame.AA2=2
 FontFrame.AA3=3
 FontFrame.CHARRANGE=Plage de caractères
+FontFrame.CHARRANGE_FORMAT={0} à {1}
 FontFrame.TO=à
 FontFrame.NORMAL=Normale
 FontFrame.ALL=Tous

--- a/org/lateralgm/messages/messages_tr_TR.properties
+++ b/org/lateralgm/messages/messages_tr_TR.properties
@@ -658,6 +658,7 @@ FontFrame.AA1=1
 FontFrame.AA2=2
 FontFrame.AA3=3
 FontFrame.CHARRANGE=Karakter menzili
+FontFrame.CHARRANGE_FORMAT={0} - {1}
 FontFrame.TO=ona
 FontFrame.NORMAL=Normal
 FontFrame.ALL=Hepsi

--- a/org/lateralgm/messages/messages_zh_CN.properties
+++ b/org/lateralgm/messages/messages_zh_CN.properties
@@ -960,6 +960,7 @@ FontFrame.AA1=1
 FontFrame.AA2=2
 FontFrame.AA3=3
 FontFrame.CHARRANGE=\u5b57\u7b26\u8303\u56f4
+FontFrame.CHARRANGE_FORMAT={0} \u5230 {1}
 FontFrame.TO=\u5230
 FontFrame.NORMAL=\u6b63\u5e38
 FontFrame.ASCII=ASCII

--- a/org/lateralgm/subframes/FontFrame.java
+++ b/org/lateralgm/subframes/FontFrame.java
@@ -57,6 +57,7 @@ import org.lateralgm.main.LGM;
 import org.lateralgm.main.Prefs;
 import org.lateralgm.main.UpdateSource.UpdateEvent;
 import org.lateralgm.main.UpdateSource.UpdateListener;
+import org.lateralgm.main.Util;
 import org.lateralgm.messages.Messages;
 import org.lateralgm.resources.Font;
 import org.lateralgm.resources.Font.PFont;
@@ -310,7 +311,7 @@ public class FontFrame extends InstantiableResourceFrame<Font,PFont> implements
 		/**/.addComponent(save)).addGroup(
 				layout.createSequentialGroup().addComponent(previewTextScroll,DEFAULT_SIZE,100,MAX_VALUE).addComponent(
 						previewRangeScroll,DEFAULT_SIZE,100,MAX_VALUE)));
-		setAllEnabled(crPane, !rangeList.isSelectionEmpty());
+		Util.setComponentTreeEnabled(crPane,!rangeList.isSelectionEmpty());
 		pack();
 		}
 
@@ -622,21 +623,9 @@ public class FontFrame extends InstantiableResourceFrame<Font,PFont> implements
 		if (e.getSource() == rangeList)
 			{
 			fireRangeUpdate();
-			setAllEnabled(crPane, !rangeList.isSelectionEmpty());
+			Util.setComponentTreeEnabled(crPane,!rangeList.isSelectionEmpty());
 			}
 
-		}
-
-	private static void setAllEnabled(JPanel panel, boolean enabled)
-		{
-		panel.setIgnoreRepaint(true);
-		panel.setEnabled(enabled);
-		for (Component component: panel.getComponents())
-			{
-			component.setEnabled(enabled);
-			}
-		panel.setIgnoreRepaint(false);
-		panel.repaint();
 		}
 
 	public void contentsChanged(ListDataEvent arg0)

--- a/org/lateralgm/subframes/FontFrame.java
+++ b/org/lateralgm/subframes/FontFrame.java
@@ -19,8 +19,6 @@ import java.awt.GraphicsEnvironment;
 import java.awt.event.ActionEvent;
 import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
-import java.text.MessageFormat;
-
 import javax.swing.AbstractAction;
 import javax.swing.BorderFactory;
 import javax.swing.GroupLayout;
@@ -589,8 +587,8 @@ public class FontFrame extends InstantiableResourceFrame<Font,PFont> implements
 			{
 			CharacterRange i = (CharacterRange) val;
 			lcr.getListCellRendererComponent(list,lab,ind,selected,focus);
-			lab.setText(MessageFormat.format(" {0} {1} {2}",i.properties.get(PCharacterRange.RANGE_MIN), //$NON-NLS-1$
-					Messages.getString("FontFrame.TO"),i.properties.get(PCharacterRange.RANGE_MAX))); //$NON-NLS-1$
+			lab.setText(Messages.format("FontFrame.CHARRANGE_FORMAT",i.properties.get(PCharacterRange.RANGE_MIN), //$NON-NLS-1$
+					i.properties.get(PCharacterRange.RANGE_MAX)));
 			return lab;
 			}
 		}

--- a/org/lateralgm/subframes/FontFrame.java
+++ b/org/lateralgm/subframes/FontFrame.java
@@ -13,8 +13,6 @@ package org.lateralgm.subframes;
 
 import static java.lang.Integer.MAX_VALUE;
 import static javax.swing.GroupLayout.DEFAULT_SIZE;
-import static java.awt.event.KeyEvent.VK_DELETE;
-
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.GraphicsEnvironment;

--- a/org/lateralgm/subframes/FontFrame.java
+++ b/org/lateralgm/subframes/FontFrame.java
@@ -205,11 +205,13 @@ public class FontFrame extends InstantiableResourceFrame<Font,PFont> implements
 		JButton fromFile = new JButton(Messages.getString("FontFrame.FROMFILE"));
 		fromFile.setActionCommand("FromFile"); //$NON-NLS-1$
 		fromFile.addActionListener(this);
-		JButton addRange = new JButton("+");
+		JButton addRange = new JButton();
+		addRange.setIcon(LGM.getIconForKey("FontFrame.ADD_RANGE"));
 		makeComponentSquarish(addRange);
 		addRange.setActionCommand("Add"); //$NON-NLS-1$
 		addRange.addActionListener(this);
-		JButton remRange = new JButton("-");
+		JButton remRange = new JButton();
+		remRange.setIcon(LGM.getIconForKey("FontFrame.REMOVE_RANGE"));
 		makeComponentSquarish(remRange);
 		remRange.setActionCommand("Remove"); //$NON-NLS-1$
 		remRange.addActionListener(this);

--- a/org/lateralgm/subframes/FontFrame.java
+++ b/org/lateralgm/subframes/FontFrame.java
@@ -355,13 +355,13 @@ public class FontFrame extends InstantiableResourceFrame<Font,PFont> implements
 		popup = new JPopupMenu();
 
 		copyItem = addItem("FontFrame.COPY"); //$NON-NLS-1$
-		copyItem.setAccelerator(Messages.getKeyboardStroke("FontFrame.CUT")); //$NON-NLS-1$
-		copyItem.setActionCommand("COPYRANGE");
+		copyItem.setAccelerator(Messages.getKeyboardStroke("FontFrame.COPY")); //$NON-NLS-1$
+		copyItem.setActionCommand("COPYRANGE"); //$NON-NLS-1$
 		popup.add(copyItem);
 		popup.addSeparator();
 		selAllItem = addItem("FontFrame.SELECTALL"); //$NON-NLS-1$
 		selAllItem.setAccelerator(Messages.getKeyboardStroke("FontFrame.SELECTALL")); //$NON-NLS-1$
-		selAllItem.setActionCommand("SELECTALLRANGE");
+		selAllItem.setActionCommand("SELECTALLRANGE"); //$NON-NLS-1$
 		popup.add(selAllItem);
 
 		previewRange.setComponentPopupMenu(popup);
@@ -370,7 +370,8 @@ public class FontFrame extends InstantiableResourceFrame<Font,PFont> implements
 	private JPanel makeCRPane()
 		{
 		JPanel panel = new JPanel();
-		panel.setBorder(BorderFactory.createTitledBorder(Messages.getString("FontFrame.CHARRANGE")));
+		String title = Messages.getString("FontFrame.CHARRANGE"); //$NON-NLS-1$
+		panel.setBorder(BorderFactory.createTitledBorder(title));
 		GroupLayout layout = new GroupLayout(panel);
 		layout.setAutoCreateGaps(true);
 		layout.setAutoCreateContainerGaps(true);

--- a/org/lateralgm/subframes/FontFrame.java
+++ b/org/lateralgm/subframes/FontFrame.java
@@ -21,6 +21,7 @@ import java.awt.GraphicsEnvironment;
 import java.awt.event.ActionEvent;
 import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
+import java.text.MessageFormat;
 
 import javax.swing.AbstractAction;
 import javax.swing.BorderFactory;
@@ -485,10 +486,10 @@ public class FontFrame extends InstantiableResourceFrame<Font,PFont> implements
 			case "Letters": //$NON-NLS-1$
 				setRange('A', 'z');
 				break;
-			case "FromPreview":
+			case "FromPreview": //$NON-NLS-1$
 				res.addRangesFromString(previewText.getText());
 				break;
-			case "FromString":
+			case "FromString": //$NON-NLS-1$
 				{
 				String result = JOptionPane.showInputDialog(this, "", "Character Sequence",
 						JOptionPane.PLAIN_MESSAGE);
@@ -498,21 +499,21 @@ public class FontFrame extends InstantiableResourceFrame<Font,PFont> implements
 					}
 				break;
 				}
-			case "FromFile":
+			case "FromFile": //$NON-NLS-1$
 				{
-				CustomFileChooser fc = new CustomFileChooser("/org/lateralgm", "LAST_FILE_DIR");
+				CustomFileChooser fc = new CustomFileChooser("/org/lateralgm", "LAST_FILE_DIR");  //$NON-NLS-1$//$NON-NLS-2$
 				fc.setMultiSelectionEnabled(false);
 				if (fc.showOpenDialog(LGM.frame) == JFileChooser.APPROVE_OPTION)
 					res.addRangesFromFile(fc.getSelectedFile());
 				break;
 				}
-			case "Add":
+			case "Add": //$NON-NLS-1$
 				res.addRange();
 				break;
-			case "Remove":
+			case "Remove": //$NON-NLS-1$
 				deleteSelectedRange();
 				break;
-			case "Clear":
+			case "Clear": //$NON-NLS-1$
 				res.characterRanges.clear();
 				rangeList.clearSelection();
 				return;
@@ -568,7 +569,7 @@ public class FontFrame extends InstantiableResourceFrame<Font,PFont> implements
 					}
 				text.append(Character.toChars(i));
 				}
-			text.append("\n");
+			text.append('\n');
 			}
 		previewRange.setText(text.toString());
 		previewRange.setFont(res.getAWTFont());
@@ -589,11 +590,10 @@ public class FontFrame extends InstantiableResourceFrame<Font,PFont> implements
 			{
 			CharacterRange i = (CharacterRange) val;
 			lcr.getListCellRendererComponent(list,lab,ind,selected,focus);
-			lab.setText(" " + i.properties.get(PCharacterRange.RANGE_MIN) + " "
-					+ Messages.getString("FontFrame.TO") + " " + i.properties.get(PCharacterRange.RANGE_MAX));
+			lab.setText(MessageFormat.format(" {0} {1} {2}",i.properties.get(PCharacterRange.RANGE_MIN), //$NON-NLS-1$
+					Messages.getString("FontFrame.TO"),i.properties.get(PCharacterRange.RANGE_MAX))); //$NON-NLS-1$
 			return lab;
 			}
-
 		}
 
 	public void fireRangeUpdate()

--- a/org/lateralgm/subframes/FontFrame.java
+++ b/org/lateralgm/subframes/FontFrame.java
@@ -337,17 +337,17 @@ public class FontFrame extends InstantiableResourceFrame<Font,PFont> implements
 		JPopupMenu popup = new JPopupMenu();
 
 		cutItem = addItem("FontFrame.CUT"); //$NON-NLS-1$
-		cutItem.setAccelerator(KeyStroke.getKeyStroke(Messages.getKeyboardString("FontFrame.CUT")));
+		cutItem.setAccelerator(Messages.getKeyboardStroke("FontFrame.CUT")); //$NON-NLS-1$
 		popup.add(cutItem);
 		copyItem = addItem("FontFrame.COPY"); //$NON-NLS-1$
-		copyItem.setAccelerator(KeyStroke.getKeyStroke(Messages.getKeyboardString("FontFrame.COPY")));
+		copyItem.setAccelerator(Messages.getKeyboardStroke("FontFrame.COPY")); //$NON-NLS-1$
 		popup.add(copyItem);
 		pasteItem = addItem("FontFrame.PASTE"); //$NON-NLS-1$
-		pasteItem.setAccelerator(KeyStroke.getKeyStroke(Messages.getKeyboardString("FontFrame.PASTE")));
+		pasteItem.setAccelerator(Messages.getKeyboardStroke("FontFrame.PASTE")); //$NON-NLS-1$
 		popup.add(pasteItem);
 		popup.addSeparator();
 		selAllItem = addItem("FontFrame.SELECTALL"); //$NON-NLS-1$
-		selAllItem.setAccelerator(KeyStroke.getKeyStroke(Messages.getKeyboardString("FontFrame.SELECTALL")));
+		selAllItem.setAccelerator(Messages.getKeyboardStroke("FontFrame.SELECTALL")); //$NON-NLS-1$
 		popup.add(selAllItem);
 
 		previewText.setComponentPopupMenu(popup);
@@ -355,12 +355,12 @@ public class FontFrame extends InstantiableResourceFrame<Font,PFont> implements
 		popup = new JPopupMenu();
 
 		copyItem = addItem("FontFrame.COPY"); //$NON-NLS-1$
-		copyItem.setAccelerator(KeyStroke.getKeyStroke(Messages.getKeyboardString("FontFrame.CUT")));
+		copyItem.setAccelerator(Messages.getKeyboardStroke("FontFrame.CUT")); //$NON-NLS-1$
 		copyItem.setActionCommand("COPYRANGE");
 		popup.add(copyItem);
 		popup.addSeparator();
 		selAllItem = addItem("FontFrame.SELECTALL"); //$NON-NLS-1$
-		selAllItem.setAccelerator(KeyStroke.getKeyStroke(Messages.getKeyboardString("FontFrame.SELECTALL")));
+		selAllItem.setAccelerator(Messages.getKeyboardStroke("FontFrame.SELECTALL")); //$NON-NLS-1$
 		selAllItem.setActionCommand("SELECTALLRANGE");
 		popup.add(selAllItem);
 

--- a/org/lateralgm/subframes/FontFrame.java
+++ b/org/lateralgm/subframes/FontFrame.java
@@ -186,9 +186,16 @@ public class FontFrame extends InstantiableResourceFrame<Font,PFont> implements
 		rangeList.setLayoutOrientation(JList.VERTICAL);
 		rangeList.setVisibleRowCount(6);
 
-		rangeList.getInputMap().put(KeyStroke.getKeyStroke(VK_DELETE, 0), "delete selected");
-		rangeList.getActionMap().put("delete selected", new AbstractAction()
+		String keyString = Messages.getKeyboardString("FontFrame.REM_RANGE"); //$NON-NLS-1$
+		KeyStroke stroke = KeyStroke.getKeyStroke(keyString);
+		rangeList.getInputMap().put(stroke, "REM_RANGE"); //$NON-NLS-1$
+		rangeList.getActionMap().put("REM_RANGE", new AbstractAction() //$NON-NLS-1$
 			{
+			/**
+			 * TODO: Default UID generated, change if necessary.
+			 */
+			private static final long serialVersionUID = 5308536583486764117L;
+
 			@Override
 			public void actionPerformed(ActionEvent e)
 				{

--- a/org/lateralgm/subframes/FontFrame.java
+++ b/org/lateralgm/subframes/FontFrame.java
@@ -196,33 +196,33 @@ public class FontFrame extends InstantiableResourceFrame<Font,PFont> implements
 				}
 			});
 
-		JButton fromPreview = new JButton(Messages.getString("FontFrame.FROMPREVIEW"));
+		JButton fromPreview = new JButton(Messages.getString("FontFrame.FROMPREVIEW")); //$NON-NLS-1$
 		fromPreview.setActionCommand("FromPreview"); //$NON-NLS-1$
 		fromPreview.addActionListener(this);
-		JButton fromString = new JButton(Messages.getString("FontFrame.FROMSTRING"));
+		JButton fromString = new JButton(Messages.getString("FontFrame.FROMSTRING")); //$NON-NLS-1$
 		fromString.setActionCommand("FromString"); //$NON-NLS-1$
 		fromString.addActionListener(this);
-		JButton fromFile = new JButton(Messages.getString("FontFrame.FROMFILE"));
+		JButton fromFile = new JButton(Messages.getString("FontFrame.FROMFILE")); //$NON-NLS-1$
 		fromFile.setActionCommand("FromFile"); //$NON-NLS-1$
 		fromFile.addActionListener(this);
 		JButton addRange = new JButton();
-		addRange.setIcon(LGM.getIconForKey("FontFrame.ADD_RANGE"));
+		addRange.setIcon(LGM.getIconForKey("FontFrame.ADD_RANGE")); //$NON-NLS-1$
 		makeComponentSquarish(addRange);
 		addRange.setActionCommand("Add"); //$NON-NLS-1$
 		addRange.addActionListener(this);
 		JButton remRange = new JButton();
-		remRange.setIcon(LGM.getIconForKey("FontFrame.REMOVE_RANGE"));
+		remRange.setIcon(LGM.getIconForKey("FontFrame.REMOVE_RANGE")); //$NON-NLS-1$
 		makeComponentSquarish(remRange);
 		remRange.setActionCommand("Remove"); //$NON-NLS-1$
 		remRange.addActionListener(this);
-		JButton clearRange = new JButton(Messages.getString("FontFrame.CLEAR"));
+		JButton clearRange = new JButton(Messages.getString("FontFrame.CLEAR")); //$NON-NLS-1$
 		clearRange.setActionCommand("Clear"); //$NON-NLS-1$
 		clearRange.addActionListener(this);
 
 		JScrollPane listScroller = new JScrollPane(rangeList);
 		listScroller.setPreferredSize(new Dimension(250,80));
 		add(listScroller);
-		previewText.setText(Messages.getString("FontFrame.PREVIEW_DEFAULT"));
+		previewText.setText(Messages.getString("FontFrame.PREVIEW_DEFAULT")); //$NON-NLS-1$
 		makeContextMenu();
 
 		JScrollPane previewTextScroll = new JScrollPane(previewText);

--- a/org/lateralgm/subframes/PreferencesFrame.java
+++ b/org/lateralgm/subframes/PreferencesFrame.java
@@ -315,11 +315,7 @@ public class PreferencesFrame extends JDialog implements ActionListener
 		/*		*/.addComponent(showTreeFilter))));
 
 		//TODO: Finish backup preferences.
-		backupsPanel.setEnabled(false);
-		Component[] coms = backupsPanel.getComponents();
-		for (int i = 0; i < coms.length; i++) {
-			coms[i].setEnabled(false);
-		}
+		Util.setComponentTreeEnabled(backupsPanel,false);
 
 		return p;
 		}


### PR DESCRIPTION
This pull request is a continuation of #388 so I can finalize it before merging it to master.

![Improved Font Editor](https://user-images.githubusercontent.com/3212801/57071637-09ba7c00-6ca9-11e9-8168-d744dc497e50.png)

### Summary of Additional Changes
* Used the Calico icons for the font frame's add/delete range buttons.
* Added missing localization tags for keys previously added by me.
* Extracted the delete range button's keyboard shortcut to the keyboard properties file.
* Extracted a utility method for setting component tree's enabled or disabled which is shared with the preferences frame.