### PR TITLE
GMX->GMK Extensions Tree Artifact Fix

### DIFF
--- a/org/lateralgm/file/GMXFileReader.java
+++ b/org/lateralgm/file/GMXFileReader.java
@@ -1978,7 +1978,7 @@ public final class GMXFileReader
 		Document in = c.in;
 
 		ResNode node = new ResNode(Resource.kindNamesPlural.get(Extension.class),
-				ResNode.STATUS_PRIMARY,ExtensionPackages.class,null);
+				ResNode.STATUS_PRIMARY,Extension.class,null);
 		root.add(node);
 
 		NodeList extList = in.getElementsByTagName("extensions"); //$NON-NLS-1$

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -134,7 +134,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.67"; //$NON-NLS-1$
+	public static final String version = "1.8.68"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.


### PR DESCRIPTION
This fixes #198 by giving the "Extensions" folder read by the GMK reader the correct type. This must have just been a minor oversight by me. So the way I have LGM organized is that `Extension.class` is for instantiable extensions for/from GMX, and "ExtensionPackages.class" is for the installable extensions for/from GMK. The problem was just our GMK reader seeing two "ExtensionPackages.class" nodes in the tree, and thinking the earlier one was the correct one to write. This changes nothing about the "Timelines" vs "Time Lines" part of the issue yet though.

Saving a GMX as any GMK version now results in the following tree in GM 8.1:
![GMX->GMK Tree GM8.1](https://user-images.githubusercontent.com/3212801/58053024-62509c80-7b24-11e9-9a2f-5defe6db2444.png)
