### PR TITLE
Fix Font Frame Toolbar Layout

### DIFF
--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -134,7 +134,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.59"; //$NON-NLS-1$
+	public static final String version = "1.8.60"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/subframes/FontFrame.java
+++ b/org/lateralgm/subframes/FontFrame.java
@@ -13,6 +13,7 @@ package org.lateralgm.subframes;
 
 import static java.lang.Integer.MAX_VALUE;
 import static javax.swing.GroupLayout.DEFAULT_SIZE;
+import static javax.swing.GroupLayout.PREFERRED_SIZE;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.GraphicsEnvironment;
@@ -305,7 +306,7 @@ public class FontFrame extends InstantiableResourceFrame<Font,PFont> implements
 		/*		*/.addComponent(aa).addComponent(aaLabel)
 		/*		*/.addComponent(bold)
 		/*		*/.addComponent(italic))
-		/**/.addComponent(rangesTB)
+		/**/.addComponent(rangesTB,DEFAULT_SIZE,PREFERRED_SIZE,PREFERRED_SIZE)
 		/**/.addGroup(layout.createParallelGroup(Alignment.BASELINE)
 		/**/.addComponent(listScroller,DEFAULT_SIZE,120,MAX_VALUE))
 		/**/.addComponent(crPane)


### PR DESCRIPTION
Small tweak to address #419 when the font frame is maximized. Solution is to just limit the max height of the toolbar in the layout to that of its preferred height.

![Maximized Font Frame Fixed Toolbar](https://user-images.githubusercontent.com/3212801/57186246-a481a900-6ea9-11e9-8bf5-bdfe0dc7da17.png)
