### PR TITLE
Force Defrag Ids

### DIFF
--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -135,7 +135,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.88"; //$NON-NLS-1$
+	public static final String version = "1.8.89"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/main/Listener.java
+++ b/org/lateralgm/main/Listener.java
@@ -409,10 +409,11 @@ public class Listener extends TransferHandler implements ActionListener,CellEdit
 			}
 		else if (promptOk)
 			{
-			JOptionPane.showMessageDialog(LGM.frame,
+			if (JOptionPane.showConfirmDialog(LGM.frame,
 					Messages.getString("Listener.CHECKIDS_OK"), //$NON-NLS-1$
 					Messages.getString("Listener.CHECKIDS_OK_TITLE"), //$NON-NLS-1$
-					JOptionPane.INFORMATION_MESSAGE);
+					JOptionPane.YES_NO_OPTION) == JOptionPane.YES_OPTION)
+				LGM.currentFile.defragIds();
 			}
 		}
 

--- a/org/lateralgm/messages/messages.properties
+++ b/org/lateralgm/messages/messages.properties
@@ -335,7 +335,9 @@ Listener.CHECKNAMES_OK_TITLE=		Names Appear Unique and Valid
 Listener.CHECKIDS_DEFRAG=		Duplicate ids were detected, and they should be defragged.\n\
 								Defragging ids cannot be undone, do you want to defrag them?
 Listener.CHECKIDS_DEFRAG_TITLE=	Duplicate Ids Detected
-Listener.CHECKIDS_OK=			All ids appear to be unique and no duplicates were detected.
+Listener.CHECKIDS_OK=			All ids appear to be unique and no duplicates were detected.\n\
+								Defragging may still yield better performance and compression.\n\
+								Defragging ids cannot be undone, do you want to defrag them?
 Listener.CHECKIDS_OK_TITLE=		Ids Appear Unique
 
 Listener.TREE_PROPERTIES=Properties


### PR DESCRIPTION
Just a minor tweak to allow the user to still defrag the ids even when they are already unique. This may give better performance and compression besides just solving issues of duplicate ids. I have updated the dialog to use a confirmation message for both cases. The non-interactive check performed on file load will not trigger this, you can only force defrag from the "Check Ids" menu. I did not bother updating the translations to other languages for this dialog, so that could still be done. I also recognize a progress bar dialog would be nice to add to the check ids and the defrag ids.

![Ids Appear Unique Confirmation](https://user-images.githubusercontent.com/3212801/66252211-9ff64080-e726-11e9-86f4-dd221bc9bdb5.png)
