### PR TITLE
ICOFile Stream Closing Fixes

### DIFF
--- a/org/lateralgm/file/iconio/ICOFile.java
+++ b/org/lateralgm/file/iconio/ICOFile.java
@@ -61,6 +61,8 @@ public class ICOFile implements Comparable<ICOFile>
 	private int type;
 	/** Number of contained images. */
 	private int imageCount;
+	/** The <code>AbstractDecoder</code> provided or derived from the constructor. */
+	private StreamDecoder decoder;
 	private final List<BitmapDescriptor> descriptors = new ArrayList<BitmapDescriptor>();
 
 	/**
@@ -73,12 +75,13 @@ public class ICOFile implements Comparable<ICOFile>
 	public ICOFile(final String pFileName) throws IOException
 		{
 		this(pFileName,new StreamDecoder(pFileName));
+		decoder.close();
 		}
 
 	/**
 	 * Create ICO file from an input stream.
 	 *
-	 * @param pInput (automatically closed)
+	 * @param pInput (left unclosed)
 	 * @throws IOException
 	 */
 	public ICOFile(final InputStream pInput) throws IOException
@@ -89,23 +92,25 @@ public class ICOFile implements Comparable<ICOFile>
 	/**
 	 * Create ICO file from an URL.
 	 *
-	 * @param pURL
+	 * @param pURL (derived decoder automatically closed)
 	 * @throws IOException
 	 */
 	public ICOFile(final URL pURL) throws IOException
 		{
 		this(pURL.toString(),new StreamDecoder(pURL.openStream()));
+		decoder.close();
 		}
 
 	/**
 	 * Create ICOFile from a byte array.
 	 *
-	 * @param pBuffer
+	 * @param pBuffer (derived decoder automatically closed)
 	 * @throws IOException
 	 */
 	public ICOFile(final byte[] pBuffer) throws IOException
 		{
 		this("[from buffer]",new StreamDecoder(new ByteArrayInputStream(pBuffer)));
+		decoder.close();
 		}
 
 	/**
@@ -120,6 +125,7 @@ public class ICOFile implements Comparable<ICOFile>
 	public ICOFile(final String pFileName, final StreamDecoder pFileDecoder) throws IOException
 		{
 		fileName = pFileName;
+		decoder = pFileDecoder;
 		read(pFileDecoder);
 		}
 

--- a/org/lateralgm/file/iconio/ICOFile.java
+++ b/org/lateralgm/file/iconio/ICOFile.java
@@ -61,7 +61,7 @@ public class ICOFile implements Comparable<ICOFile>
 	private int type;
 	/** Number of contained images. */
 	private int imageCount;
-	/** The <code>AbstractDecoder</code> provided or derived from the constructor. */
+	/** The <code>StreamDecoder</code> provided or derived from the constructor. */
 	private StreamDecoder decoder;
 	private final List<BitmapDescriptor> descriptors = new ArrayList<BitmapDescriptor>();
 

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -135,7 +135,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.87"; //$NON-NLS-1$
+	public static final String version = "1.8.88"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.


### PR DESCRIPTION
I recently caught up with a mistake I made back in 3d1842c5981fec8a81395dcc94093a974a7b2c1f when allowing you to load ICO files as sprites and backgrounds. I had undone a fix that one of the old LGM contributors added to the ICO File reader. It never closed any of the streams that it opened, so one of the LGM maintainers thought to make it close the streams. However, they made a slight mistake and had it close the stream if it was provided in the constructor.

This caused it not to work when plugged in as an image service provider, and is why I first removed it. I went a little too far though and removed closing of the derived streams too. Those could have been left, because without them the GMX reader for example is locking the file and leaking because it uses the constructor that takes a string file path. Interestingly enough, it seems this source has been patched in the same incorrect way in other places on the internet.

I have very carefully brought back the stream closing again, and this time clearly added to the documentation in which cases the stream is automatically closed. If it's provided in the constructor, it's not. Otherwise, it will be automatically closed after the ICO is read.

My only remaining concern is the BufferedInputStream wrapping that clam for some reason added.
https://github.com/IsmAvatar/LateralGM/blob/995ed9ab5fd111b805dde4dd570ec8bae0b9f19b/org/lateralgm/file/StreamDecoder.java#L40
That may continue to leak after this is merged, but is not a regression. It may also not be an issue since the caller will, hopefully, close the underlying stream, and the buffer will just be gc'd.