### PR TITLE
Negative Instance Scale

### DIFF
--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -133,7 +133,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.149"; //$NON-NLS-1$
+	public static final String version = "1.8.150"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -135,7 +135,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.89"; //$NON-NLS-1$
+	public static final String version = "1.8.90"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/subframes/RoomFrame.java
+++ b/org/lateralgm/subframes/RoomFrame.java
@@ -910,10 +910,10 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 		objectVerticalPosition.setColumns(4);
 		objectVerticalPosition.addFocusListener(this);
 		JLabel lObjScaleX = new JLabel(Messages.getString("RoomFrame.SCALE_X")); //$NON-NLS-1$
-		objectScaleX = new NumberField(0.1,9999.0,1.0,2);
+		objectScaleX = new NumberField(-9999.0,9999.0,1.0,2);
 		objectScaleX.addFocusListener(this);
 		JLabel lObjScaleY = new JLabel(Messages.getString("RoomFrame.SCALE_Y")); //$NON-NLS-1$
-		objectScaleY = new NumberField(0.1,9999.0,1.0,2);
+		objectScaleY = new NumberField(-9999.0,9999.0,1.0,2);
 		objectScaleY.addFocusListener(this);
 		JLabel lObjRotation = new JLabel(Messages.getString("RoomFrame.ROTATION")); //$NON-NLS-1$
 		objectRotation = new NumberField(0.0,360.0,0.0,2);

--- a/org/lateralgm/ui/swing/visuals/RoomVisual.java
+++ b/org/lateralgm/ui/swing/visuals/RoomVisual.java
@@ -911,10 +911,7 @@ public class RoomVisual extends AbstractVisual implements BoundedVisual,UpdateLi
 						}
 					else
 						{
-						if (at != null)
-							g2.drawRect(1,1,image.getWidth() + 1,image.getHeight() + 1);
-						else
-							g2.drawRect(1,1,image.getWidth() + 2,image.getHeight() + 2);
+						g2.drawRect(1,1,image.getWidth() + 2,image.getHeight() + 2);
 						}
 
 					// If the option 'Invert colors' is set
@@ -924,10 +921,7 @@ public class RoomVisual extends AbstractVisual implements BoundedVisual,UpdateLi
 						g2.setColor(Util.convertGmColorWithAlpha(Prefs.selectionOutsideColor));
 
 					// Draw the outside border
-					if (at != null)
-						g2.drawRect(0,0,image.getWidth() + 3,image.getHeight() + 3);
-					else
-						g2.drawRect(0,0,image.getWidth() + 4,image.getHeight() + 4);
+					g2.drawRect(0,0,image.getWidth() + 4,image.getHeight() + 4);
 					}
 
 				}

--- a/org/lateralgm/ui/swing/visuals/RoomVisual.java
+++ b/org/lateralgm/ui/swing/visuals/RoomVisual.java
@@ -906,13 +906,9 @@ public class RoomVisual extends AbstractVisual implements BoundedVisual,UpdateLi
 
 					// If the option 'Fill rectangle' is set
 					if (Prefs.useFilledRectangleForSelection)
-						{
 						g2.fillRect(1,1,image.getWidth() + 2,image.getHeight() + 2);
-						}
 					else
-						{
 						g2.drawRect(1,1,image.getWidth() + 2,image.getHeight() + 2);
-						}
 
 					// If the option 'Invert colors' is set
 					if (Prefs.useInvertedColorForSelection)

