### PR TITLE
Terminal Debug Agnostics

### DIFF
--- a/org/lateralgm/components/ErrorDialog.java
+++ b/org/lateralgm/components/ErrorDialog.java
@@ -72,7 +72,8 @@ public class ErrorDialog extends JDialog implements ActionListener
 		ret += "\nJava Vendor: " + System.getProperty("java.vendor");
 		ret += "\nVersion: " + System.getProperty("java.version");
 
-		ret += "\n\nAvailable processors (cores): " + Runtime.getRuntime().availableProcessors();
+		ret += "\n\nCurrent Thread: " + Thread.currentThread().getName();
+		ret += "\nAvailable processors (cores): " + Runtime.getRuntime().availableProcessors();
 		ret += "\nFree memory (bytes): " + Runtime.getRuntime().freeMemory();
 		long maxMemory = Runtime.getRuntime().maxMemory();
 		ret += "\nMaximum memory (bytes): " + (maxMemory == Long.MAX_VALUE ? "no limit" : maxMemory);

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -135,7 +135,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.85"; //$NON-NLS-1$
+	public static final String version = "1.8.86"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -1550,13 +1550,14 @@ public final class LGM
 	// to submit a bug report.
 	public static void showDefaultExceptionHandler(Throwable e)
 		{
-		System.err.println(Thread.currentThread().getName() + ": ");
+		String agnostics = ErrorDialog.generateAgnosticInformation();
+		System.out.println(agnostics);
 		e.printStackTrace();
 		ErrorDialog errorDialog = ErrorDialog.getInstance();
 		if (!errorDialog.isVisible())
 			{
 			errorDialog.setVisible(true);
-			errorDialog.setDebugInfo(ErrorDialog.generateAgnosticInformation());
+			errorDialog.setDebugInfo(agnostics);
 			}
 		errorDialog.appendDebugInfo(e);
 		}


### PR DESCRIPTION
I'm just adding #449 so that we also print the LGM and JDK version to the terminal when an exception is thrown. This is useful for errors or exceptions that otherwise crash LGM before the user can find this information in the error dialog.