### PR TITLE
Included File Editing Support

### DIFF
--- a/org/lateralgm/file/GMXFileWriter.java
+++ b/org/lateralgm/file/GMXFileWriter.java
@@ -1158,7 +1158,7 @@ public final class GMXFileWriter
 		// Write Backgrounds
 		Element backroot = doc.createElement("backgrounds"); //$NON-NLS-1$
 		roomroot.appendChild(backroot);
-		for (BackgroundDef back : room.backgroundDefs) 
+		for (BackgroundDef back : room.backgroundDefs)
 			{
 			PropertyMap<PBackgroundDef> props = back.properties;
 			Element bckelement = doc.createElement("background"); //$NON-NLS-1$
@@ -1298,8 +1298,9 @@ public final class GMXFileWriter
 				include.get(PInclude.SIZE).toString()));
 		incRoot.appendChild(createElement(dom,"exportDir", //$NON-NLS-1$
 				include.get(PInclude.EXPORTFOLDER).toString()));
+		int exportCode = ProjectFile.INCLUDE_EXPORT_CODE.get(include.get(PInclude.EXPORTACTION));
 		incRoot.appendChild(createElement(dom,"exportAction", //$NON-NLS-1$
-				include.get(PInclude.EXPORTACTION).toString()));
+				Integer.toString(exportCode)));
 		incRoot.appendChild(createElement(dom,"overwrite", //$NON-NLS-1$
 				boolToString((Boolean)include.get(PInclude.OVERWRITE))));
 		incRoot.appendChild(createElement(dom,"store", //$NON-NLS-1$

--- a/org/lateralgm/file/GmFileReader.java
+++ b/org/lateralgm/file/GmFileReader.java
@@ -1261,7 +1261,9 @@ public final class GmFileReader
 			incRoot = new ResNode("Includes",ResNode.STATUS_PRIMARY,Include.class);
 			for (Include inc : f.resMap.getList(Include.class))
 				{
-				inc.setName(Util.fileNameWithoutExtension(inc.get(PInclude.FILENAME).toString()));
+				String filename = inc.get(PInclude.FILENAME).toString();
+				if (!filename.isEmpty())
+					inc.setName(Util.fileNameWithoutExtension(filename));
 				incRoot.add(new ResNode(inc.getName(),ResNode.STATUS_SECONDARY,Include.class,inc.reference));
 				}
 			}

--- a/org/lateralgm/file/GmFileReader.java
+++ b/org/lateralgm/file/GmFileReader.java
@@ -490,11 +490,12 @@ public final class GmFileReader
 		//		f.gameSettings.includeFolder = in.read4(); //0 = main, 1 = temp
 		in.readBool(gs.properties,PGameSettings.OVERWRITE_EXISTING,
 				PGameSettings.REMOVE_AT_GAME_END);
+		 //1 = temp, 2 = main
+		ExportAction exportAction = gs.get(PGameSettings.INCLUDE_FOLDER) == IncludeFolder.TEMP
+				? ExportAction.TEMP_DIRECTORY : ExportAction.SAME_FOLDER;
 		for (Include inc : f.resMap.getList(Include.class))
 			{
-			 //1 = temp, 2 = main
-			ExportAction exportAction = gs.get(PGameSettings.INCLUDE_FOLDER) == IncludeFolder.TEMP
-					? ExportAction.TEMP_DIRECTORY : ExportAction.SAME_FOLDER;
+			inc.put(PInclude.EXPORTACTION,exportAction);
 			inc.put(PInclude.OVERWRITE,gs.get(PGameSettings.OVERWRITE_EXISTING));
 			inc.put(PInclude.REMOVEATGAMEEND,gs.get(PGameSettings.REMOVE_AT_GAME_END));
 			}

--- a/org/lateralgm/file/GmFileReader.java
+++ b/org/lateralgm/file/GmFileReader.java
@@ -481,9 +481,9 @@ public final class GmFileReader
 		for (int i = 0; i < no; i++)
 			{
 			Include inc = f.resMap.getList(Include.class).add();
-			inc.put(PInclude.FILEPATH,in.readStr());
-			String filepath = inc.get(PInclude.FILEPATH).toString();
+			String filepath = in.readStr();
 			String filename = new File(filepath).getName();
+			inc.put(PInclude.FILEPATH,filepath);
 			inc.put(PInclude.FILENAME,filename);
 			}
 		gs.put(PGameSettings.INCLUDE_FOLDER,ProjectFile.GS_INCFOLDERS[in.read4()]);
@@ -846,9 +846,9 @@ public final class GmFileReader
 					throw new GmFormatException(f,Messages.format("ProjectFileReader.ERROR_UNSUPPORTED", //$NON-NLS-1$
 							Messages.getString("ProjectFileReader.INDATAFILES"),ver)); //$NON-NLS-1$
 				Include inc = f.resMap.getList(Include.class).add();
-				inc.put(PInclude.FILEPATH,in.readStr());
-				String filepath = inc.get(PInclude.FILEPATH).toString();
+				String filepath = in.readStr();
 				String filename = new File(filepath).getName();
+				inc.put(PInclude.FILEPATH,filepath);
 				inc.put(PInclude.FILENAME,filename);
 				if (in.readBool()) //file data exists?
 					{
@@ -1123,8 +1123,7 @@ public final class GmFileReader
 				throw new GmFormatException(f,Messages.format("ProjectFileReader.ERROR_UNSUPPORTED", //$NON-NLS-1$
 						Messages.getString("ProjectFileReader.ININCLUDEDFILES"),ver)); //$NON-NLS-1$
 			Include inc = f.resMap.getList(Include.class).add();
-			String filename = in.readStr();
-			inc.put(PInclude.FILENAME,filename);
+			inc.put(PInclude.FILENAME,in.readStr());
 			inc.put(PInclude.FILEPATH,in.readStr());
 			inc.put(PInclude.ORIGINAL,in.readBool());
 			int size = in.read4();

--- a/org/lateralgm/file/GmFileReader.java
+++ b/org/lateralgm/file/GmFileReader.java
@@ -24,6 +24,7 @@ import java.util.Stack;
 import java.util.zip.DataFormatException;
 
 import javax.swing.JProgressBar;
+import javax.swing.tree.TreeNode;
 
 import org.lateralgm.components.impl.ResNode;
 import org.lateralgm.file.ProjectFile.ResourceHolder;
@@ -47,9 +48,10 @@ import org.lateralgm.resources.GameSettings.ProgressBar;
 import org.lateralgm.resources.GmObject;
 import org.lateralgm.resources.GmObject.PGmObject;
 import org.lateralgm.resources.Include;
+import org.lateralgm.resources.Include.ExportAction;
+import org.lateralgm.resources.Include.PInclude;
 import org.lateralgm.resources.InstantiableResource;
 import org.lateralgm.resources.Path;
-import org.lateralgm.resources.Shader;
 import org.lateralgm.resources.Path.PPath;
 import org.lateralgm.resources.Resource;
 import org.lateralgm.resources.ResourceReference;
@@ -57,6 +59,7 @@ import org.lateralgm.resources.Room;
 import org.lateralgm.resources.Room.PRoom;
 import org.lateralgm.resources.Script;
 import org.lateralgm.resources.Script.PScript;
+import org.lateralgm.resources.Shader;
 import org.lateralgm.resources.Sound;
 import org.lateralgm.resources.Sound.PSound;
 import org.lateralgm.resources.Sprite;
@@ -478,8 +481,10 @@ public final class GmFileReader
 		for (int i = 0; i < no; i++)
 			{
 			Include inc = f.resMap.getList(Include.class).add();
-			inc.filepath = in.readStr();
-			inc.filename = new File(inc.filepath).getName();
+			inc.put(PInclude.FILEPATH,in.readStr());
+			String filepath = inc.get(PInclude.FILEPATH).toString();
+			String filename = new File(filepath).getName();
+			inc.put(PInclude.FILENAME,filename);
 			}
 		gs.put(PGameSettings.INCLUDE_FOLDER,ProjectFile.GS_INCFOLDERS[in.read4()]);
 		//		f.gameSettings.includeFolder = in.read4(); //0 = main, 1 = temp
@@ -487,9 +492,11 @@ public final class GmFileReader
 				PGameSettings.REMOVE_AT_GAME_END);
 		for (Include inc : f.resMap.getList(Include.class))
 			{
-			inc.export = gs.get(PGameSettings.INCLUDE_FOLDER) == IncludeFolder.TEMP ? 1 : 2; //1 = temp, 2 = main
-			inc.overwriteExisting = gs.get(PGameSettings.OVERWRITE_EXISTING);
-			inc.removeAtGameEnd = gs.get(PGameSettings.REMOVE_AT_GAME_END);
+			 //1 = temp, 2 = main
+			ExportAction exportAction = gs.get(PGameSettings.INCLUDE_FOLDER) == IncludeFolder.TEMP
+					? ExportAction.TEMP_DIRECTORY : ExportAction.SAME_FOLDER;
+			inc.put(PInclude.OVERWRITE,gs.get(PGameSettings.OVERWRITE_EXISTING));
+			inc.put(PInclude.REMOVEATGAMEEND,gs.get(PGameSettings.REMOVE_AT_GAME_END));
 			}
 		}
 
