### PR TITLE
Generify Undoable Instance/Tile Edit

### DIFF
--- a/org/lateralgm/components/visual/RoomEditor.java
+++ b/org/lateralgm/components/visual/RoomEditor.java
@@ -60,6 +60,7 @@ import org.lateralgm.util.PropertyMap.PropertyUpdateEvent;
 import org.lateralgm.util.PropertyMap.PropertyUpdateListener;
 import org.lateralgm.util.PropertyMap.PropertyValidator;
 import org.lateralgm.util.RemovePieceInstance;
+import org.lateralgm.util.ModifyPieceInstance.Type;
 
 public class RoomEditor extends VisualPanel
 	{
@@ -404,7 +405,7 @@ public class RoomEditor extends VisualPanel
 		// If the piece was moved
 		if (objectFirstPosition != null)
 			// For the undo, record that the object was moved
-			edit = new ModifyPieceInstance(frame,cursor,objectFirstPosition,new Point(lastPosition));
+			edit = new ModifyPieceInstance(frame,cursor,Type.POSITION,objectFirstPosition,new Point(lastPosition));
 		else
 			// A new piece has been added
 			{

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -135,7 +135,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.92"; //$NON-NLS-1$
+	public static final String version = "1.8.94"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/subframes/RoomFrame.java
+++ b/org/lateralgm/subframes/RoomFrame.java
@@ -140,6 +140,7 @@ import org.lateralgm.util.PropertyMap.PropertyUpdateEvent;
 import org.lateralgm.util.PropertyMap.PropertyUpdateListener;
 import org.lateralgm.util.RemovePieceInstance;
 import org.lateralgm.util.ShiftPieceInstances;
+import org.lateralgm.util.ModifyPieceInstance.Type;
 
 public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 		ListSelectionListener,CommandHandler,UpdateListener,FocusListener,ChangeListener
@@ -939,7 +940,7 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 			if (!originalColor.equals(newColour))
 				{
 				// Record the effect of modifying the color of an object for the undo
-				UndoableEdit edit = new ModifyPieceInstance(RoomFrame.this,selectedPiece,originalColor,
+				UndoableEdit edit = new ModifyPieceInstance(RoomFrame.this,selectedPiece,Type.COLOR,originalColor,
 						newColour);
 				// notify the listeners
 				undoSupport.postEdit(edit);
@@ -3380,7 +3381,7 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 				if (objectNewName != pieceOriginalName)
 					{
 					// Record the effect of rotating an object for the undo
-					UndoableEdit edit = new ModifyPieceInstance(this,selectedPiece,pieceOriginalName,
+					UndoableEdit edit = new ModifyPieceInstance(this,selectedPiece,Type.NAME,pieceOriginalName,
 							objectNewName);
 					// notify the listeners
 					undoSupport.postEdit(edit);
@@ -3397,7 +3398,7 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 				if (!objectNewPosition.equals(pieceOriginalPosition))
 					{
 					// Record the effect of moving an object for the undo
-					UndoableEdit edit = new ModifyPieceInstance(this,selectedPiece,pieceOriginalPosition,
+					UndoableEdit edit = new ModifyPieceInstance(this,selectedPiece,Type.POSITION,pieceOriginalPosition,
 							objectNewPosition);
 					// notify the listeners
 					undoSupport.postEdit(edit);
@@ -3414,7 +3415,7 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 				if (!objectNewScale.equals(pieceOriginalScale))
 					{
 					// Record the effect of modifying the scale an object for the undo
-					UndoableEdit edit = new ModifyPieceInstance(this,selectedPiece,pieceOriginalScale,
+					UndoableEdit edit = new ModifyPieceInstance(this,selectedPiece,Type.SCALE,pieceOriginalScale,
 							new Point2D.Double(objectNewScale.getX(),objectNewScale.getY()));
 					// notify the listeners
 					undoSupport.postEdit(edit);
@@ -3431,7 +3432,7 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 				if (objectNewRotation != pieceOriginalRotation)
 					{
 					// Record the effect of rotating an object for the undo
-					UndoableEdit edit = new ModifyPieceInstance(this,selectedPiece,pieceOriginalRotation,
+					UndoableEdit edit = new ModifyPieceInstance(this,selectedPiece,Type.ROTATION,pieceOriginalRotation,
 							objectNewRotation);
 					// notify the listeners
 					undoSupport.postEdit(edit);
@@ -3448,7 +3449,7 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 				if (objectNewAlpha != pieceOriginalAlpha)
 					{
 					// Record the effect of modifying the alpha value of an object for the undo
-					UndoableEdit edit = new ModifyPieceInstance(this,selectedPiece,pieceOriginalAlpha,
+					UndoableEdit edit = new ModifyPieceInstance(this,selectedPiece,Type.ALPHA,pieceOriginalAlpha,
 							objectNewAlpha);
 					// notify the listeners
 					undoSupport.postEdit(edit);
@@ -3469,7 +3470,7 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 			if (!tileNewPosition.equals(pieceOriginalPosition))
 				{
 				// Record the effect of moving an tile for the undo
-				UndoableEdit edit = new ModifyPieceInstance(this,selectedPiece,pieceOriginalPosition,
+				UndoableEdit edit = new ModifyPieceInstance(this,selectedPiece,Type.POSITION,pieceOriginalPosition,
 						tileNewPosition);
 				// notify the listeners
 				undoSupport.postEdit(edit);

--- a/org/lateralgm/util/ModifyPieceInstance.java
+++ b/org/lateralgm/util/ModifyPieceInstance.java
@@ -26,75 +26,27 @@ import org.lateralgm.subframes.RoomFrame;
 
 public class ModifyPieceInstance extends AbstractUndoableEdit
 	{
+	public enum Type
+		{
+		NAME, POSITION, SCALE, ROTATION, ALPHA, COLOR
+		};
+
 	private static final long serialVersionUID = 1L;
 
 	private final Piece piece;
 	private RoomFrame roomFrame;
-	private String oldName = null;
-	private String newName = null;
-	private Point oldPosition = null;
-	private Point newPosition = null;
-	private Point2D oldScale = null;
-	private Point2D newScale = null;
-	private Double oldRotation = null;
-	private Double newRotation = null;
-	private Integer oldAlpha = null;
-	private Integer newAlpha = null;
-	private Color oldColor = null;
-	private Color newColor = null;
+	private Type type;
+	
+	private Object oldVal = null;
+	private Object newVal = null;
 
-	// Record the effect of renaming a piece
-	public ModifyPieceInstance(RoomFrame roomFrame, Piece piece, String oldName, String newName)
+	public ModifyPieceInstance(RoomFrame roomFrame, Piece piece, Type type, Object oldVal, Object newVal)
 		{
 		this.roomFrame = roomFrame;
 		this.piece = piece;
-		this.oldName = oldName;
-		this.newName = newName;
-		}
-
-	// Record the effect of moving a piece
-	public ModifyPieceInstance(RoomFrame roomFrame, Piece piece, Point oldPosition, Point newPosition)
-		{
-		this.roomFrame = roomFrame;
-		this.piece = piece;
-		this.oldPosition = oldPosition;
-		this.newPosition = newPosition;
-		}
-
-	// Record the effect of modifying the scale of a piece
-	public ModifyPieceInstance(RoomFrame roomFrame, Piece piece, Point2D oldScale, Point2D newScale)
-		{
-		this.roomFrame = roomFrame;
-		this.piece = piece;
-		this.oldScale = oldScale;
-		this.newScale = newScale;
-		}
-
-	// Record the effect of modifying the rotation of a piece
-	public ModifyPieceInstance(RoomFrame roomFrame, Piece piece, Double oldRotation, Double newRotation)
-		{
-		this.roomFrame = roomFrame;
-		this.piece = piece;
-		this.oldRotation = oldRotation;
-		this.newRotation = newRotation;
-		}
-
-	// Record the effect of modifying the alpha of a piece
-	public ModifyPieceInstance(RoomFrame roomFrame, Piece piece, Integer oldAlpha, Integer newAlpha)
-		{
-		this.roomFrame = roomFrame;
-		this.piece = piece;
-		this.oldAlpha = oldAlpha;
-		this.newAlpha = newAlpha;
-		}
-
-	// Record the effect of modifying the color of a piece
-	public ModifyPieceInstance(RoomFrame roomFrame, Piece piece, Color oldColor, Color newColor)
-		{
-		this.roomFrame = roomFrame;
-		this.piece = piece;
-		this.oldColor = oldColor;
-		this.newColor = newColor;
+		this.type = type;
+		this.oldVal = oldVal;
+		this.newVal = newVal;
 		}
 
 	private void selectPiece()
@@ -116,24 +68,30 @@ public class ModifyPieceInstance extends AbstractUndoableEdit
 	public void undo() throws CannotUndoException
 		{
 		selectPiece();
-		if (oldName != null) piece.setName(oldName);
-		if (oldPosition != null) piece.setPosition(oldPosition);
-		if (oldScale != null) piece.setScale(oldScale);
-		if (oldRotation != null) piece.setRotation(oldRotation);
-		if (oldAlpha != null) piece.setAlpha(oldAlpha);
-		if (oldColor != null) piece.setColor(oldColor);
+		switch (type)
+			{
+			case NAME: piece.setName((String) oldVal); break;
+			case POSITION: piece.setPosition((Point) oldVal); break;
+			case SCALE: piece.setScale((Point2D) oldVal); break;
+			case ROTATION: piece.setRotation((double) oldVal); break;
+			case ALPHA: piece.setAlpha((int) oldVal); break;
+			case COLOR: piece.setColor((Color) oldVal); break;
+			}
 		}
 
 	@Override
 	public void redo() throws CannotRedoException
 		{
 		selectPiece();
-		if (newName != null) piece.setName(newName);
-		if (newPosition != null) piece.setPosition(newPosition);
-		if (newScale != null) piece.setScale(newScale);
-		if (newRotation != null) piece.setRotation(newRotation);
-		if (newAlpha != null) piece.setAlpha(newAlpha);
-		if (newColor != null) piece.setColor(newColor);
+		switch (type)
+			{
+			case NAME: piece.setName((String) newVal); break;
+			case POSITION: piece.setPosition((Point) newVal); break;
+			case SCALE: piece.setScale((Point2D) newVal); break;
+			case ROTATION: piece.setRotation((double) newVal); break;
+			case ALPHA: piece.setAlpha((int) newVal); break;
+			case COLOR: piece.setColor((Color) newVal); break;
+			}
 		}
 
 	@Override


### PR DESCRIPTION
This is an attempt to resolve #319 by introducing an enum type to the undoable edit class used by tiles and instances. This does not actually utilize the generics, all I did was remove the variable and constructor overload for each undo type and instead replaced them with two generic Object variables. Not only does this make each undo a lot smaller memory-wise it also makes it much easier to expand this to support additional properties in the future by removing ambiguity, which were my main complaints when I filed #319 originally.

I gave this some pretty thorough regression testing and it seems to behave the same. The only thing I noticed, which hasn't changed is, the order of undos seems to be mixed up sometimes. I can reproduce that in previous releases too though, so it can be fixed later on separately from this change.