### PR TITLE
Settings Includes Fix

### DIFF
--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -135,7 +135,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.73"; //$NON-NLS-1$
+	public static final String version = "1.8.74"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/messages/messages.properties
+++ b/org/lateralgm/messages/messages.properties
@@ -647,8 +647,8 @@ IncludeFrame.SIZE=Size: {0} bytes
 IncludeFrame.ORIGINAL_FILE=Original File: {0}
 IncludeFrame.COPIES_TO=Copies to:
 IncludeFrame.PLATFORMS=
-IncludeFrame.OVERWRITE_EXISTING=Overwrite existing files
-IncludeFrame.REMOVE_FILES_AT_END=Remove files at end of game
+IncludeFrame.OVERWRITE_EXISTING=Overwrite existing file
+IncludeFrame.REMOVE_FILES_AT_END=Remove file at end of game
 IncludeFrame.STORE_EDITABLE=Store in the project editable
 IncludeFrame.FREE_MEMORY=Free memory after export
 

--- a/org/lateralgm/messages/messages.properties
+++ b/org/lateralgm/messages/messages.properties
@@ -871,6 +871,19 @@ GameSettingFrame.PRODUCT=Product:
 GameSettingFrame.COPYRIGHT=Copyright:
 GameSettingFrame.DESCRIPTION=Description:
 
+#Include tab
+GameSettingFrame.TAB_INCLUDE=Include
+GameSettingFrame.HINT_INCLUDE=Configure Includes
+GameSettingFrame.FILES_TO_INCLUDE=Files to include in the Executable
+GameSettingFrame.ADD_INCLUDE=Add
+GameSettingFrame.DELETE_INCLUDE=Delete
+GameSettingFrame.CLEAR_INCLUDES=Clear
+GameSettingFrame.EXPORT_TO=Folder to export to
+GameSettingFrame.SAME_FOLDER=Same folder as executable
+GameSettingFrame.TEMP_DIRECTORY=Temporary directory
+GameSettingFrame.OVERWRITE_EXISTING=Overwrite existing files
+GameSettingFrame.REMOVE_FILES_AT_END=Remove files at end of game
+
 #Errors tab
 GameSettingFrame.TAB_ERRORS=Errors
 GameSettingFrame.HINT_ERRORS=Configure Error handling

--- a/org/lateralgm/subframes/GameSettingFrame.java
+++ b/org/lateralgm/subframes/GameSettingFrame.java
@@ -50,13 +50,13 @@ import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.JTree;
 import javax.swing.LayoutStyle.ComponentPlacement;
+import javax.swing.SwingConstants;
 import javax.swing.event.TreeSelectionEvent;
 import javax.swing.event.TreeSelectionListener;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeCellRenderer;
 import javax.swing.tree.DefaultTreeModel;
 import javax.swing.tree.TreeSelectionModel;
-import javax.swing.SwingConstants;
 
 import org.lateralgm.components.ColorSelect;
 import org.lateralgm.components.CustomFileChooser;
@@ -500,17 +500,15 @@ public class GameSettingFrame extends ResourceFrame<GameSettings,PGameSettings>
 		includesFc.setMultiSelectionEnabled(true);
 
 		layout.setHorizontalGroup(layout.createParallelGroup()
-		/**/.addGroup(layout.createSequentialGroup()
-		/*		*/.addComponent(folderPanel).addGap(4,8,MAX_VALUE)
-		/*		*/.addGroup(layout.createParallelGroup()
-		/*				*/.addComponent(overwriteExisting)
-		/*				*/.addComponent(removeAtGameEnd))));
+		/*	*/.addComponent(folderPanel).addGap(4,8,MAX_VALUE)
+		/*	*/.addGroup(layout.createParallelGroup()
+		/*			*/.addComponent(overwriteExisting)
+		/*			*/.addComponent(removeAtGameEnd)));
 		layout.setVerticalGroup(layout.createSequentialGroup()
-		/**/.addGroup(layout.createParallelGroup()
-		/*		*/.addComponent(folderPanel)
-		/*		*/.addGroup(layout.createSequentialGroup()
-		/*				*/.addComponent(overwriteExisting)
-		/*				*/.addComponent(removeAtGameEnd))));
+		/*	*/.addComponent(folderPanel)
+		/*	*/.addGroup(layout.createSequentialGroup()
+		/*			*/.addComponent(overwriteExisting)
+		/*			*/.addComponent(removeAtGameEnd)));
 		return panel;
 		}
 


### PR DESCRIPTION
This fixes a minor regression I introduced in #434. I accidentally removed the messages for the game settings "Include" tab. That is for GMKs between 530 and 600 exclusive. Keeping the tab allows LGM to work with all versions of GM and includes and continue working. I also changed the layout to be vertical instead of horizontal since LGM has the include list as a group in the tree rather than in this tab.

![Game Settings Include Tab](https://user-images.githubusercontent.com/3212801/58285849-8eb22600-7d7b-11e9-8ca8-aea3c746818b.png)
