### PR TITLE
Font Editor Tweaks

### DIFF
--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -134,7 +134,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.54"; //$NON-NLS-1$
+	public static final String version = "1.8.55"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/subframes/FontFrame.java
+++ b/org/lateralgm/subframes/FontFrame.java
@@ -36,12 +36,12 @@ import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
+import javax.swing.JToolBar;
 import javax.swing.KeyStroke;
 import javax.swing.ListCellRenderer;
 import javax.swing.GroupLayout.Alignment;
 import javax.swing.GroupLayout.SequentialGroup;
 import javax.swing.ScrollPaneConstants;
-import javax.swing.SwingConstants;
 import javax.swing.border.EmptyBorder;
 import javax.swing.event.ListDataEvent;
 import javax.swing.event.ListDataListener;
@@ -206,6 +206,9 @@ public class FontFrame extends InstantiableResourceFrame<Font,PFont> implements
 				}
 			});
 
+		JToolBar rangesTB = new JToolBar();
+		rangesTB.setFloatable(false);
+
 		JButton fromPreview = new JButton(Messages.getString("FontFrame.FROMPREVIEW")); //$NON-NLS-1$
 		fromPreview.setActionCommand("FromPreview"); //$NON-NLS-1$
 		fromPreview.addActionListener(this);
@@ -227,7 +230,17 @@ public class FontFrame extends InstantiableResourceFrame<Font,PFont> implements
 		clearRange.setActionCommand("Clear"); //$NON-NLS-1$
 		clearRange.addActionListener(this);
 
-		layout.linkSize(SwingConstants.VERTICAL,addRange,remRange,clearRange);
+		rangesTB.add(addRange);
+		rangesTB.addSeparator();
+		rangesTB.add(fromPreview);
+		rangesTB.addSeparator();
+		rangesTB.add(fromString);
+		rangesTB.addSeparator();
+		rangesTB.add(fromFile);
+		rangesTB.addSeparator();
+		rangesTB.add(remRange);
+		rangesTB.addSeparator();
+		rangesTB.add(clearRange);
 
 		JScrollPane listScroller = new JScrollPane(rangeList);
 		listScroller.setPreferredSize(new Dimension(250,80));
@@ -265,14 +278,7 @@ public class FontFrame extends InstantiableResourceFrame<Font,PFont> implements
 		/*		*/.addComponent(aaLabel).addComponent(aa)
 		/*		*/.addComponent(bold)
 		/*		*/.addComponent(italic))
-		/**/.addGroup(layout.createSequentialGroup()
-		/*		*/.addComponent(fromPreview)
-		/*		*/.addComponent(fromString)
-		/*		*/.addComponent(fromFile))
-		/**/.addGroup(layout.createSequentialGroup()
-		/*		*/.addComponent(addRange)
-		/*		*/.addComponent(remRange)
-		/*		*/.addComponent(clearRange))
+		/**/.addComponent(rangesTB)
 		/**/.addGroup(layout.createSequentialGroup()
 		/**/.addComponent(listScroller,120,220,MAX_VALUE))
 		/**/.addComponent(crPane)
@@ -300,20 +306,14 @@ public class FontFrame extends InstantiableResourceFrame<Font,PFont> implements
 		/*		*/.addComponent(aa).addComponent(aaLabel)
 		/*		*/.addComponent(bold)
 		/*		*/.addComponent(italic))
-		/**/.addGroup(layout.createParallelGroup(Alignment.BASELINE)
-		/*		*/.addComponent(fromPreview)
-		/*		*/.addComponent(fromString)
-		/*		*/.addComponent(fromFile))
-		/**/.addGroup(layout.createParallelGroup(Alignment.BASELINE)
-		/*		*/.addComponent(addRange)
-		/*		*/.addComponent(remRange)
-		/*		*/.addComponent(clearRange))
+		/**/.addComponent(rangesTB)
 		/**/.addGroup(layout.createParallelGroup(Alignment.BASELINE)
 		/**/.addComponent(listScroller,DEFAULT_SIZE,120,MAX_VALUE))
 		/**/.addComponent(crPane)
 		/**/.addComponent(save)).addGroup(
 				layout.createSequentialGroup().addComponent(previewTextScroll,DEFAULT_SIZE,100,MAX_VALUE).addComponent(
 						previewRangeScroll,DEFAULT_SIZE,100,MAX_VALUE)));
