### PR TITLE
ScoreUnder Javac Makefile Fixes

### DIFF
--- a/org/lateralgm/ui/swing/visuals/RoomVisual.java
+++ b/org/lateralgm/ui/swing/visuals/RoomVisual.java
@@ -600,9 +600,9 @@ public class RoomVisual extends AbstractVisual implements BoundedVisual,UpdateLi
 	@SuppressWarnings("unchecked")
 	private static <P extends Piece, V extends PieceVisual<P>>Class<V> getVisualClass(Class<P> p)
 		{
-		if (p == Piece.class) return (Class<V>) (Class) PieceVisual.class;
-		if (p == Instance.class) return (Class<V>) (Class) InstanceVisual.class;
-		if (p == Tile.class) return (Class<V>) (Class) TileVisual.class;
+		if (p == Piece.class) return (Class<V>) PieceVisual.class;
+		if (p == Instance.class) return (Class<V>) InstanceVisual.class;
+		if (p == Tile.class) return (Class<V>) TileVisual.class;
 		throw new IllegalArgumentException();
 		}
 


### PR DESCRIPTION
Pulling in @ScoreUnder's fixes to the main makefile from #387 without the cast changes in room visual. I agree with the changes to the makefile including the correction of the README.md filename. I think it's more appropriate that we use javac in the makefile since those users would typically have the JDK installed. Anybody who has Eclipse installed is not going to want to build LGM from the makefile anyway. I also kept his change of `ImageEffects.java` to UTF-8 since that's correct.