### PR TITLE
Cleanup GMX Tree Writing

### DIFF
--- a/org/lateralgm/file/GMXFileWriter.java
+++ b/org/lateralgm/file/GMXFileWriter.java
@@ -37,6 +37,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.Writer;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Vector;
 
@@ -117,6 +118,34 @@ public final class GMXFileWriter
 	{
 	private static DocumentBuilder documentBuilder;
 	private static Transformer transformer;
+	private static HashMap<Class<?>,String> tagNames = new HashMap<>(), rootNames = new HashMap<>();
+
+	static
+		{
+		/// GMX isn't consistent about anything and that includes tag & attribute name plurality.
+
+		tagNames.put(Sprite.class,"sprites"); //$NON-NLS-1$
+		tagNames.put(Sound.class,"sounds"); //$NON-NLS-1$
+		tagNames.put(Background.class,"backgrounds"); //$NON-NLS-1$
+		tagNames.put(Path.class,"paths"); //$NON-NLS-1$
+		tagNames.put(Script.class,"scripts"); //$NON-NLS-1$
+		tagNames.put(Shader.class,"shaders"); //$NON-NLS-1$
+		tagNames.put(Font.class,"fonts"); //$NON-NLS-1$
+		tagNames.put(Timeline.class,"timelines"); //$NON-NLS-1$
+		tagNames.put(GmObject.class,"objects"); //$NON-NLS-1$
+		tagNames.put(Room.class,"rooms"); //$NON-NLS-1$
+
+		rootNames.put(Sprite.class,"sprites"); //$NON-NLS-1$
+		rootNames.put(Sound.class,"sound"); //$NON-NLS-1$
+		rootNames.put(Background.class,"background"); //$NON-NLS-1$
+		rootNames.put(Path.class,"paths"); //$NON-NLS-1$
+		rootNames.put(Script.class,"scripts"); //$NON-NLS-1$
+		rootNames.put(Shader.class,"shaders"); //$NON-NLS-1$
+		rootNames.put(Font.class,"fonts"); //$NON-NLS-1$
+		rootNames.put(Timeline.class,"timelines"); //$NON-NLS-1$
+		rootNames.put(GmObject.class,"objects"); //$NON-NLS-1$
+		rootNames.put(Room.class,"rooms"); //$NON-NLS-1$
+		}
 
 	private GMXFileWriter()
 		{
@@ -334,26 +363,60 @@ public final class GMXFileWriter
 		ResourceList<R> list = c.f.resMap.getList(kind);
 		if (list.isEmpty()) return;
 
-		if (kind == Sprite.class)
-			writeSprites(c,getPrimaryNode(list.first().getNode()),root);
-		else if (kind == Sound.class)
-			writeSounds(c,getPrimaryNode(list.first().getNode()),root);
-		else if (kind == Background.class)
-			writeBackgrounds(c,getPrimaryNode(list.first().getNode()),root);
-		else if (kind == Path.class)
-			writePaths(c,getPrimaryNode(list.first().getNode()),root);
-		else if (kind == Script.class)
-			writeScripts(c,getPrimaryNode(list.first().getNode()),root);
-		else if (kind == Shader.class)
-			writeShaders(c,getPrimaryNode(list.first().getNode()),root);
-		else if (kind == Font.class)
-			writeFonts(c,getPrimaryNode(list.first().getNode()),root);
-		else if (kind == Timeline.class)
-			writeTimelines(c,getPrimaryNode(list.first().getNode()),root);
-		else if (kind == GmObject.class)
-			writeGmObjects(c,getPrimaryNode(list.first().getNode()),root);
-		else if (kind == Room.class)
-			writeRooms(c,getPrimaryNode(list.first().getNode()),root);
+		writeTree(c, getPrimaryNode(list.first().getNode()), root);
+		}
+
+	private static void writeTree(ProjectFileContext c, ResNode root, Element domRoot)
+			throws IOException
+		{
+		Document dom = c.dom;
+
+		String name = root.getUserObject().toString();
+		if (root.status == ResNode.STATUS_PRIMARY) name = rootNames.get(root.kind);
+
+		Element pnode = dom.createElement(tagNames.get(root.kind));
+		pnode.setAttribute("name",name); //$NON-NLS-1$
+		domRoot.appendChild(pnode);
+		domRoot = pnode;
+
+		Vector<ResNode> children = root.getChildren();
+		if (children == null) return;
+		for (Object obj : children)
+			{
+			if (!(obj instanceof ResNode)) continue;
+
+			ResNode resNode = (ResNode) obj;
+			Class<?> kind = resNode.kind;
+			switch (resNode.status)
+				{
+				case ResNode.STATUS_PRIMARY:
+				case ResNode.STATUS_GROUP:
+					writeTree(c,resNode,domRoot);
+					break;
+				case ResNode.STATUS_SECONDARY:
+					if (kind == Sprite.class)
+						writeSprite(c,resNode,domRoot);
+					else if (kind == Sound.class)
+						writeSound(c,resNode,domRoot);
+					else if (kind == Background.class)
+						writeBackground(c,resNode,domRoot);
+					else if (kind == Path.class)
+						writePath(c,resNode,domRoot);
+					else if (kind == Script.class)
+						writeScript(c,resNode,domRoot);
+					else if (kind == Shader.class)
+						writeShader(c,resNode,domRoot);
+					else if (kind == Font.class)
+						writeFont(c,resNode,domRoot);
+					else if (kind == Timeline.class)
+						writeTimeline(c,resNode,domRoot);
+					else if (kind == GmObject.class)
+						writeGmObject(c,resNode,domRoot);
+					else if (kind == Room.class)
+						writeRoom(c,resNode,domRoot);
+					break;
+				}
+			}
 		}
 
 	public static void writeConfigurations(ProjectFileContext c, Element root, long savetime) throws IOException
@@ -495,11 +558,6 @@ public final class GMXFileWriter
 		return;
 		}
 
-	public static void writeTriggers(ProjectFile f, ResNode root, int ver) throws IOException
-		{
-		// TODO: Implement
-		}
-
 	public static void writeConstants(Constants cnsts, Document dom, Element node) throws IOException
 		{
 			Element base = dom.createElement("constants"); //$NON-NLS-1$
@@ -518,954 +576,704 @@ public final class GMXFileWriter
 			writeConstants(c.f.defaultConstants, c.dom, root);
 		}
 
-	private static void writeSprites(ProjectFileContext c, ResNode root, Element domRoot)
+	private static void writeSprite(ProjectFileContext c, ResNode resNode, Element domRoot)
 			throws IOException
 		{
-		ProjectFile f = c.f;
 		Document dom = c.dom;
+		ProjectFile f = c.f;
 
-		String name = root.getUserObject().toString();
-		if (root.status == ResNode.STATUS_PRIMARY) name = "sprites"; //$NON-NLS-1$
+		Sprite spr = (Sprite) resNode.getRes().get();
+		Element res = dom.createElement("sprite"); //$NON-NLS-1$
+		String fname = f.getDirectory() + "\\sprites\\"; //$NON-NLS-1$
+		res.setTextContent("sprites\\" + spr.getName()); //$NON-NLS-1$
+		File imagesFile = new File(Util.getPOSIXPath(fname + "\\images")); //$NON-NLS-1$
+		imagesFile.mkdirs();
 
-		Element pnode = dom.createElement("sprites"); //$NON-NLS-1$
-		pnode.setAttribute("name",name); //$NON-NLS-1$
-		domRoot.appendChild(pnode);
-		domRoot = pnode;
+		Document doc = documentBuilder.newDocument();
 
-		Vector<ResNode> children = root.getChildren();
-		if (children == null) return;
-		for (Object obj : children)
+		Element sprroot = doc.createElement("sprite"); //$NON-NLS-1$
+		doc.appendChild(sprroot);
+
+		sprroot.appendChild(createElement(doc,"xorig",spr.get(PSprite.ORIGIN_X).toString())); //$NON-NLS-1$
+		sprroot.appendChild(createElement(doc,"yorigin",spr.get(PSprite.ORIGIN_Y).toString())); //$NON-NLS-1$
+		sprroot.appendChild(createElement(doc,"colkind", //$NON-NLS-1$
+				ProjectFile.SPRITE_MASK_CODE.get(spr.get(PSprite.SHAPE)).toString()));
+		sprroot.appendChild(createElement(doc,"sepmasks", //$NON-NLS-1$
+				boolToString((Boolean) spr.get(PSprite.SEPARATE_MASK))));
+		sprroot.appendChild(createElement(doc,"bbox_left",spr.get(PSprite.BB_LEFT).toString())); //$NON-NLS-1$
+		sprroot.appendChild(createElement(doc,"bbox_right",spr.get(PSprite.BB_RIGHT).toString())); //$NON-NLS-1$
+		sprroot.appendChild(createElement(doc,"bbox_top",spr.get(PSprite.BB_TOP).toString())); //$NON-NLS-1$
+		sprroot.appendChild(createElement(doc,"bbox_bottom",spr.get(PSprite.BB_BOTTOM).toString())); //$NON-NLS-1$
+		sprroot.appendChild(createElement(doc,"bboxmode", //$NON-NLS-1$
+				ProjectFile.SPRITE_BB_CODE.get(spr.get(PSprite.BB_MODE)).toString()));
+		sprroot.appendChild(createElement(doc,"coltolerance", //$NON-NLS-1$
+				spr.get(PSprite.ALPHA_TOLERANCE).toString()));
+
+		sprroot.appendChild(createElement(doc,"HTile", //$NON-NLS-1$
+				boolToString((Boolean) spr.get(PSprite.TILE_HORIZONTALLY))));
+		sprroot.appendChild(createElement(doc,"VTile", //$NON-NLS-1$
+				boolToString((Boolean) spr.get(PSprite.TILE_VERTICALLY))));
+
+		// TODO: Write texture groups
+
+		sprroot.appendChild(createElement(doc,"For3D", //$NON-NLS-1$
+				boolToString((Boolean) spr.get(PSprite.FOR3D))));
+
+		int width = spr.getWidth(),
+		height = spr.getHeight();
+
+		sprroot.appendChild(createElement(doc,"width",Integer.toString(width))); //$NON-NLS-1$
+		sprroot.appendChild(createElement(doc,"height",Integer.toString(height))); //$NON-NLS-1$
+
+		Element frameroot = doc.createElement("frames"); //$NON-NLS-1$
+		for (int j = 0; j < spr.subImages.size(); j++)
 			{
-			if (!(obj instanceof ResNode)) continue;
-
-			ResNode resNode = (ResNode) obj;
-			switch (resNode.status)
-				{
-				case ResNode.STATUS_PRIMARY:
-				case ResNode.STATUS_GROUP:
-					writeSprites(c,resNode,domRoot);
-					break;
-				case ResNode.STATUS_SECONDARY:
-					Sprite spr = (Sprite) resNode.getRes().get();
-					Element res = dom.createElement("sprite"); //$NON-NLS-1$
-					String fname = f.getDirectory() + "\\sprites\\"; //$NON-NLS-1$
-					res.setTextContent("sprites\\" + spr.getName()); //$NON-NLS-1$
-					File imagesFile = new File(Util.getPOSIXPath(fname + "\\images")); //$NON-NLS-1$
-					imagesFile.mkdirs();
-
-					Document doc = documentBuilder.newDocument();
-
-					Element sprroot = doc.createElement("sprite"); //$NON-NLS-1$
-					doc.appendChild(sprroot);
-
-					sprroot.appendChild(createElement(doc,"xorig",spr.get(PSprite.ORIGIN_X).toString())); //$NON-NLS-1$
-					sprroot.appendChild(createElement(doc,"yorigin",spr.get(PSprite.ORIGIN_Y).toString())); //$NON-NLS-1$
-					sprroot.appendChild(createElement(doc,"colkind", //$NON-NLS-1$
-							ProjectFile.SPRITE_MASK_CODE.get(spr.get(PSprite.SHAPE)).toString()));
-					sprroot.appendChild(createElement(doc,"sepmasks", //$NON-NLS-1$
-							boolToString((Boolean) spr.get(PSprite.SEPARATE_MASK))));
-					sprroot.appendChild(createElement(doc,"bbox_left",spr.get(PSprite.BB_LEFT).toString())); //$NON-NLS-1$
-					sprroot.appendChild(createElement(doc,"bbox_right",spr.get(PSprite.BB_RIGHT).toString())); //$NON-NLS-1$
-					sprroot.appendChild(createElement(doc,"bbox_top",spr.get(PSprite.BB_TOP).toString())); //$NON-NLS-1$
-					sprroot.appendChild(createElement(doc,"bbox_bottom",spr.get(PSprite.BB_BOTTOM).toString())); //$NON-NLS-1$
-					sprroot.appendChild(createElement(doc,"bboxmode", //$NON-NLS-1$
-							ProjectFile.SPRITE_BB_CODE.get(spr.get(PSprite.BB_MODE)).toString()));
-					sprroot.appendChild(createElement(doc,"coltolerance", //$NON-NLS-1$
-							spr.get(PSprite.ALPHA_TOLERANCE).toString()));
-
-					sprroot.appendChild(createElement(doc,"HTile", //$NON-NLS-1$
-							boolToString((Boolean) spr.get(PSprite.TILE_HORIZONTALLY))));
-					sprroot.appendChild(createElement(doc,"VTile", //$NON-NLS-1$
-							boolToString((Boolean) spr.get(PSprite.TILE_VERTICALLY))));
-
-					// TODO: Write texture groups
-
-					sprroot.appendChild(createElement(doc,"For3D", //$NON-NLS-1$
-							boolToString((Boolean) spr.get(PSprite.FOR3D))));
-
-					int width = spr.getWidth(),
-					height = spr.getHeight();
-
-					sprroot.appendChild(createElement(doc,"width",Integer.toString(width))); //$NON-NLS-1$
-					sprroot.appendChild(createElement(doc,"height",Integer.toString(height))); //$NON-NLS-1$
-
-					Element frameroot = doc.createElement("frames"); //$NON-NLS-1$
-					for (int j = 0; j < spr.subImages.size(); j++)
-						{
-						String framefname = "images\\" + spr.getName() + '_' + j + ".png";  //$NON-NLS-1$//$NON-NLS-2$
-						File outputfile = new File(Util.getPOSIXPath(fname + framefname));
-						Element frameNode = createElement(doc,"frame",framefname); //$NON-NLS-1$
-						frameNode.setAttribute("index",Integer.toString(j)); //$NON-NLS-1$
-						frameroot.appendChild(frameNode);
-						BufferedImage sub = spr.subImages.get(j);
-						// GMX does have a backwards compatibility property for transparency pixel so we write
-						// the image with the transparency removed when that setting is checked
-						ImageIO.write(
-								(Boolean) spr.get(PSprite.TRANSPARENT) ? Util.getTransparentImage(sub) : sub,
-								"png",outputfile); //$NON-NLS-1$
-						}
-					sprroot.appendChild(frameroot);
-
-					File file = new File(Util.getPOSIXPath(fname + spr.getName() + ".sprite.gmx")); //$NON-NLS-1$
-					transformDocumentUnchecked(f, doc, file);
-
-					domRoot.appendChild(res);
-					break;
-				}
+			String framefname = "images\\" + spr.getName() + '_' + j + ".png";  //$NON-NLS-1$//$NON-NLS-2$
+			File outputfile = new File(Util.getPOSIXPath(fname + framefname));
+			Element frameNode = createElement(doc,"frame",framefname); //$NON-NLS-1$
+			frameNode.setAttribute("index",Integer.toString(j)); //$NON-NLS-1$
+			frameroot.appendChild(frameNode);
+			BufferedImage sub = spr.subImages.get(j);
+			// GMX does have a backwards compatibility property for transparency pixel so we write
+			// the image with the transparency removed when that setting is checked
+			ImageIO.write(
+					(Boolean) spr.get(PSprite.TRANSPARENT) ? Util.getTransparentImage(sub) : sub,
+					"png",outputfile); //$NON-NLS-1$
 			}
+		sprroot.appendChild(frameroot);
+
+		File file = new File(Util.getPOSIXPath(fname + spr.getName() + ".sprite.gmx")); //$NON-NLS-1$
+		transformDocumentUnchecked(f, doc, file);
+
+		domRoot.appendChild(res);
 		}
 
