### PR TITLE
Error Dialog Working Directory

### DIFF
--- a/org/lateralgm/components/ErrorDialog.java
+++ b/org/lateralgm/components/ErrorDialog.java
@@ -62,6 +62,7 @@ public class ErrorDialog extends JDialog implements ActionListener
 	public static String generateAgnosticInformation()
 		{
 		String ret = "LateralGM Version: " + LGM.version;
+		ret += "\nWorking Directory: " + LGM.workDir;
 
 		ret += "\n\nOperating System: " + System.getProperty("os.name");
 		ret += "\nVersion: " + System.getProperty("os.version");

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -135,7 +135,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.79"; //$NON-NLS-1$
+	public static final String version = "1.8.80"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.


### PR DESCRIPTION
This idea comes from Josh who is helping me with the ENIGMA plugin. Basically, the error dialog should always print LGM's working directory so we can more easily assist users who get errors about compileEGMf not being found. It may also make it easier to diagnose other problems in LateralGM.