### PR TITLE
Custom File Filter Null Extension Fixes

### DIFF
--- a/org/lateralgm/components/impl/CustomFileFilter.java
+++ b/org/lateralgm/components/impl/CustomFileFilter.java
@@ -15,6 +15,8 @@ import java.util.Locale;
 
 import javax.swing.filechooser.FileFilter;
 
+import org.lateralgm.main.Util;
+
 public class CustomFileFilter extends FileFilter implements FilenameFilter
 	{
 	private ArrayList<String> ext = new ArrayList<String>();
@@ -36,7 +38,7 @@ public class CustomFileFilter extends FileFilter implements FilenameFilter
 		{
 		this.desc = desc;
 		for (String element : ext)
-			this.ext.add(element);
+			if (element != null) this.ext.add(element);
 		}
 
 	public boolean accept(File f)
@@ -50,7 +52,7 @@ public class CustomFileFilter extends FileFilter implements FilenameFilter
 		if (ext.size() == 0) return true;
 		//if (f.isDirectory()) return true;
 		for (String e : ext)
-			if (name.endsWith(e))
+			if (Util.stringEndsWith(name,e))
 				return true;
 		return false;
 		}

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -135,7 +135,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.82"; //$NON-NLS-1$
+	public static final String version = "1.8.83"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/main/Util.java
+++ b/org/lateralgm/main/Util.java
@@ -1255,4 +1255,11 @@ public final class Util
 					JOptionPane.ERROR_MESSAGE);
 			}
 		}
+
+	// Guaranteed contract to not throw an NPE and return false if str or suffix is null.
+	public static boolean stringEndsWith(String str, String suffix)
+		{
+		if (suffix == null || str == null) return false;
+		return str.endsWith(suffix);
+		}
 	}


### PR DESCRIPTION
This fixes #445 for hugar. As detailed in that issue, we can not pass `null` to String's endsWith which is guaranteed in the Java docs to throw an NPE. The null was coming from the ENIGMA plugin for Linux's `gcc.ey` compiler descriptor. To address this, I've introduced a special String utility method that guarantees to return false instead of throwing an NPE if the suffix or the string itself are null. I use that to check if the selected file matches any of the extensions. I also decided to be extra cautious and ignore null extensions altogether in the custom file filter constructor since they really don't even make sense.