-	private static void writeSounds(ProjectFileContext c, ResNode root, Element domRoot)
+	private static void writeSound(ProjectFileContext c, ResNode resNode, Element domRoot)
 			throws IOException
 		{
 		ProjectFile f = c.f;
 		Document dom = c.dom;
 
-		String name = root.getUserObject().toString();
-		if (root.status == ResNode.STATUS_PRIMARY) name = "sound"; //$NON-NLS-1$
+		Sound snd = (Sound) resNode.getRes().get();
+		Element res = dom.createElement("sound"); //$NON-NLS-1$
+		String fname = f.getDirectory() + "\\sound\\"; //$NON-NLS-1$
+		res.setTextContent("sound\\" + snd.getName()); //$NON-NLS-1$
+		File audioFile = new File(Util.getPOSIXPath(fname + "\\audio")); //$NON-NLS-1$
+		audioFile.mkdirs();
 
-		Element pnode = dom.createElement("sounds"); //$NON-NLS-1$
-		pnode.setAttribute("name",name); //$NON-NLS-1$
-		domRoot.appendChild(pnode);
-		domRoot = pnode;
+		Document doc = documentBuilder.newDocument();
 
-		Vector<ResNode> children = root.getChildren();
-		if (children == null) return;
-		for (Object obj : children)
+		Element sndroot = doc.createElement("sound"); //$NON-NLS-1$
+		doc.appendChild(sndroot);
+
+		// GMX uses double nested tags for volume, bit rate, sample rate, type, and bit depth
+		// There is an exception to this however. In every one of those tags after volume the
+		// nested tag is singular, where its parent is plural.
+		String fileType = snd.get(PSound.FILE_TYPE).toString();
+		String fileName = snd.getName() + fileType;
+		sndroot.appendChild(createElement(doc,"extension",fileType)); //$NON-NLS-1$
+		sndroot.appendChild(createElement(doc,"origname","sound\\audio\\" + fileName)); //$NON-NLS-1$
+		sndroot.appendChild(createElement(doc,"kind", //$NON-NLS-1$
+				ProjectFile.SOUND_KIND_CODE.get(snd.get(PSound.KIND)).toString()));
+
+		Element volumeRoot = doc.createElement("volume"); //$NON-NLS-1$
+		volumeRoot.appendChild(createElement(doc,"volume", snd.get(PSound.VOLUME).toString())); //$NON-NLS-1$
+		sndroot.appendChild(volumeRoot);
+
+		Element bitRateRoot = doc.createElement("bitRates"); //$NON-NLS-1$
+		bitRateRoot.appendChild(createElement(doc,"bitRate", //$NON-NLS-1$
+			snd.get(PSound.BIT_RATE).toString()));
+		sndroot.appendChild(bitRateRoot);
+
+		Element sampleRateRoot = doc.createElement("sampleRates"); //$NON-NLS-1$
+		sampleRateRoot.appendChild(createElement(doc,"sampleRate", //$NON-NLS-1$
+				snd.get(PSound.SAMPLE_RATE).toString()));
+		sndroot.appendChild(sampleRateRoot);
+
+		Element typesRoot = doc.createElement("types"); //$NON-NLS-1$
+		typesRoot.appendChild(createElement(doc,"type", //$NON-NLS-1$
+			ProjectFile.SOUND_TYPE_CODE.get(snd.get(PSound.TYPE)).toString()));
+		sndroot.appendChild(typesRoot);
+
+		Element bitDepthRoot = doc.createElement("bitDepths"); //$NON-NLS-1$
+		bitDepthRoot.appendChild(createElement(doc,"bitDepth", //$NON-NLS-1$
+				snd.get(PSound.BIT_DEPTH).toString()));
+		sndroot.appendChild(bitDepthRoot);
+
+		sndroot.appendChild(createElement(doc,"pan",snd.get(PSound.PAN).toString())); //$NON-NLS-1$
+		sndroot.appendChild(createElement(doc,"preload", //$NON-NLS-1$
+				boolToString((Boolean) snd.get(PSound.PRELOAD))));
+		sndroot.appendChild(createElement(doc,"compressed", //$NON-NLS-1$
+				boolToString((Boolean) snd.get(PSound.COMPRESSED))));
+		sndroot.appendChild(createElement(doc,"streamed", //$NON-NLS-1$
+				boolToString((Boolean) snd.get(PSound.STREAMED))));
+		sndroot.appendChild(createElement(doc,"uncompressOnLoad", //$NON-NLS-1$
+				boolToString((Boolean) snd.get(PSound.DECOMPRESS_ON_LOAD))));
+		int effects = 0;
+		int n = 1;
+		for (PSound k : ProjectFile.SOUND_FX_FLAGS)
 			{
-			if (!(obj instanceof ResNode)) continue;
-
-			ResNode resNode = (ResNode) obj;
-			switch (resNode.status)
-				{
-				case ResNode.STATUS_PRIMARY:
-				case ResNode.STATUS_GROUP:
-					writeSounds(c,resNode,domRoot);
-					break;
-				case ResNode.STATUS_SECONDARY:
-					Sound snd = (Sound) resNode.getRes().get();
-					Element res = dom.createElement("sound"); //$NON-NLS-1$
-					String fname = f.getDirectory() + "\\sound\\"; //$NON-NLS-1$
-					res.setTextContent("sound\\" + snd.getName()); //$NON-NLS-1$
-					File audioFile = new File(Util.getPOSIXPath(fname + "\\audio")); //$NON-NLS-1$
-					audioFile.mkdirs();
-
-					Document doc = documentBuilder.newDocument();
-
-					Element sndroot = doc.createElement("sound"); //$NON-NLS-1$
-					doc.appendChild(sndroot);
-
-					// GMX uses double nested tags for volume, bit rate, sample rate, type, and bit depth
-					// There is an exception to this however. In every one of those tags after volume the
-					// nested tag is singular, where its parent is plural.
-					String fileType = snd.get(PSound.FILE_TYPE).toString();
-					String fileName = snd.getName() + fileType;
-					sndroot.appendChild(createElement(doc,"extension",fileType)); //$NON-NLS-1$
-					sndroot.appendChild(createElement(doc,"origname","sound\\audio\\" + fileName)); //$NON-NLS-1$
-					sndroot.appendChild(createElement(doc,"kind", //$NON-NLS-1$
-							ProjectFile.SOUND_KIND_CODE.get(snd.get(PSound.KIND)).toString()));
-
-					Element volumeRoot = doc.createElement("volume"); //$NON-NLS-1$
-					volumeRoot.appendChild(createElement(doc,"volume", snd.get(PSound.VOLUME).toString())); //$NON-NLS-1$
-					sndroot.appendChild(volumeRoot);
-
-					Element bitRateRoot = doc.createElement("bitRates"); //$NON-NLS-1$
-					bitRateRoot.appendChild(createElement(doc,"bitRate", //$NON-NLS-1$
-						snd.get(PSound.BIT_RATE).toString()));
-					sndroot.appendChild(bitRateRoot);
-
-					Element sampleRateRoot = doc.createElement("sampleRates"); //$NON-NLS-1$
-					sampleRateRoot.appendChild(createElement(doc,"sampleRate", //$NON-NLS-1$
-							snd.get(PSound.SAMPLE_RATE).toString()));
-					sndroot.appendChild(sampleRateRoot);
-
-					Element typesRoot = doc.createElement("types"); //$NON-NLS-1$
-					typesRoot.appendChild(createElement(doc,"type", //$NON-NLS-1$
-						ProjectFile.SOUND_TYPE_CODE.get(snd.get(PSound.TYPE)).toString()));
-					sndroot.appendChild(typesRoot);
-
-					Element bitDepthRoot = doc.createElement("bitDepths"); //$NON-NLS-1$
-					bitDepthRoot.appendChild(createElement(doc,"bitDepth", //$NON-NLS-1$
-							snd.get(PSound.BIT_DEPTH).toString()));
-					sndroot.appendChild(bitDepthRoot);
-
-					sndroot.appendChild(createElement(doc,"pan",snd.get(PSound.PAN).toString())); //$NON-NLS-1$
-					sndroot.appendChild(createElement(doc,"preload", //$NON-NLS-1$
-							boolToString((Boolean) snd.get(PSound.PRELOAD))));
-					sndroot.appendChild(createElement(doc,"compressed", //$NON-NLS-1$
-							boolToString((Boolean) snd.get(PSound.COMPRESSED))));
-					sndroot.appendChild(createElement(doc,"streamed", //$NON-NLS-1$
-							boolToString((Boolean) snd.get(PSound.STREAMED))));
-					sndroot.appendChild(createElement(doc,"uncompressOnLoad", //$NON-NLS-1$
-							boolToString((Boolean) snd.get(PSound.DECOMPRESS_ON_LOAD))));
-					int effects = 0;
-					int n = 1;
-					for (PSound k : ProjectFile.SOUND_FX_FLAGS)
-						{
-						if (snd.get(k)) effects |= n;
-						n <<= 1;
-						}
-					sndroot.appendChild(createElement(doc,"effects",Integer.toString(effects))); //$NON-NLS-1$
-
-					sndroot.appendChild(createElement(doc,"data",fileName)); //$NON-NLS-1$
-					Util.writeFully(Util.getPOSIXPath(fname + "audio/" + fileName),snd.data); //$NON-NLS-1$
-
-					File file = new File(Util.getPOSIXPath(fname + resNode.getUserObject().toString() + ".sound.gmx")); //$NON-NLS-1$
-					transformDocumentUnchecked(f, doc, file);
-
-					domRoot.appendChild(res);
-					break;
-				}
+			if (snd.get(k)) effects |= n;
+			n <<= 1;
 			}
+		sndroot.appendChild(createElement(doc,"effects",Integer.toString(effects))); //$NON-NLS-1$
+
+		sndroot.appendChild(createElement(doc,"data",fileName)); //$NON-NLS-1$
+		Util.writeFully(Util.getPOSIXPath(fname + "audio/" + fileName),snd.data); //$NON-NLS-1$
+
+		File file = new File(Util.getPOSIXPath(fname + resNode.getUserObject().toString() + ".sound.gmx")); //$NON-NLS-1$
+		transformDocumentUnchecked(f, doc, file);
+
+		domRoot.appendChild(res);
 		}
 
