### PR TITLE
Fix GM81 Clear View Option

### DIFF
--- a/org/lateralgm/file/GmFileReader.java
+++ b/org/lateralgm/file/GmFileReader.java
@@ -1027,9 +1027,9 @@ public final class GmFileReader
 			rm.put(PRoom.SPEED,in.read4());
 			rm.put(PRoom.PERSISTENT,in.readBool());
 			rm.put(PRoom.BACKGROUND_COLOR,Util.convertGmColor(in.read4()));
+			//NOTE: Mike Dailly must have done this lol, how does he not know what is conventionally true?
 			int backgroundViewClear = in.read4();
 			rm.put(PRoom.DRAW_BACKGROUND_COLOR,(backgroundViewClear & 1) != 0);
-			// NOTE: Mike Dailly must have done this lol, how does he not know what is conventionally true?
 			rm.put(PRoom.VIEWS_CLEAR,(backgroundViewClear & 0b10) == 0);
 			rm.put(PRoom.CREATION_CODE,in.readStr());
 			int nobackgrounds = in.read4();

--- a/org/lateralgm/file/GmFileReader.java
+++ b/org/lateralgm/file/GmFileReader.java
@@ -1027,7 +1027,10 @@ public final class GmFileReader
 			rm.put(PRoom.SPEED,in.read4());
 			rm.put(PRoom.PERSISTENT,in.readBool());
 			rm.put(PRoom.BACKGROUND_COLOR,Util.convertGmColor(in.read4()));
-			rm.put(PRoom.DRAW_BACKGROUND_COLOR,in.readBool());
+			int backgroundViewClear = in.read4();
+			rm.put(PRoom.DRAW_BACKGROUND_COLOR,(backgroundViewClear & 1) != 0);
+			// NOTE: Mike Dailly must have done this lol, how does he not know what is conventionally true?
+			rm.put(PRoom.VIEWS_CLEAR,(backgroundViewClear & 0b10) == 0);
 			rm.put(PRoom.CREATION_CODE,in.readStr());
 			int nobackgrounds = in.read4();
 			for (int j = 0; j < nobackgrounds; j++)

--- a/org/lateralgm/file/GmFileReader.java
+++ b/org/lateralgm/file/GmFileReader.java
@@ -1027,7 +1027,7 @@ public final class GmFileReader
 			rm.put(PRoom.SPEED,in.read4());
 			rm.put(PRoom.PERSISTENT,in.readBool());
 			rm.put(PRoom.BACKGROUND_COLOR,Util.convertGmColor(in.read4()));
-			//NOTE: Mike Dailly must have done this lol, how does he not know what is conventionally true?
+			//NOTE: GM8.1 is inconsistent with the views clear option being negated.
 			int backgroundViewClear = in.read4();
 			rm.put(PRoom.DRAW_BACKGROUND_COLOR,(backgroundViewClear & 1) != 0);
 			rm.put(PRoom.VIEWS_CLEAR,(backgroundViewClear & 0b10) == 0);

--- a/org/lateralgm/file/GmFileWriter.java
+++ b/org/lateralgm/file/GmFileWriter.java
@@ -680,7 +680,10 @@ public final class GmFileWriter
 				out.write4(rm.properties,PRoom.SPEED);
 				out.writeBool(rm.properties,PRoom.PERSISTENT);
 				out.write4(Util.getGmColor((Color) rm.get(PRoom.BACKGROUND_COLOR)));
-				out.writeBool(rm.properties,PRoom.DRAW_BACKGROUND_COLOR);
+				//NOTE: Mike Dailly probably did this, see GMK reader comment.
+				int viewBackgroundClear = rm.get(PRoom.DRAW_BACKGROUND_COLOR)?1:0;
+				if (!(boolean)rm.get(PRoom.VIEWS_CLEAR)) viewBackgroundClear |= 0b10;
+				out.write4(viewBackgroundClear);
 				out.writeStr(rm.properties,PRoom.CREATION_CODE);
 				out.write4(rm.backgroundDefs.size());
 				for (BackgroundDef back : rm.backgroundDefs)

--- a/org/lateralgm/file/GmFileWriter.java
+++ b/org/lateralgm/file/GmFileWriter.java
@@ -682,7 +682,7 @@ public final class GmFileWriter
 				out.write4(Util.getGmColor((Color) rm.get(PRoom.BACKGROUND_COLOR)));
 				//NOTE: Mike Dailly probably did this, see GMK reader comment.
 				int viewBackgroundClear = rm.get(PRoom.DRAW_BACKGROUND_COLOR)?1:0;
-				if (!(boolean)rm.get(PRoom.VIEWS_CLEAR)) viewBackgroundClear |= 0b10;
+				if (f.format.version >= 810 && !(boolean)rm.get(PRoom.VIEWS_CLEAR)) viewBackgroundClear |= 0b10;
 				out.write4(viewBackgroundClear);
 				out.writeStr(rm.properties,PRoom.CREATION_CODE);
 				out.write4(rm.backgroundDefs.size());

--- a/org/lateralgm/file/GmFileWriter.java
+++ b/org/lateralgm/file/GmFileWriter.java
@@ -680,7 +680,7 @@ public final class GmFileWriter
 				out.write4(rm.properties,PRoom.SPEED);
 				out.writeBool(rm.properties,PRoom.PERSISTENT);
 				out.write4(Util.getGmColor((Color) rm.get(PRoom.BACKGROUND_COLOR)));
-				//NOTE: Mike Dailly probably did this, see GMK reader comment.
+				//NOTE: GM8.1 is inconsistent with the views clear option being negated, see GMK reader comment.
 				int viewBackgroundClear = rm.get(PRoom.DRAW_BACKGROUND_COLOR)?1:0;
 				if (f.format.version >= 810 && !(boolean)rm.get(PRoom.VIEWS_CLEAR)) viewBackgroundClear |= 0b10;
 				out.write4(viewBackgroundClear);

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -135,7 +135,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.83"; //$NON-NLS-1$
+	public static final String version = "1.8.84"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -135,7 +135,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.82"; //$NON-NLS-1$
+	public static final String version = "1.8.83"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.


### PR DESCRIPTION
This is unbelievably ridiculous and I have no doubt in my mind it was Mike Dailly who done it. This pull request addresses issues reported in #443 by fixing the clear view option for the GM81 reader and writer. What was changed in GM8.1 when that option was added is that it was or'd to the existing "Draw Background Color" boolean. Mike Dailly did the illogical and didn't set the second bit based on the option being checked (true), he set it based on it being unchecked (false)! What kind of a serious dotard can make it that far without knowing such a very basic facet of boolean algebra is beyond me. He also didn't even do the reasonable thing and increment the room format version number!