### PR TITLE
Fix Font AA GMK 800 or Lower

### DIFF
--- a/org/lateralgm/file/GmFileReader.java
+++ b/org/lateralgm/file/GmFileReader.java
@@ -876,9 +876,11 @@ public final class GmFileReader
 			in.readBool(font.properties,PFont.BOLD,PFont.ITALIC);
 			int rangemin = in.read2();
 			font.put(PFont.CHARSET,in.read());
-			// AA is not 0-based in GM8.1, off==1 and 3==4
-			int aa = in.read()-1;
+			int aa = in.read();
+			// If GM8.0 or lower project doesn't have AA, use highest level
 			if (aa == 0 && f.format != ProjectFile.FormatFlavor.GM_810) aa = 3;
+			// AA is not 0-based in GM8.1, off==1 and 3==4
+			else --aa;
 			font.put(PFont.ANTIALIAS,aa);
 			font.addRange(rangemin,in.read4());
 			in.endInflate();

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -134,7 +134,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.63"; //$NON-NLS-1$
+	public static final String version = "1.8.64"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.


### PR DESCRIPTION
I just ran onto this regression caused by #421 in Wild Racing GMK which is version 800. The fonts were all blocky and I noticed it's because their AA was `-1`. This fixes the check by moving the shift of the AA level to an else statement. I tested Wild Racing again and the font AA test I made for #421 and do see now it's totally fixed.