-	private static void writeBackgrounds(ProjectFileContext c, ResNode root, Element domRoot)
+	private static void writeBackground(ProjectFileContext c, ResNode resNode, Element domRoot)
 			throws IOException
 		{
 		ProjectFile f = c.f;
 		Document dom = c.dom;
 
-		String name = root.getUserObject().toString();
-		if (root.status == ResNode.STATUS_PRIMARY) name = "background"; //$NON-NLS-1$
+		Background bkg = (Background) resNode.getRes().get();
+		Element res = dom.createElement("background"); //$NON-NLS-1$
+		String fname = f.getDirectory() + "\\background\\"; //$NON-NLS-1$
+		res.setTextContent("background\\" + bkg.getName()); //$NON-NLS-1$
+		File imagesFile = new File(Util.getPOSIXPath(fname + "\\images")); //$NON-NLS-1$
+		imagesFile.mkdirs();
 
-		Element pnode = dom.createElement("backgrounds"); //$NON-NLS-1$
-		pnode.setAttribute("name",name); //$NON-NLS-1$
-		domRoot.appendChild(pnode);
-		domRoot = pnode;
+		Document doc = documentBuilder.newDocument();
 
-		Vector<ResNode> children = root.getChildren();
-		if (children == null) return;
-		for (Object obj : children)
+		Element bkgroot = doc.createElement("background"); //$NON-NLS-1$
+		doc.appendChild(bkgroot);
+
+		bkgroot.appendChild(createElement(doc,"istileset", //$NON-NLS-1$
+				boolToString((Boolean) bkg.get(PBackground.USE_AS_TILESET))));
+		bkgroot.appendChild(createElement(doc,"tilewidth", //$NON-NLS-1$
+				bkg.get(PBackground.TILE_WIDTH).toString()));
+		bkgroot.appendChild(createElement(doc,"tileheight", //$NON-NLS-1$
+				bkg.get(PBackground.TILE_HEIGHT).toString()));
+		bkgroot.appendChild(createElement(doc,"tilexoff",bkg.get(PBackground.H_OFFSET).toString())); //$NON-NLS-1$
+		bkgroot.appendChild(createElement(doc,"tileyoff",bkg.get(PBackground.V_OFFSET).toString())); //$NON-NLS-1$
+		bkgroot.appendChild(createElement(doc,"tilehsep",bkg.get(PBackground.H_SEP).toString())); //$NON-NLS-1$
+		bkgroot.appendChild(createElement(doc,"tilevsep",bkg.get(PBackground.V_SEP).toString())); //$NON-NLS-1$
+		bkgroot.appendChild(createElement(doc,"HTile", //$NON-NLS-1$
+				boolToString((Boolean) bkg.get(PBackground.TILE_HORIZONTALLY))));
+		bkgroot.appendChild(createElement(doc,"VTile", //$NON-NLS-1$
+				boolToString((Boolean) bkg.get(PBackground.TILE_VERTICALLY))));
+
+		// TODO: Write texture groups
+
+		bkgroot.appendChild(createElement(doc,"For3D", //$NON-NLS-1$
+				boolToString((Boolean) bkg.get(PBackground.FOR3D))));
+
+		int width = bkg.getWidth(),
+		height = bkg.getHeight();
+
+		bkgroot.appendChild(createElement(doc,"width",Integer.toString(width))); //$NON-NLS-1$
+		bkgroot.appendChild(createElement(doc,"height",Integer.toString(height))); //$NON-NLS-1$
+
+		bkgroot.appendChild(createElement(doc,"data","images\\" + bkg.getName() + ".png")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		if (width > 0 && height > 0)
 			{
-			if (!(obj instanceof ResNode)) continue;
-
-			ResNode resNode = (ResNode) obj;
-			switch (resNode.status)
-				{
-				case ResNode.STATUS_PRIMARY:
-				case ResNode.STATUS_GROUP:
-					writeBackgrounds(c,resNode,domRoot);
-					break;
-				case ResNode.STATUS_SECONDARY:
-					Background bkg = (Background) resNode.getRes().get();
-					Element res = dom.createElement("background"); //$NON-NLS-1$
-					String fname = f.getDirectory() + "\\background\\"; //$NON-NLS-1$
-					res.setTextContent("background\\" + bkg.getName()); //$NON-NLS-1$
-					File imagesFile = new File(Util.getPOSIXPath(fname + "\\images")); //$NON-NLS-1$
-					imagesFile.mkdirs();
-
-					Document doc = documentBuilder.newDocument();
-
-					Element bkgroot = doc.createElement("background"); //$NON-NLS-1$
-					doc.appendChild(bkgroot);
-
-					bkgroot.appendChild(createElement(doc,"istileset", //$NON-NLS-1$
-							boolToString((Boolean) bkg.get(PBackground.USE_AS_TILESET))));
-					bkgroot.appendChild(createElement(doc,"tilewidth", //$NON-NLS-1$
-							bkg.get(PBackground.TILE_WIDTH).toString()));
-					bkgroot.appendChild(createElement(doc,"tileheight", //$NON-NLS-1$
-							bkg.get(PBackground.TILE_HEIGHT).toString()));
-					bkgroot.appendChild(createElement(doc,"tilexoff",bkg.get(PBackground.H_OFFSET).toString())); //$NON-NLS-1$
-					bkgroot.appendChild(createElement(doc,"tileyoff",bkg.get(PBackground.V_OFFSET).toString())); //$NON-NLS-1$
-					bkgroot.appendChild(createElement(doc,"tilehsep",bkg.get(PBackground.H_SEP).toString())); //$NON-NLS-1$
-					bkgroot.appendChild(createElement(doc,"tilevsep",bkg.get(PBackground.V_SEP).toString())); //$NON-NLS-1$
-					bkgroot.appendChild(createElement(doc,"HTile", //$NON-NLS-1$
-							boolToString((Boolean) bkg.get(PBackground.TILE_HORIZONTALLY))));
-					bkgroot.appendChild(createElement(doc,"VTile", //$NON-NLS-1$
-							boolToString((Boolean) bkg.get(PBackground.TILE_VERTICALLY))));
-
-					// TODO: Write texture groups
-
-					bkgroot.appendChild(createElement(doc,"For3D", //$NON-NLS-1$
-							boolToString((Boolean) bkg.get(PBackground.FOR3D))));
-
-					int width = bkg.getWidth(),
-					height = bkg.getHeight();
-
-					bkgroot.appendChild(createElement(doc,"width",Integer.toString(width))); //$NON-NLS-1$
-					bkgroot.appendChild(createElement(doc,"height",Integer.toString(height))); //$NON-NLS-1$
-
-					bkgroot.appendChild(createElement(doc,"data","images\\" + bkg.getName() + ".png")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-					if (width > 0 && height > 0)
-						{
-						File outputfile = new File(Util.getPOSIXPath(fname + "images\\" + bkg.getName() + ".png")); //$NON-NLS-1$ //$NON-NLS-2$
-						ImageIO.write(bkg.getBackgroundImage(),"png",outputfile); //$NON-NLS-1$
-						}
-
-					File file = new File(Util.getPOSIXPath(fname + resNode.getUserObject().toString() + ".background.gmx")); //$NON-NLS-1$
-					transformDocumentUnchecked(f, doc, file);
-
-					domRoot.appendChild(res);
-					break;
-				}
+			File outputfile = new File(Util.getPOSIXPath(fname + "images\\" + bkg.getName() + ".png")); //$NON-NLS-1$ //$NON-NLS-2$
+			ImageIO.write(bkg.getBackgroundImage(),"png",outputfile); //$NON-NLS-1$
 			}
+
+		File file = new File(Util.getPOSIXPath(fname + resNode.getUserObject().toString() + ".background.gmx")); //$NON-NLS-1$
+		transformDocumentUnchecked(f, doc, file);
+
+		domRoot.appendChild(res);
 		}
 
-	private static void writePaths(ProjectFileContext c, ResNode root, Element domRoot)
+	private static void writePath(ProjectFileContext c, ResNode resNode, Element domRoot)
 			throws IOException
 		{
 		ProjectFile f = c.f;
 		Document dom = c.dom;
 
-		String name = root.getUserObject().toString();
-		if (root.status == ResNode.STATUS_PRIMARY) name = "paths"; //$NON-NLS-1$
+		Path path = (Path) resNode.getRes().get();
+		Element res = dom.createElement("path"); //$NON-NLS-1$
+		String fname = f.getDirectory() + "\\paths\\"; //$NON-NLS-1$
+		res.setTextContent("paths\\" + path.getName()); //$NON-NLS-1$
+		File pathsFile = new File(Util.getPOSIXPath(f.getDirectory() + "/paths")); //$NON-NLS-1$
+		pathsFile.mkdir();
 
-		Element pnode = dom.createElement("paths"); //$NON-NLS-1$
-		pnode.setAttribute("name",name); //$NON-NLS-1$
-		domRoot.appendChild(pnode);
-		domRoot = pnode;
+		Document doc = documentBuilder.newDocument();
 
-		Vector<ResNode> children = root.getChildren();
-		if (children == null) return;
-		for (Object obj : children)
+		Element pathroot = doc.createElement("path"); //$NON-NLS-1$
+		doc.appendChild(pathroot);
+
+		int kind = path.get(PPath.SMOOTH) ? 1 : 0;
+		pathroot.appendChild(createElement(doc,"kind",Integer.toString(kind))); //$NON-NLS-1$
+		int closed = path.get(PPath.CLOSED) ? -1 : 0;
+		pathroot.appendChild(createElement(doc,"closed",Integer.toString(closed))); //$NON-NLS-1$
+		pathroot.appendChild(createElement(doc,"precision",path.get(PPath.PRECISION).toString())); //$NON-NLS-1$
+		pathroot.appendChild(createElement(doc,"backroom", //$NON-NLS-1$
+				Integer.toString(getId((ResourceReference<?>)path.get(PPath.BACKGROUND_ROOM)))));
+		pathroot.appendChild(createElement(doc,"hsnap",path.get(PPath.SNAP_X).toString())); //$NON-NLS-1$
+		pathroot.appendChild(createElement(doc,"vsnap",path.get(PPath.SNAP_Y).toString())); //$NON-NLS-1$
+
+		Element rootpoint = doc.createElement("points"); //$NON-NLS-1$
+		pathroot.appendChild(rootpoint);
+		for (PathPoint p : path.points)
 			{
-			if (!(obj instanceof ResNode)) continue;
-
-			ResNode resNode = (ResNode) obj;
-			switch (resNode.status)
-				{
-				case ResNode.STATUS_PRIMARY:
-				case ResNode.STATUS_GROUP:
-					writePaths(c,resNode,domRoot);
-					break;
-				case ResNode.STATUS_SECONDARY:
-					Path path = (Path) resNode.getRes().get();
-					Element res = dom.createElement("path"); //$NON-NLS-1$
-					String fname = f.getDirectory() + "\\paths\\"; //$NON-NLS-1$
-					res.setTextContent("paths\\" + path.getName()); //$NON-NLS-1$
-					File pathsFile = new File(Util.getPOSIXPath(f.getDirectory() + "/paths")); //$NON-NLS-1$
-					pathsFile.mkdir();
-
-					Document doc = documentBuilder.newDocument();
-
-					Element pathroot = doc.createElement("path"); //$NON-NLS-1$
-					doc.appendChild(pathroot);
-
-					int kind = path.get(PPath.SMOOTH) ? 1 : 0;
-					pathroot.appendChild(createElement(doc,"kind",Integer.toString(kind))); //$NON-NLS-1$
-					int closed = path.get(PPath.CLOSED) ? -1 : 0;
-					pathroot.appendChild(createElement(doc,"closed",Integer.toString(closed))); //$NON-NLS-1$
-					pathroot.appendChild(createElement(doc,"precision",path.get(PPath.PRECISION).toString())); //$NON-NLS-1$
-					pathroot.appendChild(createElement(doc,"backroom", //$NON-NLS-1$
-							Integer.toString(getId((ResourceReference<?>)path.get(PPath.BACKGROUND_ROOM)))));
-					pathroot.appendChild(createElement(doc,"hsnap",path.get(PPath.SNAP_X).toString())); //$NON-NLS-1$
-					pathroot.appendChild(createElement(doc,"vsnap",path.get(PPath.SNAP_Y).toString())); //$NON-NLS-1$
-
-					Element rootpoint = doc.createElement("points"); //$NON-NLS-1$
-					pathroot.appendChild(rootpoint);
-					for (PathPoint p : path.points)
-						{
-						rootpoint.appendChild(createElement(doc,"point", //$NON-NLS-1$
-								p.getX() + "," + p.getY() + ',' + p.getSpeed())); //$NON-NLS-1$
-						}
-
-					File file = new File(Util.getPOSIXPath(fname + path.getName() + ".path.gmx")); //$NON-NLS-1$
-					transformDocumentUnchecked(f, doc, file);
-
-					domRoot.appendChild(res);
-					break;
-				}
+			rootpoint.appendChild(createElement(doc,"point", //$NON-NLS-1$
+					p.getX() + "," + p.getY() + ',' + p.getSpeed())); //$NON-NLS-1$
 			}
+
+		File file = new File(Util.getPOSIXPath(fname + path.getName() + ".path.gmx")); //$NON-NLS-1$
+		transformDocumentUnchecked(f, doc, file);
+
+		domRoot.appendChild(res);
 		}
 
-	private static void writeScripts(ProjectFileContext c, ResNode root, Element domRoot)
+	private static void writeScript(ProjectFileContext c, ResNode resNode, Element domRoot)
 			throws IOException
 		{
 		ProjectFile f = c.f;
 		Document dom = c.dom;
 
-		String name = root.getUserObject().toString();
-		if (root.status == ResNode.STATUS_PRIMARY) name = "scripts"; //$NON-NLS-1$
-
-		Element pnode = dom.createElement("scripts"); //$NON-NLS-1$
-		pnode.setAttribute("name",name); //$NON-NLS-1$
-		domRoot.appendChild(pnode);
-		domRoot = pnode;
-
-		Vector<ResNode> children = root.getChildren();
-		if (children == null) return;
-		for (Object obj : children)
+		Script scr = (Script) resNode.getRes().get();
+		Element res = dom.createElement("script"); //$NON-NLS-1$
+		String fname = "scripts\\" + scr.getName() + ".gml"; //$NON-NLS-1$ //$NON-NLS-2$
+		res.setTextContent(fname);
+		File file = new File(Util.getPOSIXPath(f.getDirectory() + "/scripts")); //$NON-NLS-1$
+		file.mkdir();
+		Writer out = null;
+		try
 			{
-			if (!(obj instanceof ResNode)) continue;
-
-			ResNode resNode = (ResNode) obj;
-			switch (resNode.status)
-				{
-				case ResNode.STATUS_PRIMARY:
-				case ResNode.STATUS_GROUP:
-					writeScripts(c,resNode,domRoot);
-					break;
-				case ResNode.STATUS_SECONDARY:
-					Script scr = (Script) resNode.getRes().get();
-					Element res = dom.createElement("script"); //$NON-NLS-1$
-					String fname = "scripts\\" + scr.getName() + ".gml"; //$NON-NLS-1$ //$NON-NLS-2$
-					res.setTextContent(fname);
-					File file = new File(Util.getPOSIXPath(f.getDirectory() + "/scripts")); //$NON-NLS-1$
-					file.mkdir();
-					Writer out = null;
-					try
-						{
-						out = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(
-								Util.getPOSIXPath(f.getDirectory() + '/' + Util.getPOSIXPath(fname))),"UTF-8")); //$NON-NLS-1$
-						out.write((String) scr.properties.get(PScript.CODE));
-						}
-					finally
-						{
-						out.close();
-						}
-
-					domRoot.appendChild(res);
-					break;
-				}
+			out = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(
+					Util.getPOSIXPath(f.getDirectory() + '/' + Util.getPOSIXPath(fname))),"UTF-8")); //$NON-NLS-1$
+			out.write((String) scr.properties.get(PScript.CODE));
 			}
