### PR TITLE
Search Event Selection Fix

### DIFF
--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -134,7 +134,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.61"; //$NON-NLS-1$
+	public static final String version = "1.8.62"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/subframes/GmObjectFrame.java
+++ b/org/lateralgm/subframes/GmObjectFrame.java
@@ -933,11 +933,7 @@ public class GmObjectFrame extends InstantiableResourceFrame<GmObject,PGmObject>
 		TreeNode[] nodes = findEvent(mainid, id);
 		if (nodes != null) {
 			TreePath path = new TreePath(nodes);
-			// TODO: Why does this not work? I tried wrapping it in SwingUtilities as well as reloading
-			// the tree model.
-			//events.expandPath(path);
-			// Using this temporarily.
-			events.setExpandsSelectedPaths(true);
+			events.makeVisible(path);
 			events.setSelectionPath(path);
 		}
 	}


### PR DESCRIPTION
I ran onto one of my old todo comments from implementing the search feature and did some research. The reason `expandPath` was not making the event nodes visible under collapsed parents is because the documentation states it does not work for _leaf_ nodes.
https://docs.oracle.com/javase/7/docs/api/javax/swing/JTree.html#expandPath(javax.swing.tree.TreePath)
>If the last item in the path is a leaf, this will have no effect.

The correct thing to do is use `makeVisible` which will expand the path to a leaf node and make a leaf node fully visible.
https://docs.oracle.com/javase/7/docs/api/javax/swing/JTree.html#makeVisible(javax.swing.tree.TreePath)
>Ensures that the node identified by path is currently viewable.

Finally, from testing, I discovered we do not want to do `setExpandsSelectedPaths(true)` and want to leave it false, as it was before I messed with it. The reason is because it seems to exacerbate #282 making event group selection super annoying where you have to deselect and then select again in order expand or collapse an event group node.