@@ -819,7 +826,7 @@ public final class GmFileReader
 			}
 		}
 
-	private static void readFonts(ProjectFileContext c, int ver) throws IOException,GmFormatException
+	private static void readFonts(ProjectFileContext c, int ver) throws IOException,GmFormatException,DataFormatException
 		{
 		ProjectFile f = c.f;
 		GmStreamDecoder in = c.in;
@@ -838,20 +845,22 @@ public final class GmFileReader
 					throw new GmFormatException(f,Messages.format("ProjectFileReader.ERROR_UNSUPPORTED", //$NON-NLS-1$
 							Messages.getString("ProjectFileReader.INDATAFILES"),ver)); //$NON-NLS-1$
 				Include inc = f.resMap.getList(Include.class).add();
-				inc.filepath = in.readStr();
-				inc.filename = new File(inc.filepath).getName();
+				inc.put(PInclude.FILEPATH,in.readStr());
+				String filepath = inc.get(PInclude.FILEPATH).toString();
+				String filename = new File(filepath).getName();
+				inc.put(PInclude.FILENAME,filename);
 				if (in.readBool()) //file data exists?
 					{
-					inc.size = in.read4();
-					inc.data = new byte[inc.size];
-					in.read(inc.data,0,inc.size);
+					inc.data = in.decompress(in.read4());
+					if (inc.data != null)
+						inc.put(PInclude.SIZE,inc.data.length);
 					}
-				inc.export = in.read4();
+				inc.put(PInclude.EXPORTACTION,ProjectFile.INCLUDE_EXPORT_ACTION[in.read4()]);
 				//FIXME: Deal with Font Includes
 				//if (inc.export == 3) inc.exportFolder = Font Folder?
-				inc.overwriteExisting = in.readBool();
-				inc.freeMemAfterExport = in.readBool();
-				inc.removeAtGameEnd = in.readBool();
+				inc.put(PInclude.OVERWRITE,in.readBool());
+				inc.put(PInclude.FREEMEMORY,in.readBool());
+				inc.put(PInclude.REMOVEATGAMEEND,in.readBool());
 				}
 			return;
 			}
@@ -1113,21 +1122,25 @@ public final class GmFileReader
 				throw new GmFormatException(f,Messages.format("ProjectFileReader.ERROR_UNSUPPORTED", //$NON-NLS-1$
 						Messages.getString("ProjectFileReader.ININCLUDEDFILES"),ver)); //$NON-NLS-1$
 			Include inc = f.resMap.getList(Include.class).add();
-			inc.filename = in.readStr();
-			inc.filepath = in.readStr();
-			inc.isOriginal = in.readBool();
-			inc.size = in.read4();
-			if (in.readBool()) //store in editable?
+			String filename = in.readStr();
+			inc.put(PInclude.FILENAME,filename);
+			inc.put(PInclude.FILEPATH,in.readStr());
+			inc.put(PInclude.ORIGINAL,in.readBool());
+			int size = in.read4();
+			inc.put(PInclude.SIZE,size);
+			boolean store = in.readBool();
+			inc.put(PInclude.STORE,store);
+			if (store)
 				{
 				int s = in.read4();
 				inc.data = new byte[s];
 				in.read(inc.data,0,s);
 				}