+		finally
+			{
+			out.close();
+			}
+
+		domRoot.appendChild(res);
 		}
 
-	private static void writeShaders(ProjectFileContext c, ResNode root, Element domRoot)
+	private static void writeShader(ProjectFileContext c, ResNode resNode, Element domRoot)
 			throws IOException
 		{
 		ProjectFile f = c.f;
 		Document dom = c.dom;
 
-		String name = root.getUserObject().toString();
-		if (root.status == ResNode.STATUS_PRIMARY) name = "shaders"; //$NON-NLS-1$
-
-		Element pnode = dom.createElement("shaders"); //$NON-NLS-1$
-		pnode.setAttribute("name",name); //$NON-NLS-1$
-		domRoot.appendChild(pnode);
-		domRoot = pnode;
-
-		Vector<ResNode> children = root.getChildren();
-		if (children == null) return;
-		for (Object obj : children)
+		Shader shr = (Shader) resNode.getRes().get();
+		Element res = dom.createElement("shader"); //$NON-NLS-1$
+		String fname = "shaders\\" + shr.getName() + ".shader"; //$NON-NLS-1$ //$NON-NLS-2$
+		res.setTextContent(fname);
+		res.setAttribute("type",shr.properties.get(PShader.TYPE).toString()); //$NON-NLS-1$
+		File file = new File(Util.getPOSIXPath(f.getDirectory() + "/shaders")); //$NON-NLS-1$
+		file.mkdir();
+		Writer out = null;
+		try
 			{
-			if (!(obj instanceof ResNode)) continue;
-
-			ResNode resNode = (ResNode) obj;
-			switch (resNode.status)
-				{
-				case ResNode.STATUS_PRIMARY:
-				case ResNode.STATUS_GROUP:
-					writeShaders(c,resNode,domRoot);
-					break;
-				case ResNode.STATUS_SECONDARY:
-					Shader shr = (Shader) resNode.getRes().get();
-					Element res = dom.createElement("shader"); //$NON-NLS-1$
-					String fname = "shaders\\" + shr.getName() + ".shader"; //$NON-NLS-1$ //$NON-NLS-2$
-					res.setTextContent(fname);
-					res.setAttribute("type",shr.properties.get(PShader.TYPE).toString()); //$NON-NLS-1$
-					File file = new File(Util.getPOSIXPath(f.getDirectory() + "/shaders")); //$NON-NLS-1$
-					file.mkdir();
-					Writer out = null;
-					try
-						{
-						out = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(
-								Util.getPOSIXPath(f.getDirectory() + '/' + fname)),"UTF-8"));
-						String code = shr.properties.get(PShader.VERTEX)
-								+ ('\n' + GMXFileReader.STUPID_SHADER_MARKER)
-								+ shr.properties.get(PShader.FRAGMENT);
-						out.write(code);
-						}
-					finally
-						{
-						out.close();
-						}
-
-					domRoot.appendChild(res);
-					break;
-				}
+			out = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(
+					Util.getPOSIXPath(f.getDirectory() + '/' + fname)),"UTF-8"));
+			String code = shr.properties.get(PShader.VERTEX)
+					+ ('\n' + GMXFileReader.STUPID_SHADER_MARKER)
+					+ shr.properties.get(PShader.FRAGMENT);
+			out.write(code);
 			}
+		finally
+			{
+			out.close();
+			}
+
+		domRoot.appendChild(res);
 		}
 
-	private static void writeFonts(ProjectFileContext c, ResNode root, Element domRoot)
+	private static void writeFont(ProjectFileContext c, ResNode resNode, Element domRoot)
 			throws IOException
 		{
 		ProjectFile f = c.f;
 		Document dom = c.dom;
 
-		String name = root.getUserObject().toString();
-		if (root.status == ResNode.STATUS_PRIMARY) name = "fonts"; //$NON-NLS-1$
+		Font fnt = (Font) resNode.getRes().get();
+		Element res = dom.createElement("font"); //$NON-NLS-1$
+		String fname = f.getDirectory() + "\\fonts\\"; //$NON-NLS-1$
+		res.setTextContent("fonts\\" + fnt.getName()); //$NON-NLS-1$
+		File fontsFile = new File(Util.getPOSIXPath(fname));
+		fontsFile.mkdirs();
 
-		Element pnode = dom.createElement("fonts"); //$NON-NLS-1$
-		pnode.setAttribute("name",name); //$NON-NLS-1$
-		domRoot.appendChild(pnode);
-		domRoot = pnode;
+		Document doc = documentBuilder.newDocument();
 
-		Vector<ResNode> children = root.getChildren();
-		if (children == null) return;
-		for (Object obj : children)
+		Element fntroot = doc.createElement("font"); //$NON-NLS-1$
+		doc.appendChild(fntroot);
+
+		fntroot.appendChild(createElement(doc,"name",fnt.get(PFont.FONT_NAME).toString())); //$NON-NLS-1$
+		fntroot.appendChild(createElement(doc,"size",fnt.get(PFont.SIZE).toString())); //$NON-NLS-1$
+		fntroot.appendChild(createElement(doc,"bold",boolToString((Boolean) fnt.get(PFont.BOLD)))); //$NON-NLS-1$
+		fntroot.appendChild(createElement(doc,"italic", //$NON-NLS-1$
+				boolToString((Boolean) fnt.get(PFont.ITALIC))));
+		fntroot.appendChild(createElement(doc,"charset",fnt.get(PFont.CHARSET).toString())); //$NON-NLS-1$
+		fntroot.appendChild(createElement(doc,"aa",fnt.get(PFont.ANTIALIAS).toString())); //$NON-NLS-1$
+
+		Element rangeroot = doc.createElement("ranges"); //$NON-NLS-1$
+		fntroot.appendChild(rangeroot);
+		for (CharacterRange cr : fnt.characterRanges)
 			{
-			if (!(obj instanceof ResNode)) continue;
-
-			ResNode resNode = (ResNode) obj;
-			switch (resNode.status)
-				{
-				case ResNode.STATUS_PRIMARY:
-				case ResNode.STATUS_GROUP:
-					writeFonts(c,resNode,domRoot);
-					break;
-				case ResNode.STATUS_SECONDARY:
-					Font fnt = (Font) resNode.getRes().get();
-					Element res = dom.createElement("font"); //$NON-NLS-1$
-					String fname = f.getDirectory() + "\\fonts\\"; //$NON-NLS-1$
-					res.setTextContent("fonts\\" + fnt.getName()); //$NON-NLS-1$
-					File fontsFile = new File(Util.getPOSIXPath(fname));
-					fontsFile.mkdirs();
-
-					Document doc = documentBuilder.newDocument();
-
-					Element fntroot = doc.createElement("font"); //$NON-NLS-1$
-					doc.appendChild(fntroot);
-
-					fntroot.appendChild(createElement(doc,"name",fnt.get(PFont.FONT_NAME).toString())); //$NON-NLS-1$
-					fntroot.appendChild(createElement(doc,"size",fnt.get(PFont.SIZE).toString())); //$NON-NLS-1$
-					fntroot.appendChild(createElement(doc,"bold",boolToString((Boolean) fnt.get(PFont.BOLD)))); //$NON-NLS-1$
-					fntroot.appendChild(createElement(doc,"italic", //$NON-NLS-1$
-							boolToString((Boolean) fnt.get(PFont.ITALIC))));
-					fntroot.appendChild(createElement(doc,"charset",fnt.get(PFont.CHARSET).toString())); //$NON-NLS-1$
-					fntroot.appendChild(createElement(doc,"aa",fnt.get(PFont.ANTIALIAS).toString())); //$NON-NLS-1$
-
-					Element rangeroot = doc.createElement("ranges"); //$NON-NLS-1$
-					fntroot.appendChild(rangeroot);
-					for (CharacterRange cr : fnt.characterRanges)
-						{
-						rangeroot.appendChild(createElement(
-								doc,
-								"range0", //$NON-NLS-1$
-								cr.properties.get(PCharacterRange.RANGE_MIN) + "," //$NON-NLS-1$
-										+ cr.properties.get(PCharacterRange.RANGE_MAX)));
-						}
-
-					Element glyphroot = doc.createElement("glyphs"); //$NON-NLS-1$
-					fntroot.appendChild(glyphroot);
-					for (GlyphMetric gm : fnt.glyphMetrics)
-						{
-						Element gelement = doc.createElement("glyph"); //$NON-NLS-1$
-						gelement.setAttribute("character",gm.properties.get(PGlyphMetric.CHARACTER).toString()); //$NON-NLS-1$
-						gelement.setAttribute("x",gm.properties.get(PGlyphMetric.X).toString()); //$NON-NLS-1$
-						gelement.setAttribute("y",gm.properties.get(PGlyphMetric.Y).toString()); //$NON-NLS-1$
-						gelement.setAttribute("w",gm.properties.get(PGlyphMetric.W).toString()); //$NON-NLS-1$
-						gelement.setAttribute("h",gm.properties.get(PGlyphMetric.H).toString()); //$NON-NLS-1$
-						gelement.setAttribute("shift",gm.properties.get(PGlyphMetric.SHIFT).toString()); //$NON-NLS-1$
-						gelement.setAttribute("offset",gm.properties.get(PGlyphMetric.OFFSET).toString()); //$NON-NLS-1$
-						glyphroot.appendChild(gelement);
-						}
-
-					// TODO: Move glyph renderer from the plugin to LGM and write glyphs here
-					fntroot.appendChild(createElement(doc,"image",fnt.getName() + ".png")); //$NON-NLS-1$ //$NON-NLS-2$
-					//File outputfile = new File(getUnixPath(fname + fnt.getName() + ".png"));
-					/*
-					try
-						{
-						ImageIO.write(fnt.getBackgroundImage(), "png", outputfile);
-						}
-					catch (IOException e)
-						{
-						// TODO Auto-generated catch block
-						e.printStackTrace();
-						}
-					*/
-
-					File file = new File(Util.getPOSIXPath(fname + fnt.getName() + ".font.gmx")); //$NON-NLS-1$
-					transformDocumentUnchecked(f, doc, file);
-
-					domRoot.appendChild(res);
-					break;
-				}
+			rangeroot.appendChild(createElement(
+					doc,
+					"range0", //$NON-NLS-1$
+					cr.properties.get(PCharacterRange.RANGE_MIN) + "," //$NON-NLS-1$
+							+ cr.properties.get(PCharacterRange.RANGE_MAX)));
 			}
+
+		Element glyphroot = doc.createElement("glyphs"); //$NON-NLS-1$
+		fntroot.appendChild(glyphroot);
+		for (GlyphMetric gm : fnt.glyphMetrics)
+			{
+			Element gelement = doc.createElement("glyph"); //$NON-NLS-1$
+			gelement.setAttribute("character",gm.properties.get(PGlyphMetric.CHARACTER).toString()); //$NON-NLS-1$
+			gelement.setAttribute("x",gm.properties.get(PGlyphMetric.X).toString()); //$NON-NLS-1$
+			gelement.setAttribute("y",gm.properties.get(PGlyphMetric.Y).toString()); //$NON-NLS-1$
+			gelement.setAttribute("w",gm.properties.get(PGlyphMetric.W).toString()); //$NON-NLS-1$
+			gelement.setAttribute("h",gm.properties.get(PGlyphMetric.H).toString()); //$NON-NLS-1$
+			gelement.setAttribute("shift",gm.properties.get(PGlyphMetric.SHIFT).toString()); //$NON-NLS-1$
+			gelement.setAttribute("offset",gm.properties.get(PGlyphMetric.OFFSET).toString()); //$NON-NLS-1$
+			glyphroot.appendChild(gelement);
+			}
+
+		// TODO: Move glyph renderer from the plugin to LGM and write glyphs here
+		fntroot.appendChild(createElement(doc,"image",fnt.getName() + ".png")); //$NON-NLS-1$ //$NON-NLS-2$
+		//File outputfile = new File(getUnixPath(fname + fnt.getName() + ".png"));
+		/*
+		try
+			{
+			ImageIO.write(fnt.getBackgroundImage(), "png", outputfile);
+			}
+		catch (IOException e)
+			{
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+			}
+		*/
+
+		File file = new File(Util.getPOSIXPath(fname + fnt.getName() + ".font.gmx")); //$NON-NLS-1$
+		transformDocumentUnchecked(f, doc, file);
+
+		domRoot.appendChild(res);
 		}
 
