### PR TITLE
Fix GMK Font AA

### DIFF
--- a/org/lateralgm/file/GmFileReader.java
+++ b/org/lateralgm/file/GmFileReader.java
@@ -876,7 +876,8 @@ public final class GmFileReader
 			in.readBool(font.properties,PFont.BOLD,PFont.ITALIC);
 			int rangemin = in.read2();
 			font.put(PFont.CHARSET,in.read());
-			int aa = in.read();
+			// AA is not 0-based in GM8.1, off==1 and 3==4
+			int aa = in.read()-1;
 			if (aa == 0 && f.format != ProjectFile.FormatFlavor.GM_810) aa = 3;
 			font.put(PFont.ANTIALIAS,aa);
 			font.addRange(rangemin,in.read4());

--- a/org/lateralgm/file/GmFileWriter.java
+++ b/org/lateralgm/file/GmFileWriter.java
@@ -579,7 +579,8 @@ public final class GmFileWriter
 					{
 					out.write2(rangemin);
 					out.write((Integer) font.get(PFont.CHARSET));
-					out.write((Integer) font.get(PFont.ANTIALIAS));
+					// AA is not 0-based in GM8.1, off==1 and 3==4
+					out.write((Integer) font.get(PFont.ANTIALIAS)+1);
 					}
 				else
 					out.write4(rangemin);

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -134,7 +134,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.60"; //$NON-NLS-1$
+	public static final String version = "1.8.61"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.


### PR DESCRIPTION
This addresses #418 by shifting the GMK font AA levels by 1, making them 0-based so LGM can use them sanely. For the GMX format, the AA levels are 0-based, so we just need to subtract one on GMK read and add one on GMK write. Tested in GM8.0, GM8.1, and GMSv1.4.