### PR TITLE
Fix Room View/Background List Rendering

### DIFF
--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -134,7 +134,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.58"; //$NON-NLS-1$
+	public static final String version = "1.8.59"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/subframes/RoomFrame.java
+++ b/org/lateralgm/subframes/RoomFrame.java
@@ -2039,23 +2039,19 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 			}
 		}
 
-	public static class ListComponentRenderer implements ListCellRenderer<Object>
+	private static class ListComponentRenderer extends DefaultListCellRenderer
 		{
-		public Component getListCellRendererComponent(JList<? extends Object> list, Object val,
+		public Component getListCellRendererComponent(JList<?> list, Object val,
 				int ind, boolean selected, boolean focus)
 			{
-			Component lab = (Component) val;
-			if (selected)
-				{
-				lab.setBackground(list.getSelectionBackground());
-				lab.setForeground(list.getSelectionForeground());
-				}
-			else
-				{
-				lab.setBackground(list.getBackground());
-				lab.setForeground(list.getForeground());
-				}
-			return lab;
+			super.getListCellRendererComponent(list,val,ind,selected,focus);
+			JLabel lab = (JLabel) val;
+			this.setText(lab.getText());
+			Font font = this.getFont();
+			if (lab.getFont().isBold())
+				font = font.deriveFont(Font.BOLD);
+			this.setFont(font);
+			return this;
 			}
 		}
 


### PR DESCRIPTION
Friend of #416 and #415 which extends the same default list cell rendering fix to the room frame's view and background lists. This is the only way I can find that correctly fixes all look and feels as well as look and feel switching. I should mention that these lists are somewhat different in that they hold `JLabel` and control the bold property of the label's font based on the enabled status of the view or background. I simply made the renderer derive a bold version of its own font in that case, so it correctly uses the font family of the current look and feel.

### Room View List Fixed (Pull Request)
![Room View List Fixed](https://user-images.githubusercontent.com/3212801/57185613-fc65e300-6e9c-11e9-84ab-960fff2a3458.png)

### Room View List Buggy (Master)
![Room View List Buggy](https://user-images.githubusercontent.com/3212801/57185621-1a334800-6e9d-11e9-8a44-fae662d6d35f.png)
