### PR TITLE
Open Project Exception Handling

### DIFF
--- a/org/lateralgm/main/FileChooser.java
+++ b/org/lateralgm/main/FileChooser.java
@@ -610,6 +610,24 @@ public class FileChooser
 		open(uri,reader);
 		}
 
+	/** 
+	 /* This catches exceptions in reading without freezing the program with the
+	 /* progress bar or destroying the tree.
+	 */
+	private static void openExceptionHelper(Exception e, final URI uri)
+		{
+		// make sure the user gets all the main resource nodes
+		LGM.populateTree();
+		// if this is a GMK, we need to actually build a tree
+		// which albeit may still lack groups
+		if (projectReader.canRead(uri))
+			rebuildTree();
+		// finally, show the exception to the user
+		LGM.showDefaultExceptionHandler(e);
+		ErrorDialog.getInstance().setMessage(Messages.getString("FileChooser.ERROR_LOAD")); //$NON-NLS-1$
+		ErrorDialog.getInstance().setTitle(Messages.getString("FileChooser.ERROR_LOAD_TITLE")); //$NON-NLS-1$
+		}
+	
 	/**
 	 * Both open() methods are not headless. For a headless open:
 	 * <code>findReader(uri).read(uriStream,uri,root)</code>
@@ -633,21 +651,11 @@ public class FileChooser
 					catch (ProjectFormatException ex)
 						{
 						LGM.currentFile = ex.file;
-						LGM.populateTree();
-						rebuildTree();
-						LGM.showDefaultExceptionHandler(ex);
-						ErrorDialog.getInstance().setMessage(Messages.getString("FileChooser.ERROR_LOAD")); //$NON-NLS-1$
-						ErrorDialog.getInstance().setTitle(Messages.getString("FileChooser.ERROR_LOAD_TITLE")); //$NON-NLS-1$
+						openExceptionHelper(ex, uri);
 						}
 					catch (Exception e)
 						{
-						// TODO: This catches exceptions in reading without freezing the program with the
-						// progress bar or destroying the tree.
-						LGM.populateTree();
-						rebuildTree();
-						LGM.showDefaultExceptionHandler(e);
-						ErrorDialog.getInstance().setMessage(Messages.getString("FileChooser.ERROR_LOAD")); //$NON-NLS-1$
-						ErrorDialog.getInstance().setTitle(Messages.getString("FileChooser.ERROR_LOAD_TITLE")); //$NON-NLS-1$
+						openExceptionHelper(e, uri);
 						}
 					setTitleURI(uri);
 					PrefsStore.addRecentFile(uri.toString());


### PR DESCRIPTION
This is an alternative to #466 which simply gets rid of reloading the tree for anything but GMK. I made this after realizing the importance of rebuilding the tree for GMK. With GMK, the tree is not read until the very end, so if an exception occurs a tree would not otherwise exist. That is not the case with how we read GMX, which builds the tree as it reads each resource. Therefore, this redundant tree rebuilding in the event of an exception merely causes all of the resources to be duplicated on their root ancestor with their path truncated, making all further debugging impossible.