-	private static void writeTimelines(ProjectFileContext c, ResNode root, Element domRoot)
+	private static void writeTimeline(ProjectFileContext c, ResNode resNode, Element domRoot)
 			throws IOException
 		{
 		ProjectFile f = c.f;
 		Document dom = c.dom;
 
-		String name = root.getUserObject().toString();
-		if (root.status == ResNode.STATUS_PRIMARY) name = "timelines"; //$NON-NLS-1$
+		Timeline timeline = (Timeline) resNode.getRes().get();
+		Element res = dom.createElement("timeline"); //$NON-NLS-1$
+		String fname = f.getDirectory() + "\\timelines\\"; //$NON-NLS-1$
+		res.setTextContent("timelines\\" + timeline.getName()); //$NON-NLS-1$
+		File timelinesFile = new File(Util.getPOSIXPath(f.getDirectory() + "/timelines")); //$NON-NLS-1$
+		timelinesFile.mkdir();
 
-		Element pnode = dom.createElement("timelines"); //$NON-NLS-1$
-		pnode.setAttribute("name",name); //$NON-NLS-1$
-		domRoot.appendChild(pnode);
-		domRoot = pnode;
+		Document doc = documentBuilder.newDocument();
 
-		Vector<ResNode> children = root.getChildren();
-		if (children == null) return;
-		for (Object obj : children)
+		Element tmlroot = doc.createElement("timeline"); //$NON-NLS-1$
+		doc.appendChild(tmlroot);
+
+		for (Moment mom : timeline.moments)
 			{
-			if (!(obj instanceof ResNode)) continue;
-
-			ResNode resNode = (ResNode) obj;
-			switch (resNode.status)
-				{
-				case ResNode.STATUS_PRIMARY:
-				case ResNode.STATUS_GROUP:
-					writeTimelines(c,resNode,domRoot);
-					break;
-				case ResNode.STATUS_SECONDARY:
-					Timeline timeline = (Timeline) resNode.getRes().get();
-					Element res = dom.createElement("timeline"); //$NON-NLS-1$
-					String fname = f.getDirectory() + "\\timelines\\"; //$NON-NLS-1$
-					res.setTextContent("timelines\\" + timeline.getName()); //$NON-NLS-1$
-					File timelinesFile = new File(Util.getPOSIXPath(f.getDirectory() + "/timelines")); //$NON-NLS-1$
-					timelinesFile.mkdir();
-
-					Document doc = documentBuilder.newDocument();
-
-					Element tmlroot = doc.createElement("timeline"); //$NON-NLS-1$
-					doc.appendChild(tmlroot);
-
-					for (Moment mom : timeline.moments)
-						{
-						Element entroot = doc.createElement("entry"); //$NON-NLS-1$
-						tmlroot.appendChild(entroot);
-						entroot.appendChild(createElement(doc,"step",Integer.toString(mom.stepNo))); //$NON-NLS-1$
-						Element evtroot = doc.createElement("event"); //$NON-NLS-1$
-						entroot.appendChild(evtroot);
-						writeActions(doc,evtroot,mom);
-						}
-
-					File file = new File(Util.getPOSIXPath(fname + timeline.getName() + ".timeline.gmx")); //$NON-NLS-1$
-					transformDocumentUnchecked(f, doc, file);
-
-					domRoot.appendChild(res);
-					break;
-				}
+			Element entroot = doc.createElement("entry"); //$NON-NLS-1$
+			tmlroot.appendChild(entroot);
+			entroot.appendChild(createElement(doc,"step",Integer.toString(mom.stepNo))); //$NON-NLS-1$
+			Element evtroot = doc.createElement("event"); //$NON-NLS-1$
+			entroot.appendChild(evtroot);
+			writeActions(doc,evtroot,mom);
 			}
+
+		File file = new File(Util.getPOSIXPath(fname + timeline.getName() + ".timeline.gmx")); //$NON-NLS-1$
+		transformDocumentUnchecked(f, doc, file);
+
+		domRoot.appendChild(res);
 		}
 