-			inc.export = in.read4();
-			inc.exportFolder = in.readStr();
-			inc.overwriteExisting = in.readBool();
-			inc.freeMemAfterExport = in.readBool();
-			inc.removeAtGameEnd = in.readBool();
+			inc.put(PInclude.EXPORTACTION,ProjectFile.INCLUDE_EXPORT_ACTION[in.read4()]);
+			inc.put(PInclude.EXPORTFOLDER,in.readStr());
+			inc.put(PInclude.OVERWRITE,in.readBool());
+			inc.put(PInclude.FREEMEMORY,in.readBool());
+			inc.put(PInclude.REMOVEATGAMEEND,in.readBool());
 			in.endInflate();
 			}
 		}
@@ -1189,6 +1202,9 @@ public final class GmFileReader
 			{
 			byte status = (byte) in.read4();
 			Class<?> type = ProjectFile.RESOURCE_KIND[in.read4()];
+			// It's "Data Files" in GM5, some of which are fonts.
+			if (ver == 500 && type == Font.class)
+				type = Include.class;
 			int ind = in.read4();
 			String name = in.readStr();
 			boolean hasRef;
@@ -1199,11 +1215,18 @@ public final class GmFileReader
 				hasRef = false;
 			ResourceList<?> rl = hasRef ? (ResourceList<?>) f.resMap.get(type) : null;
 			ResNode node = new ResNode(name,status,type,hasRef ? rl.getUnsafe(ind).reference : null);
+			if (ver == 500 && type == Include.class)
+				{
+				// Included files don't redundantly store the name with the metadata
+				// so we need to sync the resource name with the tree name.
+				if (hasRef) rl.getUnsafe(ind).setName(name);
 
-			if (ver == 500 && status == ResNode.STATUS_PRIMARY && type == Font.class)
-				path.peek().addChild(Messages.getString("LGM.FNT"),status,type); //$NON-NLS-1$
-			else
-				path.peek().add(node);
+				// GameMaker 5 did not have a dedicated primary fonts group, let's add one.
+				if (status == ResNode.STATUS_PRIMARY)
+					path.peek().addChild(Messages.getString("LGM.FNT"),status,Font.class); //$NON-NLS-1$
+				}
+
+			path.peek().add(node);
 			int contents = in.read4();
 			if (contents > 0)
 				{
@@ -1216,25 +1239,44 @@ public final class GmFileReader
 				rootnodes = left.pop().intValue();
 				path.pop();
 				}
-
 			}
-		if (ver <= 540) root.addChild(Messages.getString("LGM.EXT"), //$NON-NLS-1$
+
+		ResNode incRoot = null;
+		if (ver == 500)
+			{
+			// For GameMaker 5 we need to move the "Data Files" folder
+			// to the place of the "Includes" folder in LGM's default tree
+			TreeNode dataFileNode = root.getChildAt(6);
+			if (dataFileNode instanceof ResNode)
+				{
+				incRoot = (ResNode)dataFileNode;
+				incRoot.setUserObject("Includes");
+				root.remove(incRoot);
+				}
+			}
+		else
+			{
+			// All newer GameMaker versions don't have a primary node for included files.
+			// Therefore we need to create a primary node for them and construct a tree.
+			incRoot = new ResNode("Includes",ResNode.STATUS_PRIMARY,Include.class);
+			for (Include inc : f.resMap.getList(Include.class))
+				{
+				inc.setName(Util.fileNameWithoutExtension(inc.get(PInclude.FILENAME).toString()));
+				incRoot.add(new ResNode(inc.getName(),ResNode.STATUS_SECONDARY,Include.class,inc.reference));
+				}
+			}
+		root.insert(incRoot,9);
+
+		if (ver <= 540) root.addChild("Extension Packages",
 				ResNode.STATUS_SECONDARY,ExtensionPackages.class);
 
-		//TODO: This just makes the GMK arrange to the modern version of the IDE
+		//This just makes the GMK arrange to the modern version of the IDE
 		ResNode node = new ResNode("Shaders",ResNode.STATUS_PRIMARY,Shader.class);
 		root.insert(node,5);
 		node = new ResNode("Extensions",ResNode.STATUS_PRIMARY,Extension.class);
-		root.insert(node,10);
-		node = new ResNode("Includes",ResNode.STATUS_PRIMARY,Include.class);
-		root.insert(node,10);
-		for (Include inc : f.resMap.getList(Include.class))
-			{
-			node.add(new ResNode(inc.getName(),ResNode.STATUS_SECONDARY,Include.class,inc.reference));
-			}
+		root.insert(node,11);
 		node = new ResNode("Constants",ResNode.STATUS_SECONDARY,Constants.class);
 		root.insert(node,12);
-
 		}
 
 	private static void readActions(ProjectFileContext c, ActionContainer container, String errorKey,

--- a/org/lateralgm/file/GmFileWriter.java
+++ b/org/lateralgm/file/GmFileWriter.java
@@ -760,14 +760,13 @@ public final class GmFileWriter
 			out.writeStr(i.properties,PInclude.FILEPATH);
 			out.writeBool(i.properties,PInclude.ORIGINAL);
 			out.write4(i.properties,PInclude.SIZE);
-			if (i.data != null)
+			boolean store = i.get(PInclude.STORE);
+			out.writeBool(store);
+			if (store)
 				{
-				out.writeBool(true);
 				out.write4(i.data.length);
 				out.write(i.data);
 				}
-			else
-				out.writeBool(false);
 			out.write4(ProjectFile.INCLUDE_EXPORT_CODE.get(i.get(PInclude.EXPORTACTION)));
 			out.writeStr(i.properties,PInclude.EXPORTFOLDER);
 			out.writeBool(i.properties,PInclude.OVERWRITE);

--- a/org/lateralgm/file/GmFileWriter.java
+++ b/org/lateralgm/file/GmFileWriter.java
@@ -16,8 +16,8 @@ import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.io.OutputStream;
+import java.nio.charset.Charset;
 import java.util.Enumeration;
 import java.util.List;
 
@@ -29,53 +29,54 @@ import org.lateralgm.main.LGM;
 import org.lateralgm.main.Util;
 import org.lateralgm.messages.Messages;
 import org.lateralgm.resources.Background;
+import org.lateralgm.resources.Background.PBackground;
 import org.lateralgm.resources.Constants;
 import org.lateralgm.resources.Extension;
 import org.lateralgm.resources.Font;
+import org.lateralgm.resources.Font.PFont;
 import org.lateralgm.resources.GameInformation;
+import org.lateralgm.resources.GameInformation.PGameInformation;
 import org.lateralgm.resources.GameSettings;
+import org.lateralgm.resources.GameSettings.PGameSettings;
+import org.lateralgm.resources.GameSettings.ProgressBar;
 import org.lateralgm.resources.GmObject;
+import org.lateralgm.resources.GmObject.PGmObject;
 import org.lateralgm.resources.Include;
+import org.lateralgm.resources.Include.PInclude;
 import org.lateralgm.resources.InstantiableResource;
 import org.lateralgm.resources.Path;
+import org.lateralgm.resources.Path.PPath;
 import org.lateralgm.resources.Resource;
 import org.lateralgm.resources.ResourceReference;
 import org.lateralgm.resources.Room;
+import org.lateralgm.resources.Room.PRoom;
 import org.lateralgm.resources.Script;
+import org.lateralgm.resources.Script.PScript;
 import org.lateralgm.resources.Shader;
 import org.lateralgm.resources.Sound;
-import org.lateralgm.resources.Sprite;
-import org.lateralgm.resources.Timeline;
-import org.lateralgm.resources.Background.PBackground;
-import org.lateralgm.resources.Font.PFont;
-import org.lateralgm.resources.GameInformation.PGameInformation;
-import org.lateralgm.resources.GameSettings.PGameSettings;
-import org.lateralgm.resources.GameSettings.ProgressBar;
-import org.lateralgm.resources.GmObject.PGmObject;
-import org.lateralgm.resources.Path.PPath;
-import org.lateralgm.resources.Room.PRoom;
-import org.lateralgm.resources.Script.PScript;
 import org.lateralgm.resources.Sound.PSound;
+import org.lateralgm.resources.Sprite;
 import org.lateralgm.resources.Sprite.PSprite;
+import org.lateralgm.resources.Timeline;
 import org.lateralgm.resources.library.LibAction;
 import org.lateralgm.resources.sub.Action;
 import org.lateralgm.resources.sub.ActionContainer;
 import org.lateralgm.resources.sub.Argument;
 import org.lateralgm.resources.sub.BackgroundDef;
-import org.lateralgm.resources.sub.CharacterRange.PCharacterRange;
+import org.lateralgm.resources.sub.BackgroundDef.PBackgroundDef;
 import org.lateralgm.resources.sub.CharacterRange;
+import org.lateralgm.resources.sub.CharacterRange.PCharacterRange;
 import org.lateralgm.resources.sub.Constant;
 import org.lateralgm.resources.sub.Event;
 import org.lateralgm.resources.sub.Instance;
+import org.lateralgm.resources.sub.Instance.PInstance;
 import org.lateralgm.resources.sub.MainEvent;
 import org.lateralgm.resources.sub.Moment;
 import org.lateralgm.resources.sub.PathPoint;
 import org.lateralgm.resources.sub.Tile;
+import org.lateralgm.resources.sub.Tile.PTile;
 import org.lateralgm.resources.sub.Trigger;
 import org.lateralgm.resources.sub.View;
-import org.lateralgm.resources.sub.BackgroundDef.PBackgroundDef;
-import org.lateralgm.resources.sub.Instance.PInstance;
-import org.lateralgm.resources.sub.Tile.PTile;
 import org.lateralgm.resources.sub.View.PView;
 import org.lateralgm.util.PropertyMap;
 
@@ -278,7 +279,7 @@ public final class GmFileWriter
 				ResourceList<Include> includes = f.resMap.getList(Include.class);
 				out.write4(includes.size());
 				for (Include inc : includes)
-					out.writeStr(inc.filepath);
+					out.writeStr(inc.properties,PInclude.FILEPATH);
 				out.write4(ProjectFile.GS_INCFOLDER_CODE.get(p.get(PGameSettings.INCLUDE_FOLDER)));
 				out.writeBool(p,PGameSettings.OVERWRITE_EXISTING,PGameSettings.REMOVE_AT_GAME_END);
 				}
