### PR TITLE
GMX Included File Reading/Writing

### DIFF
--- a/org/lateralgm/file/GMXFileReader.java
+++ b/org/lateralgm/file/GMXFileReader.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -1606,6 +1607,23 @@ public final class GMXFileReader
 		inc.put(PInclude.EXPORTACTION,exportAction);
 		String filename = el.getElementsByTagName("filename").item(0).getTextContent(); //$NON-NLS-1$
 		inc.put(PInclude.FILENAME,filename);
+
+		String filePath = filename;
+		ResNode parent = node;
+		while (parent != null && parent.status == ResNode.STATUS_GROUP) {
+			filePath = parent.toString() + '/' + filePath;
+			parent = (ResNode) parent.getParent();
+		}
+		filePath = f.getDirectory() + "/datafiles/" + filePath; //$NON-NLS-1$
+		File dataFile = new File(filePath);
+		try
+			{
+			inc.data = Files.readAllBytes(dataFile.toPath());
+			}
+		catch (IOException e)
+			{
+			LGM.showDefaultExceptionHandler(new GmFormatException(c.f, "failed to read: " + dataFile.getAbsolutePath(), e));
+			}
 		}
 
 	private static void readPackages(ProjectFileContext c, ResNode root)

--- a/org/lateralgm/file/GMXFileReader.java
+++ b/org/lateralgm/file/GMXFileReader.java
@@ -66,6 +66,7 @@ import org.lateralgm.resources.GameSettings.PGameSettings;
 import org.lateralgm.resources.GmObject;
 import org.lateralgm.resources.GmObject.PGmObject;
 import org.lateralgm.resources.Include;
+import org.lateralgm.resources.Include.PInclude;
 import org.lateralgm.resources.Path;
 import org.lateralgm.resources.Path.PPath;
 import org.lateralgm.resources.Resource;
@@ -107,6 +108,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+import org.w3c.dom.Element;
 import org.xml.sax.SAXException;
 
 import com.sun.org.apache.xerces.internal.impl.dv.util.HexBin;
@@ -380,8 +382,8 @@ public final class GMXFileReader
 					readGmObject(c,node,cNode);
 				else if (tagName.equals("room")) //$NON-NLS-1$
 					readRoom(c,node,cNode);
-				//else if (tagName.equals("include")) //$NON-NLS-1$
-				//readInclude(c,node,cNode);
+				else if (tagName.equals("datafile")) //$NON-NLS-1$
+					readInclude(c,node,cNode);
 				}
 			}
 		}
@@ -1573,6 +1575,37 @@ public final class GMXFileReader
 				rmn.put(PRoom.PHYSICS_PIXTOMETERS,Double.parseDouble(pnode.getTextContent()));
 				}
 			}
+		}
+
+	private static void readInclude(ProjectFileContext c, ResNode node, Node cNode)
+		{
+		if (!(cNode instanceof Element)) return;
+		Element el = (Element)cNode;
+
+		final ProjectFile f = c.f;
+
+		final Include inc = f.resMap.getList(Include.class).add();
+		String name = el.getElementsByTagName("name").item(0).getTextContent(); //$NON-NLS-1$
+		inc.setName(name);
+		ResNode rnode = new ResNode(inc.getName(),ResNode.STATUS_SECONDARY,Include.class,inc.reference);
+		node.add(rnode);
+
+		boolean overwrite = Integer.parseInt(el.getElementsByTagName("overwrite").item(0).getTextContent()) != 0; //$NON-NLS-1$
+		inc.put(PInclude.OVERWRITE,overwrite);
+		boolean freeMemory = Integer.parseInt(el.getElementsByTagName("freeData").item(0).getTextContent()) != 0; //$NON-NLS-1$
+		inc.put(PInclude.FREEMEMORY,freeMemory);
+		boolean removeEnd = Integer.parseInt(el.getElementsByTagName("removeEnd").item(0).getTextContent()) != 0; //$NON-NLS-1$
+		inc.put(PInclude.REMOVEATGAMEEND,removeEnd);
+		boolean store = Integer.parseInt(el.getElementsByTagName("store").item(0).getTextContent()) != 0; //$NON-NLS-1$
+		inc.put(PInclude.STORE,store);
+		int size = Integer.parseInt(el.getElementsByTagName("size").item(0).getTextContent()); //$NON-NLS-1$
+		inc.put(PInclude.SIZE,size);
+		String exportFolder = el.getElementsByTagName("exportDir").item(0).getTextContent(); //$NON-NLS-1$
+		inc.put(PInclude.EXPORTFOLDER,exportFolder);
+		int exportAction = Integer.parseInt(el.getElementsByTagName("exportAction").item(0).getTextContent()); //$NON-NLS-1$
+		inc.put(PInclude.EXPORTACTION,exportAction);
+		String filename = el.getElementsByTagName("filename").item(0).getTextContent(); //$NON-NLS-1$
+		inc.put(PInclude.FILENAME,filename);
 		}
 
 	private static void readPackages(ProjectFileContext c, ResNode root)

