### PR TITLE
Preferences Reload

### DIFF
--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -135,7 +135,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.78"; //$NON-NLS-1$
+	public static final String version = "1.8.79"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/subframes/PreferencesFrame.java
+++ b/org/lateralgm/subframes/PreferencesFrame.java
@@ -243,9 +243,8 @@ public class PreferencesFrame extends JDialog implements ActionListener
 		{
 		if (visible)
 			for (PreferencesGroup group : groups)
-				{
 				group.load();
-				}
+
 		super.setVisible(visible);
 		}
 

--- a/org/lateralgm/subframes/PreferencesFrame.java
+++ b/org/lateralgm/subframes/PreferencesFrame.java
@@ -123,7 +123,6 @@ public class PreferencesFrame extends JDialog implements ActionListener
 			DefaultMutableTreeNode node = new DefaultMutableTreeNode(group.name);
 			root.add(node);
 			cardPane.add(group.makePanel(), group.name);
-			group.load();
 			}
 
 		//TODO: Fix UI bugs in JoshEdit repo and then use the serialize feature to save them.
@@ -237,6 +236,17 @@ public class PreferencesFrame extends JDialog implements ActionListener
 			{
 			group.load();
 			}
+		}
+
+	@Override
+	public void setVisible(boolean visible)
+		{
+		if (visible)
+			for (PreferencesGroup group : groups)
+				{
+				group.load();
+				}
+		super.setVisible(visible);
 		}
 
 	private Timer blinkTimer;


### PR DESCRIPTION
This is a minor tweak to the new preferences set up to make it reload each preference group every time the frame is shown. This means if the frame is closed without hitting apply, it will be reloaded before it is next shown. This means the frame no longer has to explicitly load each preference group during its construction.