@@ -755,10 +756,10 @@ public final class GmFileWriter
 				out.writeD(gs.getLastChanged());
 				}
 			out.write4(ver);
-			out.writeStr(i.filename);
-			out.writeStr(i.filepath);
-			out.writeBool(i.isOriginal);
-			out.write4(i.size);
+			out.writeStr(i.properties,PInclude.FILENAME);
+			out.writeStr(i.properties,PInclude.FILEPATH);
+			out.writeBool(i.properties,PInclude.ORIGINAL);
+			out.write4(i.properties,PInclude.SIZE);
 			if (i.data != null)
 				{
 				out.writeBool(true);
@@ -767,11 +768,11 @@ public final class GmFileWriter
 				}
 			else
 				out.writeBool(false);
-			out.write4(i.export);
-			out.writeStr(i.exportFolder);
-			out.writeBool(i.overwriteExisting);
-			out.writeBool(i.freeMemAfterExport);
-			out.writeBool(i.removeAtGameEnd);
+			out.write4(ProjectFile.INCLUDE_EXPORT_CODE.get(i.get(PInclude.EXPORTACTION)));
+			out.writeStr(i.properties,PInclude.EXPORTFOLDER);
+			out.writeBool(i.properties,PInclude.OVERWRITE);
+			out.writeBool(i.properties,PInclude.FREEMEMORY);
+			out.writeBool(i.properties,PInclude.REMOVEATGAMEEND);
 			out.endDeflate();
 			}
 		}

--- a/org/lateralgm/file/ProjectFile.java
+++ b/org/lateralgm/file/ProjectFile.java
@@ -59,6 +59,7 @@ import org.lateralgm.resources.GameSettings.ProgressBar;
 import org.lateralgm.resources.GameSettings.Resolution;
 import org.lateralgm.resources.GmObject;
 import org.lateralgm.resources.GmObject.PhysicsShape;
+import org.lateralgm.resources.Include.ExportAction;
 import org.lateralgm.resources.InstantiableResource;
 import org.lateralgm.resources.Path;
 import org.lateralgm.resources.Resource;
@@ -199,6 +200,16 @@ public class ProjectFile implements UpdateListener
 		m.put(MaskShape.POLYGON,m.get(MaskShape.RECTANGLE));
 		SPRITE_MASK_CODE = Collections.unmodifiableMap(m);
 		}