-	private static void writeGmObjects(ProjectFileContext c, ResNode root, Element domRoot)
+	private static void writeGmObject(ProjectFileContext c, ResNode resNode, Element domRoot)
 			throws IOException
 		{
 		ProjectFile f = c.f;
 		Document dom = c.dom;
 
-		String name = root.getUserObject().toString();
-		if (root.status == ResNode.STATUS_PRIMARY) name = "objects"; //$NON-NLS-1$
+		GmObject object = (GmObject) resNode.getRes().get();
+		Element res = dom.createElement("object"); //$NON-NLS-1$
+		String fname = f.getDirectory() + "\\objects\\"; //$NON-NLS-1$
+		res.setTextContent("objects\\" + object.getName()); //$NON-NLS-1$
+		File objectsFile = new File(Util.getPOSIXPath(f.getDirectory() + "/objects")); //$NON-NLS-1$
+		objectsFile.mkdir();
 
-		Element pnode = dom.createElement("objects"); //$NON-NLS-1$
-		pnode.setAttribute("name",name); //$NON-NLS-1$
-		domRoot.appendChild(pnode);
-		domRoot = pnode;
+		Document doc = documentBuilder.newDocument();
 
-		Vector<ResNode> children = root.getChildren();
-		if (children == null) return;
-		for (Object obj : children)
+		Element objroot = doc.createElement("object"); //$NON-NLS-1$
+		doc.appendChild(objroot);
+		objroot.appendChild(createElement(doc,"spriteName", //$NON-NLS-1$
+				getName((ResourceReference<?>)object.get(PGmObject.SPRITE))));
+		objroot.appendChild(createElement(doc,"solid", //$NON-NLS-1$
+				boolToString((Boolean) object.get(PGmObject.SOLID))));
+		objroot.appendChild(createElement(doc,"visible", //$NON-NLS-1$
+				boolToString((Boolean) object.get(PGmObject.VISIBLE))));
+		objroot.appendChild(createElement(doc,"depth",object.get(PGmObject.DEPTH).toString())); //$NON-NLS-1$
+		objroot.appendChild(createElement(doc,"persistent", //$NON-NLS-1$
+				boolToString((Boolean) object.get(PGmObject.PERSISTENT))));
+		objroot.appendChild(createElement(doc,"maskName", //$NON-NLS-1$
+				getName((ResourceReference<?>)object.get(PGmObject.MASK))));
+		objroot.appendChild(createElement(doc,"parentName", //$NON-NLS-1$
+				getName((ResourceReference<?>)object.get(PGmObject.PARENT))));
+
+		Element evtroot = doc.createElement("events"); //$NON-NLS-1$
+		for (int i = 0; i < object.mainEvents.size(); i++)
 			{
-			if (!(obj instanceof ResNode)) continue;
-
-			ResNode resNode = (ResNode) obj;
-			switch (resNode.status)
+			MainEvent me = object.mainEvents.get(i);
+			for (int k = me.events.size(); k > 0; k--)
 				{
-				case ResNode.STATUS_PRIMARY:
-				case ResNode.STATUS_GROUP:
-					writeGmObjects(c,resNode,domRoot);
-					break;
-				case ResNode.STATUS_SECONDARY:
-					GmObject object = (GmObject) resNode.getRes().get();
-					Element res = dom.createElement("object"); //$NON-NLS-1$
-					String fname = f.getDirectory() + "\\objects\\"; //$NON-NLS-1$
-					res.setTextContent("objects\\" + object.getName()); //$NON-NLS-1$
-					File objectsFile = new File(Util.getPOSIXPath(f.getDirectory() + "/objects")); //$NON-NLS-1$
-					objectsFile.mkdir();
-
-					Document doc = documentBuilder.newDocument();
-
-					Element objroot = doc.createElement("object"); //$NON-NLS-1$
-					doc.appendChild(objroot);
-					objroot.appendChild(createElement(doc,"spriteName", //$NON-NLS-1$
-							getName((ResourceReference<?>)object.get(PGmObject.SPRITE))));
-					objroot.appendChild(createElement(doc,"solid", //$NON-NLS-1$
-							boolToString((Boolean) object.get(PGmObject.SOLID))));
-					objroot.appendChild(createElement(doc,"visible", //$NON-NLS-1$
-							boolToString((Boolean) object.get(PGmObject.VISIBLE))));
-					objroot.appendChild(createElement(doc,"depth",object.get(PGmObject.DEPTH).toString())); //$NON-NLS-1$
-					objroot.appendChild(createElement(doc,"persistent", //$NON-NLS-1$
-							boolToString((Boolean) object.get(PGmObject.PERSISTENT))));
-					objroot.appendChild(createElement(doc,"maskName", //$NON-NLS-1$
-							getName((ResourceReference<?>)object.get(PGmObject.MASK))));
-					objroot.appendChild(createElement(doc,"parentName", //$NON-NLS-1$
-							getName((ResourceReference<?>)object.get(PGmObject.PARENT))));
-
-					Element evtroot = doc.createElement("events"); //$NON-NLS-1$
-					for (int i = 0; i < object.mainEvents.size(); i++)
-						{
-						MainEvent me = object.mainEvents.get(i);
-						for (int k = me.events.size(); k > 0; k--)
-							{
-							Event ev = me.events.get(k - 1);
-							Element evtelement = doc.createElement("event"); //$NON-NLS-1$
-							evtelement.setAttribute("eventtype",Integer.toString(ev.mainId)); //$NON-NLS-1$
-							if (ev.mainId == MainEvent.EV_COLLISION)
-								{
-								evtelement.setAttribute("ename", //$NON-NLS-1$
-										getName((ResourceReference<GmObject>)ev.other));
-								}
-							else
-								{
-								evtelement.setAttribute("enumb",Integer.toString(ev.id)); //$NON-NLS-1$
-								}
-							evtroot.appendChild(evtelement);
-							writeActions(doc,evtelement,ev);
-							}
-						}
-					objroot.appendChild(evtroot);
-
-					// Physics Properties
-					objroot.appendChild(createElement(doc,"PhysicsObject", //$NON-NLS-1$
-							boolToString((Boolean) object.get(PGmObject.PHYSICS_OBJECT))));
-					objroot.appendChild(createElement(doc,"PhysicsObjectSensor", //$NON-NLS-1$
-							boolToString((Boolean) object.get(PGmObject.PHYSICS_SENSOR))));
-					objroot.appendChild(createElement(doc,"PhysicsObjectShape", //$NON-NLS-1$
-							ProjectFile.SHAPE_CODE.get(object.get(PGmObject.PHYSICS_SHAPE)).toString()));
-					objroot.appendChild(createElement(doc,"PhysicsObjectDensity", //$NON-NLS-1$
-							Double.toString((Double) object.get(PGmObject.PHYSICS_DENSITY))));
-					objroot.appendChild(createElement(doc,"PhysicsObjectRestitution", //$NON-NLS-1$
-							Double.toString((Double) object.get(PGmObject.PHYSICS_RESTITUTION))));
-					objroot.appendChild(createElement(doc,"PhysicsObjectGroup", //$NON-NLS-1$
-							Integer.toString((Integer) object.get(PGmObject.PHYSICS_GROUP))));
-					objroot.appendChild(createElement(doc,"PhysicsObjectLinearDamping", //$NON-NLS-1$
-							Double.toString((Double) object.get(PGmObject.PHYSICS_DAMPING_LINEAR))));
-					objroot.appendChild(createElement(doc,"PhysicsObjectAngularDamping", //$NON-NLS-1$
-							Double.toString((Double) object.get(PGmObject.PHYSICS_DAMPING_ANGULAR))));
-					objroot.appendChild(createElement(doc,"PhysicsObjectFriction", //$NON-NLS-1$
-							Double.toString((Double) object.get(PGmObject.PHYSICS_FRICTION))));
-					objroot.appendChild(createElement(doc,"PhysicsObjectAwake", //$NON-NLS-1$
-							boolToString((Boolean) object.get(PGmObject.PHYSICS_AWAKE))));
-					objroot.appendChild(createElement(doc,"PhysicsObjectKinematic", //$NON-NLS-1$
-							boolToString((Boolean) object.get(PGmObject.PHYSICS_KINEMATIC))));
-
-					Element pointsroot = doc.createElement("PhysicsShapePoints"); //$NON-NLS-1$
-					for (ShapePoint point : object.shapePoints)
-						{
-						pointsroot.appendChild(createElement(doc,"point",point.getX() + "," + point.getY())); //$NON-NLS-1$ //$NON-NLS-2$
-						}
-					objroot.appendChild(pointsroot);
-
-					File file = new File(Util.getPOSIXPath(fname + object.getName() + ".object.gmx")); //$NON-NLS-1$
-					transformDocumentUnchecked(f, doc, file);
-
-					domRoot.appendChild(res);
-					break;
+				Event ev = me.events.get(k - 1);
+				Element evtelement = doc.createElement("event"); //$NON-NLS-1$
+				evtelement.setAttribute("eventtype",Integer.toString(ev.mainId)); //$NON-NLS-1$
+				if (ev.mainId == MainEvent.EV_COLLISION)
+					{
+					evtelement.setAttribute("ename", //$NON-NLS-1$
+							getName((ResourceReference<GmObject>)ev.other));
+					}
+				else
+					{
+					evtelement.setAttribute("enumb",Integer.toString(ev.id)); //$NON-NLS-1$
+					}
+				evtroot.appendChild(evtelement);
+				writeActions(doc,evtelement,ev);
 				}
 			}
+		objroot.appendChild(evtroot);
+
+		// Physics Properties
+		objroot.appendChild(createElement(doc,"PhysicsObject", //$NON-NLS-1$
+				boolToString((Boolean) object.get(PGmObject.PHYSICS_OBJECT))));
+		objroot.appendChild(createElement(doc,"PhysicsObjectSensor", //$NON-NLS-1$
+				boolToString((Boolean) object.get(PGmObject.PHYSICS_SENSOR))));
+		objroot.appendChild(createElement(doc,"PhysicsObjectShape", //$NON-NLS-1$
+				ProjectFile.SHAPE_CODE.get(object.get(PGmObject.PHYSICS_SHAPE)).toString()));
+		objroot.appendChild(createElement(doc,"PhysicsObjectDensity", //$NON-NLS-1$
+				Double.toString((Double) object.get(PGmObject.PHYSICS_DENSITY))));
+		objroot.appendChild(createElement(doc,"PhysicsObjectRestitution", //$NON-NLS-1$
+				Double.toString((Double) object.get(PGmObject.PHYSICS_RESTITUTION))));
+		objroot.appendChild(createElement(doc,"PhysicsObjectGroup", //$NON-NLS-1$
+				Integer.toString((Integer) object.get(PGmObject.PHYSICS_GROUP))));
+		objroot.appendChild(createElement(doc,"PhysicsObjectLinearDamping", //$NON-NLS-1$
+				Double.toString((Double) object.get(PGmObject.PHYSICS_DAMPING_LINEAR))));
+		objroot.appendChild(createElement(doc,"PhysicsObjectAngularDamping", //$NON-NLS-1$
+				Double.toString((Double) object.get(PGmObject.PHYSICS_DAMPING_ANGULAR))));
+		objroot.appendChild(createElement(doc,"PhysicsObjectFriction", //$NON-NLS-1$
+				Double.toString((Double) object.get(PGmObject.PHYSICS_FRICTION))));
+		objroot.appendChild(createElement(doc,"PhysicsObjectAwake", //$NON-NLS-1$
+				boolToString((Boolean) object.get(PGmObject.PHYSICS_AWAKE))));
+		objroot.appendChild(createElement(doc,"PhysicsObjectKinematic", //$NON-NLS-1$
+				boolToString((Boolean) object.get(PGmObject.PHYSICS_KINEMATIC))));
+
+		Element pointsroot = doc.createElement("PhysicsShapePoints"); //$NON-NLS-1$
+		for (ShapePoint point : object.shapePoints)
+			{
+			pointsroot.appendChild(createElement(doc,"point",point.getX() + "," + point.getY())); //$NON-NLS-1$ //$NON-NLS-2$
+			}
+		objroot.appendChild(pointsroot);
+
+		File file = new File(Util.getPOSIXPath(fname + object.getName() + ".object.gmx")); //$NON-NLS-1$
+		transformDocumentUnchecked(f, doc, file);
+
+		domRoot.appendChild(res);
 		}
 
