### PR TITLE
Fix Font List Cell Renderer

### DIFF
--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -134,7 +134,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.56"; //$NON-NLS-1$
+	public static final String version = "1.8.57"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/subframes/FontFrame.java
+++ b/org/lateralgm/subframes/FontFrame.java
@@ -21,6 +21,7 @@ import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
 import javax.swing.AbstractAction;
 import javax.swing.BorderFactory;
+import javax.swing.DefaultListCellRenderer;
 import javax.swing.GroupLayout;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
@@ -62,7 +63,6 @@ import org.lateralgm.resources.Font;
 import org.lateralgm.resources.Font.PFont;
 import org.lateralgm.resources.sub.CharacterRange;
 import org.lateralgm.resources.sub.CharacterRange.PCharacterRange;
-import org.lateralgm.subframes.RoomFrame.ListComponentRenderer;
 import org.lateralgm.ui.swing.propertylink.FormattedLink;
 import org.lateralgm.ui.swing.propertylink.PropertyLinkFactory;
 import org.lateralgm.ui.swing.propertylink.ComboBoxLink.IndexComboBoxConversion;
@@ -572,22 +572,16 @@ public class FontFrame extends InstantiableResourceFrame<Font,PFont> implements
 
 	private static class RangeListComponentRenderer implements ListCellRenderer<CharacterRange>
 		{
-		private final JLabel lab = new JLabel();
-		private final ListComponentRenderer lcr = new ListComponentRenderer();
+		private final DefaultListCellRenderer lcr = new DefaultListCellRenderer();
 
-		public RangeListComponentRenderer()
-			{
-			lab.setOpaque(true);
-			}
-
+		@Override
 		public Component getListCellRendererComponent(JList<? extends CharacterRange> list,
 				CharacterRange val, int ind, boolean selected, boolean focus)
 			{
-			CharacterRange i = (CharacterRange) val;
-			lcr.getListCellRendererComponent(list,lab,ind,selected,focus);
-			lab.setText(Messages.format("FontFrame.CHARRANGE_FORMAT",i.properties.get(PCharacterRange.RANGE_MIN), //$NON-NLS-1$
-					i.properties.get(PCharacterRange.RANGE_MAX)));
-			return lab;
+			lcr.getListCellRendererComponent(list,val,ind,selected,focus);
+			lcr.setText(Messages.format("FontFrame.CHARRANGE_FORMAT",val.properties.get(PCharacterRange.RANGE_MIN), //$NON-NLS-1$
+					val.properties.get(PCharacterRange.RANGE_MAX)));
+			return lcr;
 			}
 		}
 

--- a/org/lateralgm/subframes/FontFrame.java
+++ b/org/lateralgm/subframes/FontFrame.java
@@ -39,7 +39,6 @@ import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.JToolBar;
 import javax.swing.KeyStroke;
-import javax.swing.ListCellRenderer;
 import javax.swing.GroupLayout.Alignment;
 import javax.swing.GroupLayout.SequentialGroup;
 import javax.swing.ScrollPaneConstants;
@@ -570,18 +569,23 @@ public class FontFrame extends InstantiableResourceFrame<Font,PFont> implements
 		previewRange.setFont(res.getAWTFont());
 		}
 
-	private static class RangeListComponentRenderer implements ListCellRenderer<CharacterRange>
+	private static class RangeListComponentRenderer extends DefaultListCellRenderer
 		{
-		private final DefaultListCellRenderer lcr = new DefaultListCellRenderer();
+		/**
+		 * Default UID generated, change if necessary.
+		 */
+		private static final long serialVersionUID = 6095060644468207193L;
 
 		@Override
-		public Component getListCellRendererComponent(JList<? extends CharacterRange> list,
-				CharacterRange val, int ind, boolean selected, boolean focus)
+		public Component getListCellRendererComponent(JList<?> list,
+				Object val, int ind, boolean selected, boolean focus)
 			{
-			lcr.getListCellRendererComponent(list,val,ind,selected,focus);
-			lcr.setText(Messages.format("FontFrame.CHARRANGE_FORMAT",val.properties.get(PCharacterRange.RANGE_MIN), //$NON-NLS-1$
-					val.properties.get(PCharacterRange.RANGE_MAX)));
-			return lcr;
+			Component comp = super.getListCellRendererComponent(list,val,ind,selected,focus);
+			if (!(val instanceof CharacterRange)) return comp;
+			CharacterRange cr = (CharacterRange) val;
+			this.setText(Messages.format("FontFrame.CHARRANGE_FORMAT",cr.properties.get(PCharacterRange.RANGE_MIN), //$NON-NLS-1$
+					cr.properties.get(PCharacterRange.RANGE_MAX)));
+			return comp;
 			}
 		}
 


### PR DESCRIPTION
This fixes two issues with the font frame's character range list cell renderer. The bugs are the result of confusion surrounding the list cell rendering API. Instead of using our own JLabel, I made it simply extend `DefaultListCellRenderer`, which already extends JLabel with the style logic, then set the custom text we want. This fixes the look and feel rendering as far as selection and insets. I chose to use class inheritance of `DefaultListCellRenderer` rather than class composition because that is the only way to fix look and feel switching. If we do not do this, a look and feel change will make other look and feels render the list with the UI properties of the first look and feel.

### Font Frame List Renderer Fixed (Pull Request)
![Font Frame List Renderer Fixed](https://user-images.githubusercontent.com/3212801/57184361-7b9cec00-6e88-11e9-9b01-680133b183ba.png)

### Font Frame List Renderer Broken (Master)
![Font Frame List Renderer Broken](https://user-images.githubusercontent.com/3212801/57184376-a9823080-6e88-11e9-9cd0-7e66d0084e3c.png)