+	public static final ExportAction[] INCLUDE_EXPORT_ACTION = { ExportAction.DONT_EXPORT, ExportAction.TEMP_DIRECTORY,
+			ExportAction.SAME_FOLDER, ExportAction.CUSTOM_FOLDER };
+	public static final Map<ExportAction,Integer> INCLUDE_EXPORT_CODE;
+	static
+		{
+		EnumMap<ExportAction,Integer> m = new EnumMap<ExportAction,Integer>(ExportAction.class);
+		for (int i = 0; i < INCLUDE_EXPORT_ACTION.length; i++)
+			m.put(INCLUDE_EXPORT_ACTION[i],i);
+		INCLUDE_EXPORT_CODE = Collections.unmodifiableMap(m);
+		}
 
 	public String getPath()
 		{
@@ -289,8 +300,8 @@ public class ProjectFile implements UpdateListener
 
 	public static class FormatFlavor
 		{
-		public static final String GM_OWNER = "GM";
-		public static final String GMX_OWNER = "GMX";
+		public static final String GM_OWNER = "GM"; //$NON-NLS-1$
+		public static final String GMX_OWNER = "GMX"; //$NON-NLS-1$
 		public static final FormatFlavor GM_530 = new FormatFlavor(GM_OWNER,530);
 		public static final FormatFlavor GM_600 = new FormatFlavor(GM_OWNER,600);
 		public static final FormatFlavor GM_701 = new FormatFlavor(GM_OWNER,701);

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -56,6 +56,7 @@ import java.util.Properties;
 import java.util.Scanner;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
+
 import javax.imageio.spi.IIORegistry;
 import javax.swing.AbstractButton;
 import javax.swing.Box;
@@ -134,7 +135,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.72"; //$NON-NLS-1$
+	public static final String version = "1.8.73"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/main/Util.java
+++ b/org/lateralgm/main/Util.java
@@ -66,6 +66,7 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
 import javax.swing.border.Border;
+
 import org.lateralgm.components.CustomFileChooser;
 import org.lateralgm.components.impl.CustomFileFilter;
 import org.lateralgm.components.visual.FileChooserImagePreview;
@@ -238,7 +239,7 @@ public final class Util
 			return Util.readFully(new File(path));
 		}
 
-	public static void writeFully(File file, byte[] data) throws FileNotFoundException, IOException 
+	public static void writeFully(File file, byte[] data) throws FileNotFoundException, IOException
 		{
 		try (FileOutputStream fos = new FileOutputStream(file);
 				BufferedOutputStream bos = new BufferedOutputStream(fos))
@@ -475,6 +476,15 @@ public final class Util
 			return ""; // empty extension
 			}
 		return name.substring(lastIndexOf + 1);
+		}
+
+	public static String fileNameWithoutExtension(String fileName)
+		{
+		if (fileName.indexOf('.') > 0)
+			{
+			return fileName.substring(0,fileName.indexOf('.'));
+			}
+		return fileName;
 		}
 
 	//TODO: JPEG Writing is bugged in some newer JVM versions causing the RGB color channels to be mixed up.
@@ -1224,7 +1234,7 @@ public final class Util
 			ico.getDescriptors().add(bmd);
 			}
 		}
