### PR TITLE
Cleanup GMX Tree Reading Recursion

### DIFF
--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -134,7 +134,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.69"; //$NON-NLS-1$
+	public static final String version = "1.8.70"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.


### PR DESCRIPTION
This pull request is a continuation of #430 and a friend of #414. The idea is to centralize all of the tree recursion logic in a new helper and remove all the duplication of it from each individual resource reading method. The changes here inherently create an ugly diff and there's no way to avoid the indentation and formatting changes.

The benefits of this pull request mean the reader is easier to maintain as well as understand. It is now easier to read a single GMX resource at a time, making it more possible for LGM to eventually have features like #341.