--- a/org/lateralgm/file/GMXFileWriter.java
+++ b/org/lateralgm/file/GMXFileWriter.java
@@ -71,6 +71,7 @@ import org.lateralgm.resources.GameSettings.PGameSettings;
 import org.lateralgm.resources.GmObject;
 import org.lateralgm.resources.GmObject.PGmObject;
 import org.lateralgm.resources.Include;
+import org.lateralgm.resources.Include.PInclude;
 import org.lateralgm.resources.InstantiableResource;
 import org.lateralgm.resources.Path;
 import org.lateralgm.resources.Path.PPath;
@@ -236,7 +237,7 @@ public final class GMXFileWriter
 		LGM.setProgress(100,Messages.getString("ProgressDialog.ROOMS")); //$NON-NLS-1$
 		writeGroup(c,root,Room.class);
 		LGM.setProgress(110,Messages.getString("ProgressDialog.INCLUDEFILES")); //$NON-NLS-1$
-		//writeGroup(c,root,Include.class);
+		writeGroup(c,root,Include.class);
 		LGM.setProgress(120,Messages.getString("ProgressDialog.PACKAGES")); //$NON-NLS-1$
 		//writePackages(c, root);
 		LGM.setProgress(130,Messages.getString("ProgressDialog.CONSTANTS")); //$NON-NLS-1$
@@ -327,7 +328,7 @@ public final class GMXFileWriter
 		}
 
 	// This is used to store booleans since GMX uses -1 and 0 and other times false and true
-	private static String boolToString(boolean bool)
+	private static String boolToString(Boolean bool)
 		{
 			return bool ? "-1" : "0"; //$NON-NLS-1$ //$NON-NLS-2$
 		}
@@ -417,6 +418,8 @@ public final class GMXFileWriter
 						writeGmObject(c,resNode,domRoot);
 					else if (kind == Room.class)
 						writeRoom(c,resNode,domRoot);
+					else if (kind == Include.class)
+						writeInclude(c,resNode,domRoot);
 					break;
 				}
 			}
@@ -1279,9 +1282,36 @@ public final class GMXFileWriter
 		domRoot.appendChild(res);
 		}
 
-	public static void writeIncludedFiles(ProjectFileContext c, Element root) throws IOException
+	private static void writeInclude(ProjectFileContext c, ResNode resNode, Element domRoot)
+			throws IOException
 		{
-		// TODO: Implement
+		ProjectFile f = c.f;
+		Document dom = c.dom;
+
+		Include include = (Include) resNode.getRes().get();
+		Element incRoot = dom.createElement("datafile"); //$NON-NLS-1$
+		incRoot.appendChild(createElement(dom,"name", include.getName())); //$NON-NLS-1$
+		incRoot.appendChild(createElement(dom,"filename", //$NON-NLS-1$
+				include.get(PInclude.FILENAME).toString()));
+		incRoot.appendChild(createElement(dom,"size", //$NON-NLS-1$
+				include.get(PInclude.SIZE).toString()));
+		incRoot.appendChild(createElement(dom,"exportDir", //$NON-NLS-1$
+				include.get(PInclude.EXPORTFOLDER).toString()));
+		incRoot.appendChild(createElement(dom,"exportAction", //$NON-NLS-1$
+				include.get(PInclude.EXPORTACTION).toString()));
+		incRoot.appendChild(createElement(dom,"overwrite", //$NON-NLS-1$
+				boolToString((Boolean)include.get(PInclude.OVERWRITE))));
+		incRoot.appendChild(createElement(dom,"store", //$NON-NLS-1$
+				boolToString((Boolean)include.get(PInclude.STORE))));
+		incRoot.appendChild(createElement(dom,"freeData", //$NON-NLS-1$
+				boolToString((Boolean)include.get(PInclude.FREEMEMORY))));
+		incRoot.appendChild(createElement(dom,"removeEnd", //$NON-NLS-1$
+				boolToString((Boolean)include.get(PInclude.REMOVEATGAMEEND))));
+		domRoot.appendChild(incRoot);
+
+		String folderName = f.getDirectory() + "/datafiles"; //$NON-NLS-1$
+		File folderFile = new File(Util.getPOSIXPath(folderName));
+		folderFile.mkdir();
 		}
 
 	public static void writePackages(ProjectFileContext c, Element root) throws IOException