-	private static void writeRooms(ProjectFileContext c, ResNode root, Element domRoot)
+	private static void writeRoom(ProjectFileContext c, ResNode resNode, Element domRoot)
 			throws IOException
 		{
 		ProjectFile f = c.f;
 		Document dom = c.dom;
 
-		String name = root.getUserObject().toString();
-		if (root.status == ResNode.STATUS_PRIMARY) name = "rooms"; //$NON-NLS-1$
+		Room room = (Room) resNode.getRes().get();
+		Element res = dom.createElement("room"); //$NON-NLS-1$
+		String fname = f.getDirectory() + "\\rooms\\"; //$NON-NLS-1$
+		res.setTextContent("rooms\\" + room.getName()); //$NON-NLS-1$
+		File roomsFile = new File(Util.getPOSIXPath(f.getDirectory() + "/rooms")); //$NON-NLS-1$
+		roomsFile.mkdir();
 
-		Element pnode = dom.createElement("rooms"); //$NON-NLS-1$
-		pnode.setAttribute("name",name); //$NON-NLS-1$
-		domRoot.appendChild(pnode);
-		domRoot = pnode;
+		Document doc = documentBuilder.newDocument();
 
-		Vector<ResNode> children = root.getChildren();
-		if (children == null) return;
-		for (Object obj : children)
+		Element roomroot = doc.createElement("room"); //$NON-NLS-1$
+		doc.appendChild(roomroot);
+
+		roomroot.appendChild(createElement(doc,"caption",room.get(PRoom.CAPTION).toString())); //$NON-NLS-1$
+		roomroot.appendChild(createElement(doc,"width",room.get(PRoom.WIDTH).toString())); //$NON-NLS-1$
+		roomroot.appendChild(createElement(doc,"height",room.get(PRoom.HEIGHT).toString())); //$NON-NLS-1$
+		roomroot.appendChild(createElement(doc,"hsnap",room.get(PRoom.SNAP_X).toString())); //$NON-NLS-1$
+		roomroot.appendChild(createElement(doc,"vsnap",room.get(PRoom.SNAP_Y).toString())); //$NON-NLS-1$
+		roomroot.appendChild(createElement(doc,"isometric", //$NON-NLS-1$
+				boolToString((Boolean) room.get(PRoom.ISOMETRIC))));
+		roomroot.appendChild(createElement(doc,"speed",room.get(PRoom.SPEED).toString())); //$NON-NLS-1$
+		roomroot.appendChild(createElement(doc,"persistent", //$NON-NLS-1$
+				boolToString((Boolean) room.get(PRoom.PERSISTENT))));
+		roomroot.appendChild(createElement(doc,"colour", //$NON-NLS-1$
+				Integer.toString(Util.getGmColor((Color) room.get(PRoom.BACKGROUND_COLOR)))));
+		roomroot.appendChild(createElement(doc,"showcolour", //$NON-NLS-1$
+				boolToString((Boolean) room.get(PRoom.DRAW_BACKGROUND_COLOR))));
+		roomroot.appendChild(createElement(doc,"code",room.get(PRoom.CREATION_CODE).toString())); //$NON-NLS-1$
+		roomroot.appendChild(createElement(doc,"enableViews", //$NON-NLS-1$
+				boolToString((Boolean) room.get(PRoom.VIEWS_ENABLED))));
+		roomroot.appendChild(createElement(doc,"clearViewBackground", //$NON-NLS-1$
+				boolToString((Boolean) room.get(PRoom.VIEWS_CLEAR))));
+
+		// Write the maker settings, or basically the settings of the editor.
+		Element mkeroot = doc.createElement("makerSettings"); //$NON-NLS-1$
+		mkeroot.appendChild(createElement(doc,"isSet", //$NON-NLS-1$
+				boolToString((Boolean) room.get(PRoom.REMEMBER_WINDOW_SIZE))));
+		mkeroot.appendChild(createElement(doc,"w",room.get(PRoom.EDITOR_WIDTH).toString())); //$NON-NLS-1$
+		mkeroot.appendChild(createElement(doc,"h",room.get(PRoom.EDITOR_HEIGHT).toString())); //$NON-NLS-1$
+		mkeroot.appendChild(createElement(doc,"showGrid", //$NON-NLS-1$
+				boolToString((Boolean) room.get(PRoom.SHOW_GRID))));
+		mkeroot.appendChild(createElement(doc,"showObjects", //$NON-NLS-1$
+				boolToString((Boolean) room.get(PRoom.SHOW_OBJECTS))));
+		mkeroot.appendChild(createElement(doc,"showTiles", //$NON-NLS-1$
+				boolToString((Boolean) room.get(PRoom.SHOW_TILES))));
+		mkeroot.appendChild(createElement(doc,"showBackgrounds", //$NON-NLS-1$
+				boolToString((Boolean) room.get(PRoom.SHOW_BACKGROUNDS))));
+		mkeroot.appendChild(createElement(doc,"showForegrounds", //$NON-NLS-1$
+				boolToString((Boolean) room.get(PRoom.SHOW_FOREGROUNDS))));
+		mkeroot.appendChild(createElement(doc,"showViews", //$NON-NLS-1$
+				boolToString((Boolean) room.get(PRoom.SHOW_VIEWS))));
+		mkeroot.appendChild(createElement(doc,"deleteUnderlyingObj", //$NON-NLS-1$
+				boolToString((Boolean) room.get(PRoom.DELETE_UNDERLYING_OBJECTS))));
+		mkeroot.appendChild(createElement(doc,"deleteUnderlyingTiles", //$NON-NLS-1$
+				boolToString((Boolean) room.get(PRoom.DELETE_UNDERLYING_TILES))));
+		mkeroot.appendChild(createElement(doc,"page",room.get(PRoom.CURRENT_TAB).toString())); //$NON-NLS-1$
+		mkeroot.appendChild(createElement(doc,"xoffset",room.get(PRoom.SCROLL_BAR_X).toString())); //$NON-NLS-1$
+		mkeroot.appendChild(createElement(doc,"yoffset",room.get(PRoom.SCROLL_BAR_Y).toString())); //$NON-NLS-1$
+		roomroot.appendChild(mkeroot);
+
+		// Write Backgrounds
+		Element backroot = doc.createElement("backgrounds"); //$NON-NLS-1$
+		roomroot.appendChild(backroot);
+		for (BackgroundDef back : room.backgroundDefs) 
 			{
-			if (!(obj instanceof ResNode)) continue;
+			PropertyMap<PBackgroundDef> props = back.properties;
+			Element bckelement = doc.createElement("background"); //$NON-NLS-1$
+			backroot.appendChild(bckelement);
 
-			ResNode resNode = (ResNode) obj;
-			switch (resNode.status)
-				{
-				case ResNode.STATUS_PRIMARY:
-				case ResNode.STATUS_GROUP:
-					writeRooms(c,resNode,domRoot);
-					break;
-				case ResNode.STATUS_SECONDARY:
-					Room room = (Room) resNode.getRes().get();
-					Element res = dom.createElement("room"); //$NON-NLS-1$
-					String fname = f.getDirectory() + "\\rooms\\"; //$NON-NLS-1$
-					res.setTextContent("rooms\\" + room.getName()); //$NON-NLS-1$
-					File roomsFile = new File(Util.getPOSIXPath(f.getDirectory() + "/rooms")); //$NON-NLS-1$
-					roomsFile.mkdir();
-
-					Document doc = documentBuilder.newDocument();
-
-					Element roomroot = doc.createElement("room"); //$NON-NLS-1$
-					doc.appendChild(roomroot);
-
-					roomroot.appendChild(createElement(doc,"caption",room.get(PRoom.CAPTION).toString())); //$NON-NLS-1$
-					roomroot.appendChild(createElement(doc,"width",room.get(PRoom.WIDTH).toString())); //$NON-NLS-1$
-					roomroot.appendChild(createElement(doc,"height",room.get(PRoom.HEIGHT).toString())); //$NON-NLS-1$
-					roomroot.appendChild(createElement(doc,"hsnap",room.get(PRoom.SNAP_X).toString())); //$NON-NLS-1$
-					roomroot.appendChild(createElement(doc,"vsnap",room.get(PRoom.SNAP_Y).toString())); //$NON-NLS-1$
-					roomroot.appendChild(createElement(doc,"isometric", //$NON-NLS-1$
-							boolToString((Boolean) room.get(PRoom.ISOMETRIC))));
-					roomroot.appendChild(createElement(doc,"speed",room.get(PRoom.SPEED).toString())); //$NON-NLS-1$
-					roomroot.appendChild(createElement(doc,"persistent", //$NON-NLS-1$
-							boolToString((Boolean) room.get(PRoom.PERSISTENT))));
-					roomroot.appendChild(createElement(doc,"colour", //$NON-NLS-1$
-							Integer.toString(Util.getGmColor((Color) room.get(PRoom.BACKGROUND_COLOR)))));
-					roomroot.appendChild(createElement(doc,"showcolour", //$NON-NLS-1$
-							boolToString((Boolean) room.get(PRoom.DRAW_BACKGROUND_COLOR))));
-					roomroot.appendChild(createElement(doc,"code",room.get(PRoom.CREATION_CODE).toString())); //$NON-NLS-1$
-					roomroot.appendChild(createElement(doc,"enableViews", //$NON-NLS-1$
-							boolToString((Boolean) room.get(PRoom.VIEWS_ENABLED))));
-					roomroot.appendChild(createElement(doc,"clearViewBackground", //$NON-NLS-1$
-							boolToString((Boolean) room.get(PRoom.VIEWS_CLEAR))));
-
-					// Write the maker settings, or basically the settings of the editor.
-					Element mkeroot = doc.createElement("makerSettings"); //$NON-NLS-1$
-					mkeroot.appendChild(createElement(doc,"isSet", //$NON-NLS-1$
-							boolToString((Boolean) room.get(PRoom.REMEMBER_WINDOW_SIZE))));
-					mkeroot.appendChild(createElement(doc,"w",room.get(PRoom.EDITOR_WIDTH).toString())); //$NON-NLS-1$
-					mkeroot.appendChild(createElement(doc,"h",room.get(PRoom.EDITOR_HEIGHT).toString())); //$NON-NLS-1$
-					mkeroot.appendChild(createElement(doc,"showGrid", //$NON-NLS-1$
-							boolToString((Boolean) room.get(PRoom.SHOW_GRID))));
-					mkeroot.appendChild(createElement(doc,"showObjects", //$NON-NLS-1$
-							boolToString((Boolean) room.get(PRoom.SHOW_OBJECTS))));
-					mkeroot.appendChild(createElement(doc,"showTiles", //$NON-NLS-1$
-							boolToString((Boolean) room.get(PRoom.SHOW_TILES))));
-					mkeroot.appendChild(createElement(doc,"showBackgrounds", //$NON-NLS-1$
-							boolToString((Boolean) room.get(PRoom.SHOW_BACKGROUNDS))));
-					mkeroot.appendChild(createElement(doc,"showForegrounds", //$NON-NLS-1$
-							boolToString((Boolean) room.get(PRoom.SHOW_FOREGROUNDS))));
-					mkeroot.appendChild(createElement(doc,"showViews", //$NON-NLS-1$
-							boolToString((Boolean) room.get(PRoom.SHOW_VIEWS))));
-					mkeroot.appendChild(createElement(doc,"deleteUnderlyingObj", //$NON-NLS-1$
-							boolToString((Boolean) room.get(PRoom.DELETE_UNDERLYING_OBJECTS))));
-					mkeroot.appendChild(createElement(doc,"deleteUnderlyingTiles", //$NON-NLS-1$
-							boolToString((Boolean) room.get(PRoom.DELETE_UNDERLYING_TILES))));
-					mkeroot.appendChild(createElement(doc,"page",room.get(PRoom.CURRENT_TAB).toString())); //$NON-NLS-1$
-					mkeroot.appendChild(createElement(doc,"xoffset",room.get(PRoom.SCROLL_BAR_X).toString())); //$NON-NLS-1$
-					mkeroot.appendChild(createElement(doc,"yoffset",room.get(PRoom.SCROLL_BAR_Y).toString())); //$NON-NLS-1$
-					roomroot.appendChild(mkeroot);
-
-					// Write Backgrounds
-					Element backroot = doc.createElement("backgrounds"); //$NON-NLS-1$
-					roomroot.appendChild(backroot);
-					for (BackgroundDef back : room.backgroundDefs) 
-						{
-						PropertyMap<PBackgroundDef> props = back.properties;
-						Element bckelement = doc.createElement("background"); //$NON-NLS-1$
-						backroot.appendChild(bckelement);
-
-						bckelement.setAttribute("visible", //$NON-NLS-1$
-								boolToString((Boolean) props.get(PBackgroundDef.VISIBLE)));
-						bckelement.setAttribute("foreground", //$NON-NLS-1$
-								boolToString((Boolean) props.get(PBackgroundDef.FOREGROUND)));
-						bckelement.setAttribute("name", //$NON-NLS-1$
-								getName((ResourceReference<?>)props.get(PBackgroundDef.BACKGROUND),""));
-						bckelement.setAttribute("x",Integer.toString((Integer) props.get(PBackgroundDef.X))); //$NON-NLS-1$
-						bckelement.setAttribute("y",Integer.toString((Integer) props.get(PBackgroundDef.Y))); //$NON-NLS-1$
-						bckelement.setAttribute("htiled", //$NON-NLS-1$
-								boolToString((Boolean) props.get(PBackgroundDef.TILE_HORIZ)));
-						bckelement.setAttribute("vtiled", //$NON-NLS-1$
-								boolToString((Boolean) props.get(PBackgroundDef.TILE_VERT)));
-						bckelement.setAttribute("hspeed", //$NON-NLS-1$
-								Integer.toString((Integer) props.get(PBackgroundDef.H_SPEED)));
-						bckelement.setAttribute("vspeed", //$NON-NLS-1$
-								Integer.toString((Integer) props.get(PBackgroundDef.V_SPEED)));
-						bckelement.setAttribute("stretch", //$NON-NLS-1$
-								boolToString((Boolean) props.get(PBackgroundDef.STRETCH)));
-						}
-
-					// Write Views
-					Element viewroot = doc.createElement("views"); //$NON-NLS-1$
-					roomroot.appendChild(viewroot);
-					for (View view : room.views)
-						{
-						PropertyMap<PView> props = view.properties;
-						Element vwelement = doc.createElement("view"); //$NON-NLS-1$
-						viewroot.appendChild(vwelement);
-
-						vwelement.setAttribute("visible",boolToString((Boolean) props.get(PView.VISIBLE))); //$NON-NLS-1$
-						vwelement.setAttribute("objName", //$NON-NLS-1$
-								getName((ResourceReference<?>) props.get(PView.OBJECT)));
-						vwelement.setAttribute("xview",Integer.toString((Integer) props.get(PView.VIEW_X))); //$NON-NLS-1$
-						vwelement.setAttribute("yview",Integer.toString((Integer) props.get(PView.VIEW_Y))); //$NON-NLS-1$
-						vwelement.setAttribute("wview",Integer.toString((Integer) props.get(PView.VIEW_W))); //$NON-NLS-1$
-						vwelement.setAttribute("hview",Integer.toString((Integer) props.get(PView.VIEW_H))); //$NON-NLS-1$
-						vwelement.setAttribute("xport",Integer.toString((Integer) props.get(PView.PORT_X))); //$NON-NLS-1$
-						vwelement.setAttribute("yport",Integer.toString((Integer) props.get(PView.PORT_Y))); //$NON-NLS-1$
-						vwelement.setAttribute("wport",Integer.toString((Integer) props.get(PView.PORT_W))); //$NON-NLS-1$
-						vwelement.setAttribute("hport",Integer.toString((Integer) props.get(PView.PORT_H))); //$NON-NLS-1$
-						vwelement.setAttribute("hborder",Integer.toString((Integer) props.get(PView.BORDER_H))); //$NON-NLS-1$
-						vwelement.setAttribute("vborder",Integer.toString((Integer) props.get(PView.BORDER_V))); //$NON-NLS-1$
-						vwelement.setAttribute("hspeed",Integer.toString((Integer) props.get(PView.SPEED_H))); //$NON-NLS-1$
-						vwelement.setAttribute("vspeed",Integer.toString((Integer) props.get(PView.SPEED_V))); //$NON-NLS-1$
-						}
-
-					// Write instances
-					Element insroot = doc.createElement("instances"); //$NON-NLS-1$
-					roomroot.appendChild(insroot);
-					for (Instance in : room.instances)
-						{
-						Element inselement = doc.createElement("instance"); //$NON-NLS-1$
-						insroot.appendChild(inselement);
-						inselement.setAttribute("objName", //$NON-NLS-1$
-								getName((ResourceReference<?>) in.properties.get(PInstance.OBJECT)));
-						inselement.setAttribute("x",Integer.toString(in.getPosition().x)); //$NON-NLS-1$
-						inselement.setAttribute("y",Integer.toString(in.getPosition().y)); //$NON-NLS-1$
-						inselement.setAttribute("name",in.getName()); //$NON-NLS-1$
-						inselement.setAttribute("id",Integer.toString(in.getID())); //$NON-NLS-1$
-						inselement.setAttribute("locked",boolToString(in.isLocked())); //$NON-NLS-1$
-						inselement.setAttribute("code",in.getCreationCode()); //$NON-NLS-1$
-						inselement.setAttribute("scaleX",Double.toString(in.getScale().getX())); //$NON-NLS-1$
-						inselement.setAttribute("scaleY",Double.toString(in.getScale().getY())); //$NON-NLS-1$
-						String color = Long.toString(Util.getInstanceColorWithAlpha(in.getColor(),in.getAlpha()));
-						inselement.setAttribute("colour",color); // default white //$NON-NLS-1$
-						inselement.setAttribute("rotation",Double.toString(in.getRotation())); //$NON-NLS-1$
-						}
-
-					// Write Tiles
-					Element tileroot = doc.createElement("tiles"); //$NON-NLS-1$
-					roomroot.appendChild(tileroot);
-					for (Tile tile : room.tiles)
-						{
-						PropertyMap<PTile> props = tile.properties;
-						Element tileelement = doc.createElement("tile"); //$NON-NLS-1$
-						tileroot.appendChild(tileelement);
-
-						tileelement.setAttribute("bgName", //$NON-NLS-1$
-								getName((ResourceReference<?>) props.get(PTile.BACKGROUND),""));
-						tileelement.setAttribute("x",Integer.toString((Integer) props.get(PTile.ROOM_X))); //$NON-NLS-1$
-						tileelement.setAttribute("y",Integer.toString((Integer) props.get(PTile.ROOM_Y))); //$NON-NLS-1$
-						tileelement.setAttribute("w",Integer.toString((Integer) props.get(PTile.WIDTH))); //$NON-NLS-1$
-						tileelement.setAttribute("h",Integer.toString((Integer) props.get(PTile.HEIGHT))); //$NON-NLS-1$
-						tileelement.setAttribute("xo",Integer.toString((Integer) props.get(PTile.BG_X))); //$NON-NLS-1$
-						tileelement.setAttribute("yo",Integer.toString((Integer) props.get(PTile.BG_Y))); //$NON-NLS-1$
-						tileelement.setAttribute("id",Integer.toString((Integer) props.get(PTile.ID))); //$NON-NLS-1$
-						tileelement.setAttribute("name",(String) props.get(PTile.NAME)); //$NON-NLS-1$
-						tileelement.setAttribute("depth",Integer.toString(tile.getDepth())); //$NON-NLS-1$
-						tileelement.setAttribute("locked",boolToString(tile.isLocked())); //$NON-NLS-1$
-						Point2D scale = tile.getScale();
-						tileelement.setAttribute("scaleX",Double.toString(scale.getX())); //$NON-NLS-1$
-						tileelement.setAttribute("scaleY",Double.toString(scale.getY())); //$NON-NLS-1$
-						tileelement.setAttribute("colour",Long.toString(tile.getColor())); //$NON-NLS-1$
-						}
-
-					// Physics properties
-					roomroot.appendChild(createElement(doc,"PhysicsWorld", //$NON-NLS-1$
-						boolToString((Boolean) room.get(PRoom.PHYSICS_WORLD))));
-					roomroot.appendChild(createElement(doc,"PhysicsWorldTop", //$NON-NLS-1$
-						Integer.toString((Integer) room.get(PRoom.PHYSICS_TOP))));
-					roomroot.appendChild(createElement(doc,"PhysicsWorldLeft", //$NON-NLS-1$
-						Integer.toString((Integer) room.get(PRoom.PHYSICS_LEFT))));
-					roomroot.appendChild(createElement(doc,"PhysicsWorldRight", //$NON-NLS-1$
-						Integer.toString((Integer) room.get(PRoom.PHYSICS_RIGHT))));
-					roomroot.appendChild(createElement(doc,"PhysicsWorldBottom", //$NON-NLS-1$
-						Integer.toString((Integer) room.get(PRoom.PHYSICS_BOTTOM))));
-					roomroot.appendChild(createElement(doc,"PhysicsWorldGravityX", //$NON-NLS-1$
-						Double.toString((Double) room.get(PRoom.PHYSICS_GRAVITY_X))));
-					roomroot.appendChild(createElement(doc,"PhysicsWorldGravityY", //$NON-NLS-1$
-						Double.toString((Double) room.get(PRoom.PHYSICS_GRAVITY_Y))));
-					roomroot.appendChild(createElement(doc,"PhysicsWorldPixToMeters", //$NON-NLS-1$
-						Double.toString((Double) room.get(PRoom.PHYSICS_PIXTOMETERS))));
-
-					File file = new File(Util.getPOSIXPath(fname + room.getName() + ".room.gmx")); //$NON-NLS-1$
-					transformDocumentUnchecked(f, doc, file);
-
-					domRoot.appendChild(res);
-					break;
-				}
+			bckelement.setAttribute("visible", //$NON-NLS-1$
+					boolToString((Boolean) props.get(PBackgroundDef.VISIBLE)));
+			bckelement.setAttribute("foreground", //$NON-NLS-1$
+					boolToString((Boolean) props.get(PBackgroundDef.FOREGROUND)));
+			bckelement.setAttribute("name", //$NON-NLS-1$
+					getName((ResourceReference<?>)props.get(PBackgroundDef.BACKGROUND),""));
+			bckelement.setAttribute("x",Integer.toString((Integer) props.get(PBackgroundDef.X))); //$NON-NLS-1$
+			bckelement.setAttribute("y",Integer.toString((Integer) props.get(PBackgroundDef.Y))); //$NON-NLS-1$
+			bckelement.setAttribute("htiled", //$NON-NLS-1$
+					boolToString((Boolean) props.get(PBackgroundDef.TILE_HORIZ)));
+			bckelement.setAttribute("vtiled", //$NON-NLS-1$
+					boolToString((Boolean) props.get(PBackgroundDef.TILE_VERT)));
+			bckelement.setAttribute("hspeed", //$NON-NLS-1$
+					Integer.toString((Integer) props.get(PBackgroundDef.H_SPEED)));
+			bckelement.setAttribute("vspeed", //$NON-NLS-1$
+					Integer.toString((Integer) props.get(PBackgroundDef.V_SPEED)));
+			bckelement.setAttribute("stretch", //$NON-NLS-1$
+					boolToString((Boolean) props.get(PBackgroundDef.STRETCH)));
 			}
+
+		// Write Views
+		Element viewroot = doc.createElement("views"); //$NON-NLS-1$
+		roomroot.appendChild(viewroot);
+		for (View view : room.views)
+			{
+			PropertyMap<PView> props = view.properties;
+			Element vwelement = doc.createElement("view"); //$NON-NLS-1$
+			viewroot.appendChild(vwelement);
+
+			vwelement.setAttribute("visible",boolToString((Boolean) props.get(PView.VISIBLE))); //$NON-NLS-1$
+			vwelement.setAttribute("objName", //$NON-NLS-1$
+					getName((ResourceReference<?>) props.get(PView.OBJECT)));
+			vwelement.setAttribute("xview",Integer.toString((Integer) props.get(PView.VIEW_X))); //$NON-NLS-1$
+			vwelement.setAttribute("yview",Integer.toString((Integer) props.get(PView.VIEW_Y))); //$NON-NLS-1$
+			vwelement.setAttribute("wview",Integer.toString((Integer) props.get(PView.VIEW_W))); //$NON-NLS-1$
+			vwelement.setAttribute("hview",Integer.toString((Integer) props.get(PView.VIEW_H))); //$NON-NLS-1$
+			vwelement.setAttribute("xport",Integer.toString((Integer) props.get(PView.PORT_X))); //$NON-NLS-1$
+			vwelement.setAttribute("yport",Integer.toString((Integer) props.get(PView.PORT_Y))); //$NON-NLS-1$
+			vwelement.setAttribute("wport",Integer.toString((Integer) props.get(PView.PORT_W))); //$NON-NLS-1$
+			vwelement.setAttribute("hport",Integer.toString((Integer) props.get(PView.PORT_H))); //$NON-NLS-1$
+			vwelement.setAttribute("hborder",Integer.toString((Integer) props.get(PView.BORDER_H))); //$NON-NLS-1$
+			vwelement.setAttribute("vborder",Integer.toString((Integer) props.get(PView.BORDER_V))); //$NON-NLS-1$
+			vwelement.setAttribute("hspeed",Integer.toString((Integer) props.get(PView.SPEED_H))); //$NON-NLS-1$
+			vwelement.setAttribute("vspeed",Integer.toString((Integer) props.get(PView.SPEED_V))); //$NON-NLS-1$
+			}
+
+		// Write instances
+		Element insroot = doc.createElement("instances"); //$NON-NLS-1$
+		roomroot.appendChild(insroot);
+		for (Instance in : room.instances)
+			{
+			Element inselement = doc.createElement("instance"); //$NON-NLS-1$
+			insroot.appendChild(inselement);
+			inselement.setAttribute("objName", //$NON-NLS-1$
+					getName((ResourceReference<?>) in.properties.get(PInstance.OBJECT)));
+			inselement.setAttribute("x",Integer.toString(in.getPosition().x)); //$NON-NLS-1$
+			inselement.setAttribute("y",Integer.toString(in.getPosition().y)); //$NON-NLS-1$
+			inselement.setAttribute("name",in.getName()); //$NON-NLS-1$
+			inselement.setAttribute("id",Integer.toString(in.getID())); //$NON-NLS-1$
+			inselement.setAttribute("locked",boolToString(in.isLocked())); //$NON-NLS-1$
+			inselement.setAttribute("code",in.getCreationCode()); //$NON-NLS-1$
+			inselement.setAttribute("scaleX",Double.toString(in.getScale().getX())); //$NON-NLS-1$
+			inselement.setAttribute("scaleY",Double.toString(in.getScale().getY())); //$NON-NLS-1$
+			String color = Long.toString(Util.getInstanceColorWithAlpha(in.getColor(),in.getAlpha()));
+			inselement.setAttribute("colour",color); // default white //$NON-NLS-1$
+			inselement.setAttribute("rotation",Double.toString(in.getRotation())); //$NON-NLS-1$
+			}
+
+		// Write Tiles
+		Element tileroot = doc.createElement("tiles"); //$NON-NLS-1$
+		roomroot.appendChild(tileroot);
+		for (Tile tile : room.tiles)
+			{
+			PropertyMap<PTile> props = tile.properties;
+			Element tileelement = doc.createElement("tile"); //$NON-NLS-1$
+			tileroot.appendChild(tileelement);
+
+			tileelement.setAttribute("bgName", //$NON-NLS-1$
+					getName((ResourceReference<?>) props.get(PTile.BACKGROUND),""));
+			tileelement.setAttribute("x",Integer.toString((Integer) props.get(PTile.ROOM_X))); //$NON-NLS-1$
+			tileelement.setAttribute("y",Integer.toString((Integer) props.get(PTile.ROOM_Y))); //$NON-NLS-1$
+			tileelement.setAttribute("w",Integer.toString((Integer) props.get(PTile.WIDTH))); //$NON-NLS-1$
+			tileelement.setAttribute("h",Integer.toString((Integer) props.get(PTile.HEIGHT))); //$NON-NLS-1$
+			tileelement.setAttribute("xo",Integer.toString((Integer) props.get(PTile.BG_X))); //$NON-NLS-1$
+			tileelement.setAttribute("yo",Integer.toString((Integer) props.get(PTile.BG_Y))); //$NON-NLS-1$
+			tileelement.setAttribute("id",Integer.toString((Integer) props.get(PTile.ID))); //$NON-NLS-1$
+			tileelement.setAttribute("name",(String) props.get(PTile.NAME)); //$NON-NLS-1$
+			tileelement.setAttribute("depth",Integer.toString(tile.getDepth())); //$NON-NLS-1$
+			tileelement.setAttribute("locked",boolToString(tile.isLocked())); //$NON-NLS-1$
+			Point2D scale = tile.getScale();
+			tileelement.setAttribute("scaleX",Double.toString(scale.getX())); //$NON-NLS-1$
+			tileelement.setAttribute("scaleY",Double.toString(scale.getY())); //$NON-NLS-1$
+			tileelement.setAttribute("colour",Long.toString(tile.getColor())); //$NON-NLS-1$
+			}
+
+		// Physics properties
+		roomroot.appendChild(createElement(doc,"PhysicsWorld", //$NON-NLS-1$
+			boolToString((Boolean) room.get(PRoom.PHYSICS_WORLD))));
+		roomroot.appendChild(createElement(doc,"PhysicsWorldTop", //$NON-NLS-1$
+			Integer.toString((Integer) room.get(PRoom.PHYSICS_TOP))));
+		roomroot.appendChild(createElement(doc,"PhysicsWorldLeft", //$NON-NLS-1$
+			Integer.toString((Integer) room.get(PRoom.PHYSICS_LEFT))));
+		roomroot.appendChild(createElement(doc,"PhysicsWorldRight", //$NON-NLS-1$
+			Integer.toString((Integer) room.get(PRoom.PHYSICS_RIGHT))));
+		roomroot.appendChild(createElement(doc,"PhysicsWorldBottom", //$NON-NLS-1$
+			Integer.toString((Integer) room.get(PRoom.PHYSICS_BOTTOM))));
+		roomroot.appendChild(createElement(doc,"PhysicsWorldGravityX", //$NON-NLS-1$
+			Double.toString((Double) room.get(PRoom.PHYSICS_GRAVITY_X))));
+		roomroot.appendChild(createElement(doc,"PhysicsWorldGravityY", //$NON-NLS-1$
+			Double.toString((Double) room.get(PRoom.PHYSICS_GRAVITY_Y))));
+		roomroot.appendChild(createElement(doc,"PhysicsWorldPixToMeters", //$NON-NLS-1$
+			Double.toString((Double) room.get(PRoom.PHYSICS_PIXTOMETERS))));
+
+		File file = new File(Util.getPOSIXPath(fname + room.getName() + ".room.gmx")); //$NON-NLS-1$
+		transformDocumentUnchecked(f, doc, file);
+
+		domRoot.appendChild(res);
 		}
 
 	public static void writeIncludedFiles(ProjectFileContext c, Element root) throws IOException

--- a/org/lateralgm/file/GMXFileWriter.java
+++ b/org/lateralgm/file/GMXFileWriter.java
@@ -4,7 +4,7 @@
 *
 * @section License
 *
-* Copyright (C) 2013-2015 Robert B. Colton
+* Copyright (C) 2013-2015,2019 Robert B. Colton
 * This file is a part of the LateralGM IDE.
 *
 * This program is free software: you can redistribute it and/or modify

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -134,7 +134,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.55"; //$NON-NLS-1$
+	public static final String version = "1.8.56"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.


### PR DESCRIPTION
When I first added the GMX writer, I had duplicated the recursive logic to each resource type. That's unnecessary and I've now refactored it into a single `writeTree` helper. Now that each resource has its own write method, it would be much easier to do #341 and similar export/import features.