+
 		Util.setComponentTreeEnabled(crPane,!rangeList.isSelectionEmpty());
 		pack();
 		}

--- a/org/lateralgm/subframes/FontFrame.java
+++ b/org/lateralgm/subframes/FontFrame.java
@@ -41,6 +41,7 @@ import javax.swing.ListCellRenderer;
 import javax.swing.GroupLayout.Alignment;
 import javax.swing.GroupLayout.SequentialGroup;
 import javax.swing.ScrollPaneConstants;
+import javax.swing.SwingConstants;
 import javax.swing.border.EmptyBorder;
 import javax.swing.event.ListDataEvent;
 import javax.swing.event.ListDataListener;
@@ -216,17 +217,17 @@ public class FontFrame extends InstantiableResourceFrame<Font,PFont> implements
 		fromFile.addActionListener(this);
 		JButton addRange = new JButton();
 		addRange.setIcon(LGM.getIconForKey("FontFrame.ADD_RANGE")); //$NON-NLS-1$
-		makeComponentSquarish(addRange);
 		addRange.setActionCommand("Add"); //$NON-NLS-1$
 		addRange.addActionListener(this);
 		JButton remRange = new JButton();
 		remRange.setIcon(LGM.getIconForKey("FontFrame.REMOVE_RANGE")); //$NON-NLS-1$
-		makeComponentSquarish(remRange);
 		remRange.setActionCommand("Remove"); //$NON-NLS-1$
 		remRange.addActionListener(this);
 		JButton clearRange = new JButton(Messages.getString("FontFrame.CLEAR")); //$NON-NLS-1$
 		clearRange.setActionCommand("Clear"); //$NON-NLS-1$
 		clearRange.addActionListener(this);
+
+		layout.linkSize(SwingConstants.VERTICAL,addRange,remRange,clearRange);
 
 		JScrollPane listScroller = new JScrollPane(rangeList);
 		listScroller.setPreferredSize(new Dimension(250,80));
@@ -315,13 +316,6 @@ public class FontFrame extends InstantiableResourceFrame<Font,PFont> implements
 						previewRangeScroll,DEFAULT_SIZE,100,MAX_VALUE)));
 		Util.setComponentTreeEnabled(crPane,!rangeList.isSelectionEmpty());
 		pack();
-		}
-
-	private static void makeComponentSquarish(Component addRange)
-		{
-		Dimension addRangeSize = addRange.getPreferredSize();
-		addRangeSize.setSize(Math.max(addRangeSize.width, addRangeSize.height) * 1.2, addRangeSize.height);
-		addRange.setMinimumSize(addRangeSize);
 		}
 
 	public JMenuItem addItem(String key)

--- a/org/lateralgm/subframes/FontFrame.java
+++ b/org/lateralgm/subframes/FontFrame.java
@@ -183,6 +183,10 @@ public class FontFrame extends InstantiableResourceFrame<Font,PFont> implements
 		rangeList.setSelectedIndex(0);
 		rangeList.setLayoutOrientation(JList.VERTICAL);
 		rangeList.setVisibleRowCount(6);
+		if (res.getNode().newRes && res.characterRanges.isEmpty())
+			{
+			res.addRange();
+			}
 
 		String keyString = Messages.getKeyboardString("FontFrame.REM_RANGE"); //$NON-NLS-1$
 		KeyStroke stroke = KeyStroke.getKeyStroke(keyString);


### PR DESCRIPTION
This is just some minor tweaks to the font editor extending #412. Use a non-floatable toolbar to lay out the character range list buttons. This makes the buttons more visually consistent. Also, add a default character range to the font when its editor is first opened as the object frame does for the basic create/step/draw events.

![Font Editor Range Buttons Layout](https://user-images.githubusercontent.com/3212801/57178341-7e71ef80-6e3c-11e9-89cb-2b58d225e036.png)
