### PR TITLE
Room Properties Tweaks

### DIFF
--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -134,7 +134,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.62"; //$NON-NLS-1$
+	public static final String version = "1.8.63"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/main/Prefs.java
+++ b/org/lateralgm/main/Prefs.java
@@ -110,7 +110,7 @@ public final class Prefs
 		userLibraryPath = getString("userLibraryPath","./lib");
 
 		imagePreviewBackgroundColor = getInt("imagePreviewBackgroundColor",
-			new Color(204,204,204).getRGB());
+			new Color(224,224,224).getRGB());
 		imagePreviewForegroundColor = getInt("imagePreviewForegroundColor",
 			new Color(172,172,172).getRGB());
 		highlightMatchCountBackground = getBoolean("highlightMatchCountBackground",false);

--- a/org/lateralgm/resources/Room.java
+++ b/org/lateralgm/resources/Room.java
@@ -60,7 +60,7 @@ public class Room extends InstantiableResource<Room,Room.PRoom> implements CodeH
 		}
 
 	private static final EnumMap<PRoom,Object> DEFS = PropertyMap.makeDefaultMap(PRoom.class,"",640,
-			480,16,16,false,30,false,new Color(102,204,255),true,"",true,1024,640,true,true,true,true,true,
+			480,16,16,false,30,false,Color.LIGHT_GRAY,true,"",true,1024,640,true,true,true,true,true,
 			false,false,false,TAB_OBJECTS,0,0,false,true,false,0,0,640,480,0.0,10.0,0.1);
 
 	public Room()

--- a/org/lateralgm/subframes/RoomFrame.java
+++ b/org/lateralgm/subframes/RoomFrame.java
@@ -79,7 +79,6 @@ import javax.swing.JToggleButton;
 import javax.swing.JToolBar;
 import javax.swing.JViewport;
 import javax.swing.KeyStroke;
-import javax.swing.ListCellRenderer;
 import javax.swing.ListModel;
 import javax.swing.ListSelectionModel;
 import javax.swing.TransferHandler;


### PR DESCRIPTION
These are some minor tweaks to take us back to the same default room background color as GM that LGM used in the 16b4 release. My eyes seriously hurt from looking at the bright blue I added. Me and Rusky discussed this to death, and using something like cornflower blue just promulgates a "Unity3D" or "made with GM effect" which we do not want.

I had to tweak the default colors stored in preferences for making an image preview background since those are used by the room editor. I chose to make the colors more contrasting. Finally, I removed an unused import I accidentally left in #417.

![Room Property Tweaks](https://user-images.githubusercontent.com/3212801/57194984-45f51300-6f1b-11e9-9c76-3256c477d838.png)