--- a/org/lateralgm/file/GMXFileWriter.java
+++ b/org/lateralgm/file/GMXFileWriter.java
@@ -37,6 +37,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.Writer;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Vector;
@@ -1309,9 +1310,16 @@ public final class GMXFileWriter
 				boolToString((Boolean)include.get(PInclude.REMOVEATGAMEEND))));
 		domRoot.appendChild(incRoot);
 
-		String folderName = f.getDirectory() + "/datafiles"; //$NON-NLS-1$
-		File folderFile = new File(Util.getPOSIXPath(folderName));
-		folderFile.mkdir();
+		String filePath = include.get(PInclude.FILENAME).toString();
+		ResNode parent = (ResNode) resNode.getParent();
+		while (parent != null && parent.status == ResNode.STATUS_GROUP) {
+			filePath = parent.toString() + '/' + filePath;
+			parent = (ResNode) parent.getParent();
+		}
+		filePath = f.getDirectory() + "/datafiles/" + filePath; //$NON-NLS-1$
+		File dataFile = new File(filePath);
+		dataFile.getParentFile().mkdirs();
+		Files.write(dataFile.toPath(),include.data);
 		}
 
 	public static void writePackages(ProjectFileContext c, Element root) throws IOException

--- a/org/lateralgm/file/GMXFileWriter.java
+++ b/org/lateralgm/file/GMXFileWriter.java
@@ -70,6 +70,7 @@ import org.lateralgm.resources.GameSettings;
 import org.lateralgm.resources.GameSettings.PGameSettings;
 import org.lateralgm.resources.GmObject;
 import org.lateralgm.resources.GmObject.PGmObject;
+import org.lateralgm.resources.Include;
 import org.lateralgm.resources.InstantiableResource;
 import org.lateralgm.resources.Path;
 import org.lateralgm.resources.Path.PPath;
@@ -134,6 +135,7 @@ public final class GMXFileWriter
 		tagNames.put(Timeline.class,"timelines"); //$NON-NLS-1$
 		tagNames.put(GmObject.class,"objects"); //$NON-NLS-1$
 		tagNames.put(Room.class,"rooms"); //$NON-NLS-1$
+		tagNames.put(Include.class,"datafiles"); //$NON-NLS-1$
 
 		rootNames.put(Sprite.class,"sprites"); //$NON-NLS-1$
 		rootNames.put(Sound.class,"sound"); //$NON-NLS-1$
@@ -145,6 +147,7 @@ public final class GMXFileWriter
 		rootNames.put(Timeline.class,"timelines"); //$NON-NLS-1$
 		rootNames.put(GmObject.class,"objects"); //$NON-NLS-1$
 		rootNames.put(Room.class,"rooms"); //$NON-NLS-1$
+		rootNames.put(Include.class,"datafiles"); //$NON-NLS-1$
 		}
 
 	private GMXFileWriter()

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -134,7 +134,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.71"; //$NON-NLS-1$
+	public static final String version = "1.8.72"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/resources/Include.java
+++ b/org/lateralgm/resources/Include.java
@@ -14,7 +14,6 @@ import org.lateralgm.util.PropertyMap;
 
 public class Include extends InstantiableResource<Include,Include.PInclude>
 	{
-
 	public byte[] data = new byte[0];
 
 	public enum PInclude


### PR DESCRIPTION
Now that I have the GMX reader and writer mostly cleaned up, I decided to go ahead and support included files. There's actually still a problem here (described in #255) in that I don't yet read or write the multiple configs because I am not exactly sure how they work yet. However, because includes are stored in the main tree directly rather than having their own XML doc, it's still better that we read and write part of them (less destructive to the tree) rather than none of them (totally destructive to the tree).