-	
+
 	public static void OpenDesktopEditor(File file)
 		{
 		try

--- a/org/lateralgm/main/icons.properties
+++ b/org/lateralgm/main/icons.properties
@@ -267,14 +267,8 @@ ActionList.DELETE=actions/delete.png
 ConstantsFrame.IMPORT=actions/open.png
 ConstantsFrame.EXPORT=actions/save.png
 
-IncludeFrame.IMPORT=actions/open.png
-IncludeFrame.EXPORT=actions/save.png
-IncludeFrame.OVERWRITE=Overwrite existing file
-IncludeFrame.FREEDATA=Free data after export
-IncludeFrame.REMOVEATGAMEEND=Remove at game end
-IncludeFrame.EXPORTTO=Export to Targets
-IncludeFrame.SIZE=Size
-IncludeFrame.ORIGINAL=Original
+IncludeFrame.LOAD_DATA=actions/open.png
+IncludeFrame.SAVE_DATA=actions/save.png
 
 EnigmaPlugin.STOP=actions/stop.png
 EnigmaPlugin.EXECUTE=actions/execute.png

--- a/org/lateralgm/messages/messages.properties
+++ b/org/lateralgm/messages/messages.properties
@@ -636,6 +636,27 @@ RevertableMDIFrame.KEEPCHANGES_TITLE=Unsaved Changes
 
 ## Include Frame
 IncludeFrame.TITLE=Included File
+IncludeFrame.NAME=Name:
+IncludeFrame.SAVE=Save
+IncludeFrame.LOAD_DATA=Load Data
+IncludeFrame.SAVE_DATA=Save Data
+IncludeFrame.LOAD_TIP=Load data from file
+IncludeFrame.SAVE_TIP=Save data to file
+IncludeFrame.FILE_NAME=File Name:
+IncludeFrame.SIZE=Size: {0} bytes
+IncludeFrame.ORIGINAL_FILE=Original File: {0}
+IncludeFrame.COPIES_TO=Copies to:
+IncludeFrame.PLATFORMS=
+IncludeFrame.OVERWRITE_EXISTING=Overwrite existing files
+IncludeFrame.REMOVE_FILES_AT_END=Remove files at end of game
+IncludeFrame.STORE_EDITABLE=Store in the project editable
+IncludeFrame.FREE_MEMORY=Free memory after export
+
+IncludeFrame.EXPORT_ACTION=Export Action
+IncludeFrame.DONT_EXPORT=Don't export by default
+IncludeFrame.TEMP_DIRECTORY=Temporary directory
+IncludeFrame.SAME_FOLDER=Same folder as executable
+IncludeFrame.CUSTOM_FOLDER=Custom folder:
 
 ## Extension Frame
 ExtensionFrame.TITLE=Extension
@@ -849,19 +870,6 @@ GameSettingFrame.COMPANY=Company:
 GameSettingFrame.PRODUCT=Product:
 GameSettingFrame.COPYRIGHT=Copyright:
 GameSettingFrame.DESCRIPTION=Description:
-
-#Include tab
-GameSettingFrame.TAB_INCLUDE=Include
-GameSettingFrame.HINT_INCLUDE=Configure Includes
-GameSettingFrame.FILES_TO_INCLUDE=Files to include in the Executable
-GameSettingFrame.ADD_INCLUDE=Add
-GameSettingFrame.DELETE_INCLUDE=Delete
-GameSettingFrame.CLEAR_INCLUDES=Clear
-GameSettingFrame.EXPORT_TO=Folder to export to
-GameSettingFrame.SAME_FOLDER=Same folder as executable
-GameSettingFrame.TEMP_DIRECTORY=Temporary directory
-GameSettingFrame.OVERWRITE_EXISTING=Overwrite existing files
-GameSettingFrame.REMOVE_FILES_AT_END=Remove files at end of game
 
 #Errors tab
 GameSettingFrame.TAB_ERRORS=Errors
@@ -1492,16 +1500,6 @@ Targets.TIZEN_NATIVE=Tizen (Native)
 Targets.WINDOWSYYC=Windows (YYC)
 Targets.ANDROIDYYC=Android (YYC)
 Targets.IOSYYC=iOS (YYC)
-
-#Included File Frame
-IncludeFrame.NAME=Name
-IncludeFrame.IMPORT=Import data from file
-IncludeFrame.EXPORT=Export data to file
-IncludeFrame.SIZE=Size:
-IncludeFrame.BYTES={0} bytes
-IncludeFrame.ORIGINAL_FILE=Original File:
-IncludeFrame.COPIES_TO=Copies to:
-IncludeFrame.PLATFORMS=
 
 ##JoshEdit
 JoshText.TYPE_TXT=Plain Text File

--- a/org/lateralgm/resources/Include.java
+++ b/org/lateralgm/resources/Include.java
@@ -16,61 +16,46 @@ public class Include extends InstantiableResource<Include,Include.PInclude>
 	{
 	public byte[] data = new byte[0];
 
+	public enum ExportAction
+		{
+		DONT_EXPORT,TEMP_DIRECTORY,SAME_FOLDER,CUSTOM_FOLDER
+		}
+
 	public enum PInclude
 		{
 		FILENAME,FILEPATH,ORIGINAL,SIZE,EXPORTACTION,EXPORTFOLDER,OVERWRITE,FREEMEMORY,REMOVEATGAMEEND,
 		STORE
 		}
 
-	private static final EnumMap<PInclude,Object> DEF = PropertyMap.makeDefaultMap(PInclude.class,"",
-			"",true,0,2,"",false,true,true,false);
+	private static final EnumMap<PInclude,Object> DEFS = PropertyMap.makeDefaultMap(PInclude.class,"", //$NON-NLS-1$
+			"",true,0,ExportAction.SAME_FOLDER,"",false,true,true,false);  //$NON-NLS-1$//$NON-NLS-2$
 
-	public String filename = ""; //$NON-NLS-1$
-	public String filepath = ""; //$NON-NLS-1$
-	public boolean isOriginal;
-	public int size = 0;
-	public int export = 2;
-	public String exportFolder = ""; //$NON-NLS-1$
-	public boolean overwriteExisting = false;
-	public boolean freeMemAfterExport = true;
-	public boolean removeAtGameEnd = true;
-
-	public Include copy()
+	public Include()
 		{
-		Include inc = new Include();
-		inc.filename = filename;
-		inc.filepath = filepath;
-		inc.isOriginal = isOriginal;
-		inc.size = size;
-		inc.data = data;
-		inc.export = export;
-		inc.exportFolder = exportFolder;
-		inc.overwriteExisting = overwriteExisting;
-		inc.freeMemAfterExport = freeMemAfterExport;
-		inc.removeAtGameEnd = removeAtGameEnd;
-		return inc;
+		this(null);
 		}
 
-	public String toString()
+	public Include(ResourceReference<Include> ref)
 		{
-		return filepath;
+		super(ref);
 		}
 
 	@Override
 	public Include makeInstance(ResourceReference<Include> ref)
 		{
-		return new Include();
+		return new Include(ref);
 		}
 
 	@Override
 	protected PropertyMap<PInclude> makePropertyMap()
 		{
-		return new PropertyMap<PInclude>(PInclude.class,this,DEF);
+		return new PropertyMap<PInclude>(PInclude.class,this,DEFS);
 		}
 
 	@Override
 	protected void postCopy(Include dest)
-		{ //Nothing else to copy
-
+		{
+		super.postCopy(dest);
+		dest.data = data.clone();
 		}
 	}

--- a/org/lateralgm/subframes/IncludeFrame.java
+++ b/org/lateralgm/subframes/IncludeFrame.java
@@ -4,7 +4,7 @@
 *
 * @section License
 *
-* Copyright (C) 2014 Robert B. Colton
+* Copyright (C) 2014,2019 Robert B. Colton
 * This file is a part of the LateralGM IDE.
 *
 * This program is free software: you can redistribute it and/or modify
@@ -23,63 +23,84 @@
 
 package org.lateralgm.subframes;
 
+import static java.lang.Integer.MAX_VALUE;
+import static javax.swing.GroupLayout.DEFAULT_SIZE;
+import static javax.swing.GroupLayout.PREFERRED_SIZE;
+
 import java.awt.BorderLayout;
 import java.awt.event.ActionEvent;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 
+import javax.swing.BorderFactory;
+import javax.swing.BoxLayout;
+import javax.swing.ButtonGroup;
 import javax.swing.GroupLayout;
+import javax.swing.GroupLayout.Alignment;
 import javax.swing.JButton;
+import javax.swing.JCheckBox;
 import javax.swing.JFileChooser;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.JToolBar;
+import javax.swing.JRadioButton;
+import javax.swing.JTextField;
 
 import org.lateralgm.components.CustomFileChooser;
-import org.lateralgm.components.impl.DocumentUndoManager;
 import org.lateralgm.components.impl.ResNode;
 import org.lateralgm.main.LGM;
 import org.lateralgm.messages.Messages;
 import org.lateralgm.resources.ExtensionPackages;
 import org.lateralgm.resources.Include;
+import org.lateralgm.resources.Include.ExportAction;
+import org.lateralgm.resources.Include.PInclude;
 
 public class IncludeFrame extends InstantiableResourceFrame<Include,Include.PInclude>
 	{
-	private static final long serialVersionUID = 1L;
-	protected DocumentUndoManager undoManager = new DocumentUndoManager();
-	private CustomFileChooser fc = new CustomFileChooser("/org/lateralgm","LAST_FILE_DIR");
-	private JButton exportBut;
-	private JButton importBut;
-
-	public IncludeFrame(Include res)
-		{
-		this(res,null);
-		}
+	/**
+	 * NOTE: Default UID generated, changed if necessary.
+	 */
+	private static final long serialVersionUID = -2341007814035473389L;
+	private CustomFileChooser fc = new CustomFileChooser("/org/lateralgm","LAST_INCLUDE_FILE_DIR");  //$NON-NLS-1$//$NON-NLS-2$
+	private JButton saveDataBut, loadDataBut;
+	private JLabel originalNameLabel, sizeLabel;
 
 	public IncludeFrame(Include r, ResNode node)
 		{
-		//,Messages.getString("IncludeFrame.TITLE"),true
 		super(r,node);
 		setDefaultCloseOperation(HIDE_ON_CLOSE);
-		setSize(300,350);
 		this.setLayout(new BorderLayout());
 
-		JToolBar toolbar = new JToolBar();
-		toolbar.setFloatable(false);
-		toolbar.add(save);
-		toolbar.addSeparator();
-		exportBut = new JButton(LGM.getIconForKey("IncludeFrame.EXPORT")); //$NON-NLS-1$
-		exportBut.setToolTipText(Messages.getString("IncludeFrame.EXPORT"));
-		exportBut.addActionListener(this);
-		toolbar.add(exportBut);
-		importBut = new JButton(LGM.getIconForKey("IncludeFrame.IMPORT")); //$NON-NLS-1$
-		importBut.setToolTipText(Messages.getString("IncludeFrame.IMPORT"));
-		importBut.addActionListener(this);
-		toolbar.add(importBut);
-		toolbar.addSeparator();
-		toolbar.add(new JLabel("Name:"));
-		name.setColumns(13);
-		name.setMaximumSize(name.getPreferredSize());
-		toolbar.add(name);
+		saveDataBut = new JButton(LGM.getIconForKey("IncludeFrame.SAVE_DATA")); //$NON-NLS-1$
+		saveDataBut.setText(Messages.getString("IncludeFrame.SAVE_DATA")); //$NON-NLS-1$
+		saveDataBut.setToolTipText(Messages.getString("IncludeFrame.SAVE_TIP")); //$NON-NLS-1$
+		saveDataBut.addActionListener(this);
+
+		loadDataBut = new JButton(LGM.getIconForKey("IncludeFrame.LOAD_DATA")); //$NON-NLS-1$
+		loadDataBut.setText(Messages.getString("IncludeFrame.LOAD_DATA")); //$NON-NLS-1$
+		loadDataBut.setToolTipText(Messages.getString("IncludeFrame.LOAD_TIP")); //$NON-NLS-1$
+		loadDataBut.addActionListener(this);
+
+		JLabel nameLabel = new JLabel(Messages.getString("IncludeFrame.NAME")); //$NON-NLS-1$
+		originalNameLabel = new JLabel();
+		sizeLabel = new JLabel();
+		updateStatusLabels();
+
+		JLabel fileNameLabel = new JLabel(Messages.getString("IncludeFrame.FILE_NAME")); //$NON-NLS-1$
+		JTextField fileNameField = new JTextField();
+		plf.make(fileNameField.getDocument(),PInclude.FILENAME);
+
+		JCheckBox store, removeEnd, freeMemory, overwrite;
+		store = new JCheckBox(Messages.getString("IncludeFrame.STORE_EDITABLE")); //$NON-NLS-1$
+		plf.make(store,PInclude.STORE);
+		removeEnd = new JCheckBox(Messages.getString("IncludeFrame.REMOVE_FILES_AT_END")); //$NON-NLS-1$
+		plf.make(removeEnd,PInclude.REMOVEATGAMEEND);
+		freeMemory = new JCheckBox(Messages.getString("IncludeFrame.FREE_MEMORY")); //$NON-NLS-1$
+		plf.make(freeMemory,PInclude.FREEMEMORY);
+		overwrite = new JCheckBox(Messages.getString("IncludeFrame.OVERWRITE_EXISTING")); //$NON-NLS-1$
+		plf.make(overwrite,PInclude.OVERWRITE);
 
 		JPanel p = new JPanel();
 		GroupLayout gl = new GroupLayout(p);
@@ -87,9 +108,100 @@ public class IncludeFrame extends InstantiableResourceFrame<Include,Include.PInc
 		gl.setAutoCreateGaps(true);
 		gl.setAutoCreateContainerGaps(true);
 
-		this.add(p,BorderLayout.CENTER);
-		this.add(toolbar,BorderLayout.NORTH);
+		JPanel exportActionPanel = new JPanel();
+		exportActionPanel.setLayout(new BoxLayout(exportActionPanel,BoxLayout.Y_AXIS));
+		exportActionPanel.setBorder(BorderFactory.createTitledBorder(
+				Messages.getString("IncludeFrame.EXPORT_ACTION"))); //$NON-NLS-1$
 
+		final JTextField customFolderField = new JTextField();
+		customFolderField.setEnabled(r.get(PInclude.EXPORTACTION) == ExportAction.CUSTOM_FOLDER);
+		plf.make(customFolderField.getDocument(),PInclude.EXPORTFOLDER);
+
+		JRadioButton dontExport, tempDirectory, sameFolder;
+		final JRadioButton customFolder;
+		dontExport = new JRadioButton(Messages.getString("IncludeFrame.DONT_EXPORT")); //$NON-NLS-1$
+		tempDirectory = new JRadioButton(Messages.getString("IncludeFrame.TEMP_DIRECTORY")); //$NON-NLS-1$
+		sameFolder = new JRadioButton(Messages.getString("IncludeFrame.SAME_FOLDER")); //$NON-NLS-1$
+		customFolder = new JRadioButton(Messages.getString("IncludeFrame.CUSTOM_FOLDER")); //$NON-NLS-1$
+		customFolder.addItemListener(new ItemListener() {
+			@Override
+			public void itemStateChanged(ItemEvent e)
+				{
+				customFolderField.setEnabled(e.getStateChange() == ItemEvent.SELECTED);
+				}
+		});
+
+		exportActionPanel.add(dontExport);
+		exportActionPanel.add(tempDirectory);
+		exportActionPanel.add(sameFolder);
+		exportActionPanel.add(customFolder);
+		exportActionPanel.add(customFolderField);
+
+		ButtonGroup bg = new ButtonGroup();
+		bg.add(dontExport);
+		bg.add(tempDirectory);
+		bg.add(sameFolder);
+		bg.add(customFolder);
+		plf.make(bg,PInclude.EXPORTACTION,Include.ExportAction.class);
+
+		save.setText(Messages.getString("IncludeFrame.SAVE")); //$NON-NLS-1$
+
+		gl.setHorizontalGroup(gl.createParallelGroup()
+		/**/.addGroup(gl.createSequentialGroup()
+		/*	*/.addComponent(save,DEFAULT_SIZE,PREFERRED_SIZE,MAX_VALUE)
+		/*	*/.addComponent(loadDataBut,DEFAULT_SIZE,PREFERRED_SIZE,MAX_VALUE)
+		/*	*/.addComponent(saveDataBut,DEFAULT_SIZE,PREFERRED_SIZE,MAX_VALUE))
+		/**/.addGroup(gl.createSequentialGroup()
+		/*	*/.addComponent(nameLabel)
+		/*	*/.addComponent(name,DEFAULT_SIZE,PREFERRED_SIZE,MAX_VALUE))
+		// we want these two labels to have an ellipsis if too long
+		// and the tooltip can be used to see the full name/value
+		/**/.addComponent(originalNameLabel,0,0,DEFAULT_SIZE)
+		/**/.addComponent(sizeLabel,0,0,DEFAULT_SIZE)
+		/**/.addGroup(gl.createSequentialGroup()
+		/*	*/.addComponent(fileNameLabel)
+		/*	*/.addComponent(fileNameField,DEFAULT_SIZE,PREFERRED_SIZE,MAX_VALUE))
+		/**/.addComponent(store)
+		/**/.addComponent(removeEnd)
+		/**/.addComponent(freeMemory)
+		/**/.addComponent(overwrite)
+		/**/.addComponent(exportActionPanel,DEFAULT_SIZE,PREFERRED_SIZE,MAX_VALUE));
+
+		gl.setVerticalGroup(gl.createSequentialGroup()
+		/**/.addGroup(gl.createParallelGroup(Alignment.BASELINE)
+		/*	*/.addComponent(save)
+		/*	*/.addComponent(loadDataBut)
+		/*	*/.addComponent(saveDataBut))
+		/**/.addGroup(gl.createParallelGroup(Alignment.BASELINE)
+		/*	*/.addComponent(nameLabel)
+		/*	*/.addComponent(name))
+		/**/.addComponent(originalNameLabel)
+		/**/.addComponent(sizeLabel)
+		/**/.addGroup(gl.createParallelGroup(Alignment.BASELINE)
+		/*	*/.addComponent(fileNameLabel)
+		/*	*/.addComponent(fileNameField))
+		/**/.addComponent(store)
+		/**/.addComponent(removeEnd)
+		/**/.addComponent(freeMemory)
+		/**/.addComponent(overwrite)
+		/**/.addComponent(exportActionPanel,DEFAULT_SIZE,DEFAULT_SIZE,PREFERRED_SIZE));
+
+		this.add(p,BorderLayout.CENTER);
+		this.pack();
+		this.setMinimumSize(this.getSize());
+		}
+
+	private void updateStatusLabels()
+		{
+		saveDataBut.setEnabled(res.data != null && res.data.length > 0);
+
+		String filePathText = Messages.format("IncludeFrame.ORIGINAL_FILE",res.get(PInclude.FILEPATH)); //$NON-NLS-1$
+		originalNameLabel.setText(filePathText);
+		String sizeText = Messages.format("IncludeFrame.SIZE",res.get(PInclude.SIZE)); //$NON-NLS-1$
+		sizeLabel.setText(sizeText);
+		// set the tooltip text too so the full path can be seen without resizing the editor
+		originalNameLabel.setToolTipText(filePathText);
+		sizeLabel.setToolTipText(sizeText);
 		}
 
 	public Object getUserObject()
@@ -107,17 +219,38 @@ public class IncludeFrame extends InstantiableResourceFrame<Include,Include.PInc
 		{
 		super.actionPerformed(ev);
 		Object source = ev.getSource();
-		if (source == importBut)
+		if (source == loadDataBut)
 			{
 			if (fc.showOpenDialog(LGM.frame) != JFileChooser.APPROVE_OPTION) return;
 			File f = fc.getSelectedFile();
 			if (!f.exists()) return;
-			//TODO: can't handle .ext
-			res.setName(f.getName());
+			res.put(PInclude.FILENAME,f.getName());
+			res.put(PInclude.FILEPATH,f.getAbsolutePath());
+			try
+				{
+				res.data = Files.readAllBytes(f.toPath());
+				}
+			catch (IOException e)
+				{
+				LGM.showDefaultExceptionHandler(e);
+				}
+			res.put(PInclude.SIZE,res.data.length);
+			updateStatusLabels();
 			return;
 			}
-		if (source == exportBut)
+		if (source == saveDataBut)
 			{
+			fc.setSelectedFile(new File(res.get(PInclude.FILENAME).toString()));
+			if (fc.showSaveDialog(LGM.frame) != JFileChooser.APPROVE_OPTION) return;
+			File f = fc.getSelectedFile();
+			try
+				{
+				Files.write(f.toPath(),res.data);
+				}
+			catch (IOException e)
+				{
+				LGM.showDefaultExceptionHandler(e);
+				}
 			return;
 			}
 		}


### PR DESCRIPTION
I felt really bad about having broken the include support in my last attempt to move them to the tree and out of game settings. I am now attempting to correct those mistakes by not only fixing what I broke, but also by fixing other aspects of it that were broke before too.

I had to make a lot of fixes to the file readers and writers. We were ignoring that the data files in GMD are zlib compressed. We were ignoring the store option for GMK 800 and 810 include files. We were throwing out the data files hierarchy in the GMD, which we now reuse for includes. In GMX, we needed an enum mapping for the export action in order to use the property link factory.

The basic decision made here is that we are going with a revamped GameMaker 5 version of data files. This is like GMSv1.4 in that the included file hierarchy is present in the main tree. It differs in that I decided not to open up LGM's main tree to having file extensions in resource names for fear of regression. However, since the new editor, like GM5's, allows you to edit the file name property separately, it should still remain GMSv1.4 compatible.

![LGM New Include Editor](https://user-images.githubusercontent.com/3212801/58247036-ad3a0200-7d26-11e9-8b20-3c9f0393cd9e.png)