--- a/org/lateralgm/ui/swing/visuals/RoomVisual.java
+++ b/org/lateralgm/ui/swing/visuals/RoomVisual.java
@@ -804,10 +804,10 @@ public class RoomVisual extends AbstractVisual implements BoundedVisual,UpdateLi
 			if (scale.getX() != 1.0 || scale.getY() != 1.0 || angle != 0)
 				{
 				at = new AffineTransform(); // << start with identity
-				if (scale.getX() != 1.0 || scale.getY() != 1.0)
-					at.scale(scale.getX(),scale.getY()); // << scale bounds & drawing
 				if (angle != 0)
 					at.rotate(Math.toRadians(-angle)); // << rotate bounds & drawing
+				if (scale.getX() != 1.0 || scale.getY() != 1.0)
+					at.scale(scale.getX(),scale.getY()); // << scale bounds & drawing
 
 				// Apply the transformation
 				Shape newRect = at.createTransformedShape(newBounds);

--- a/org/lateralgm/ui/swing/visuals/RoomVisual.java
+++ b/org/lateralgm/ui/swing/visuals/RoomVisual.java
@@ -746,7 +746,7 @@ public class RoomVisual extends AbstractVisual implements BoundedVisual,UpdateLi
 		private final InstancePropertyListener ipl = new InstancePropertyListener();
 
 		// The instance's local transformation.
-		AffineTransform at = null;
+		private AffineTransform at = null;
 
 		public InstanceVisual(Instance i)
 			{

--- a/org/lateralgm/ui/swing/visuals/RoomVisual.java
+++ b/org/lateralgm/ui/swing/visuals/RoomVisual.java
@@ -831,9 +831,9 @@ public class RoomVisual extends AbstractVisual implements BoundedVisual,UpdateLi
 			else
 				at = null;
 
-			// the bounds cares about position, origin, scaling, & rotation
-			// the drawing only cares about scaling, & rotation
-			// the at with only scaling and rotation and without translation
+			// 1) the bounds cares about position, origin, scaling, & rotation
+			// 2) the drawing only cares about scaling, & rotation
+			// the at with only scaling and rotation, and without translation,
 			// will be cached and reused to paint the graphic
 
 			newBounds.translate(position.x, position.y);

--- a/org/lateralgm/ui/swing/visuals/RoomVisual.java
+++ b/org/lateralgm/ui/swing/visuals/RoomVisual.java
@@ -801,7 +801,7 @@ public class RoomVisual extends AbstractVisual implements BoundedVisual,UpdateLi
 			Rectangle newBounds = new Rectangle(0,0,newWidth,newHeight);
 
 			// Calculate the new bounds when there is a local transformation
-			if (scale.getX() != 1.0 || scale.getY() != 1.0 || angle != 0 || originx != 0 || originy != 0)
+			if (angle != 0 || scale.getX() != 1.0 || scale.getY() != 1.0 || originx != 0 || originy != 0)
 				{
 				at = new AffineTransform(); // << start with identity
 				if (angle != 0)
@@ -834,9 +834,9 @@ public class RoomVisual extends AbstractVisual implements BoundedVisual,UpdateLi
 				at = null;
 
 			// the bounds cares about position, origin, scaling, & rotation
-			// the drawing only cares about scaling & rotation
-			// so the at used to transform bounds will be cached until the paint
-			// to make scaling & rotation be reused
+			// the drawing only cares about scaling, & rotation
+			// the at with only scaling and rotation and without translation
+			// will be cached and reused to paint the graphic
 
 			newBounds.translate(position.x, position.y);
 			setBounds(newBounds);

--- a/org/lateralgm/ui/swing/visuals/RoomVisual.java
+++ b/org/lateralgm/ui/swing/visuals/RoomVisual.java
@@ -782,17 +782,15 @@ public class RoomVisual extends AbstractVisual implements BoundedVisual,UpdateLi
 			Point2D scale = piece.getScale();
 			double angle = piece.getRotation();
 
-			int borderOffsetx = 0;
-			int borderOffsety = 0;
-
 			// If the instance is selected use bigger bounds for border, and make sure the instance is visible
 			if (piece.isSelected())
 				{
 				binVisual.setDepth(this,o == null ? 0 : Integer.MIN_VALUE,true);
+				// we want these included in the local transformation
 				newWidth += 4;
 				newHeight += 4;
-				borderOffsetx = 2;
-				borderOffsety = 2;
+				originx += 2;
+				originy += 2;
 				}
 			else
 				binVisual.setDepth(this,o == null ? 0 : (Integer) o.get(PGmObject.DEPTH),false);

--- a/org/lateralgm/ui/swing/visuals/RoomVisual.java
+++ b/org/lateralgm/ui/swing/visuals/RoomVisual.java
@@ -798,16 +798,18 @@ public class RoomVisual extends AbstractVisual implements BoundedVisual,UpdateLi
 				binVisual.setDepth(this,o == null ? 0 : (Integer) o.get(PGmObject.DEPTH),false);
 
 			// Create a rectangle with image's size
-			Rectangle newBounds = new Rectangle(-originx,-originy,newWidth,newHeight);
+			Rectangle newBounds = new Rectangle(0,0,newWidth,newHeight);
 
 			// Calculate the new bounds when there is a local transformation
-			if (scale.getX() != 1.0 || scale.getY() != 1.0 || angle != 0)
+			if (scale.getX() != 1.0 || scale.getY() != 1.0 || angle != 0 || originx != 0 || originy != 0)
 				{
 				at = new AffineTransform(); // << start with identity
 				if (angle != 0)
 					at.rotate(Math.toRadians(-angle)); // << rotate bounds & drawing
 				if (scale.getX() != 1.0 || scale.getY() != 1.0)
 					at.scale(scale.getX(),scale.getY()); // << scale bounds & drawing
+				if (originx != 0 && originy != 0)
+					at.translate(-originx,-originy); // << translate bounds & drawing
 
 				// Apply the transformation
 				Shape newRect = at.createTransformedShape(newBounds);

--- a/org/lateralgm/ui/swing/visuals/RoomVisual.java
+++ b/org/lateralgm/ui/swing/visuals/RoomVisual.java
@@ -823,8 +823,10 @@ public class RoomVisual extends AbstractVisual implements BoundedVisual,UpdateLi
 
 				newBounds = new Rectangle(offsetx,offsety,newWidth,newHeight);
 
-				if (scale.getX() < 0) at.translate(-newWidth,0); // mirror x on drawing
-				if (scale.getY() < 0) at.translate(0,-newHeight); // mirror y on drawing
+				// preconcatenate acts like we translated before rotating and scaling
+				// this moves the graphics by however much the scale or rotation caused
+				// a mirror of the origin
+				at.preConcatenate(AffineTransform.getTranslateInstance(-offsetx,-offsety));
 				}
 			else
 				at = null;


### PR DESCRIPTION
This is a proposal to address #460 in support of user. I decided to just allow negative, and zero, x/y scales for instances in the room editor rather than make a separate checkbox. The GMX format just serializes the "Flip X" and "Flip Y" checkboxes by making the number negative. I'd rather we not clutter the UI as most people would just expect to enter negative values if they need to.

**NOTE**: This does not fix tiles and may not fix selection since it appears those use duplicated logic, see #515 for more about that.

* Changed the x/y scale fields of instances in the room editor to allow for negative values.
* Cached the local transformation of the instance visual so that it does not need redundantly computed for paint.
* Cleaned up the origin and property reading in instance visual validation.
* Removed the border offset variable and combined it with the origin since it logically accomplishes the same.
* Used the affine transformation to apply scaling and origin translation instead of doing it manually.
* The above helped to give the bounds the correct mirror offset.
* The computed bounds are then used to reset the origin so the painting only performs positive scaling and rotation.
* Removed some checks it seems egofree was doing to try addressing a clipping issue with the selection border.
* The above is caused by the scaling of the bounds not accounting for the scaling of the selection border line stroke.
* Not sure what to do about it, but it's still the same as it was before, so I'm not too concerned about it.
* In my opinion, the selection border shouldn't be scaled anyway and that's probably what we should change.

As always, I have prepared a test project we can reuse when we later fix tiles. It should probably be committed to enigma-dev CI tests too so that we can ensure the game looks the same as the editor. Later on LGM could use its own user interface tests as well.
Download: [room-piece-transform-test.zip](https://github.com/IsmAvatar/LateralGM/files/4927114/room-piece-transform-test.zip)

What's fascinating is that this pull request makes LGM the same as what the game should look like, which GMSv1.4 doesn't even get correct. We can see ENIGMA is doing a good job though drawing just the way the game should.

| Master | Pull | GMSv1.4 |
|--------|------|---------|
|![LGM Room Piece Test Master](https://user-images.githubusercontent.com/3212801/87580427-84509b00-c6a5-11ea-8cf3-b580b5d99ab0.png)|![LGM Room Piece Test Pull](https://user-images.githubusercontent.com/3212801/87581631-40f72c00-c6a7-11ea-99bc-1608e6906123.png)|![GMSv1.4 Room Piece Test](https://user-images.githubusercontent.com/3212801/87579955-c0cfc700-c6a4-11ea-9a2b-67c441e6cc84.png)|