### PR TITLE
Alternative Instance/Tile Property Undo

### DIFF
--- a/org/lateralgm/components/visual/RoomEditor.java
+++ b/org/lateralgm/components/visual/RoomEditor.java
@@ -60,7 +60,6 @@ import org.lateralgm.util.PropertyMap.PropertyUpdateEvent;
 import org.lateralgm.util.PropertyMap.PropertyUpdateListener;
 import org.lateralgm.util.PropertyMap.PropertyValidator;
 import org.lateralgm.util.RemovePieceInstance;
-import org.lateralgm.util.ModifyPieceInstance.Type;
 
 public class RoomEditor extends VisualPanel
 	{
@@ -400,22 +399,25 @@ public class RoomEditor extends VisualPanel
 		{
 		// Stores several actions in one compound action for the undo
 		CompoundEdit compoundEdit = new CompoundEdit();
-		UndoableEdit edit = null;
 
 		// If the piece was moved
 		if (objectFirstPosition != null)
+			{
 			// For the undo, record that the object was moved
-			edit = new ModifyPieceInstance(frame,cursor,Type.POSITION,objectFirstPosition,new Point(lastPosition));
+			Object xkey = (cursor instanceof Instance) ? PInstance.X : PTile.ROOM_X;
+			Object ykey = (cursor instanceof Instance) ? PInstance.Y : PTile.ROOM_Y;
+			compoundEdit.addEdit(new ModifyPieceInstance(frame,cursor,xkey,objectFirstPosition.x,lastPosition.x));
+			compoundEdit.addEdit(new ModifyPieceInstance(frame,cursor,ykey,objectFirstPosition.y,lastPosition.y));
+			}
 		else
 			// A new piece has been added
 			{
 			if (cursor instanceof Instance)
-				edit = new AddPieceInstance(frame,cursor,room.instances.size() - 1);
+				compoundEdit.addEdit(new AddPieceInstance(frame,cursor,room.instances.size() - 1));
 			else
-				edit = new AddPieceInstance(frame,cursor,room.tiles.size() - 1);
+				compoundEdit.addEdit(new AddPieceInstance(frame,cursor,room.tiles.size() - 1));
 			}
 
-		compoundEdit.addEdit(edit);
 		objectFirstPosition = null;
 
 		//it must be guaranteed that cursor != null

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -135,7 +135,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.94"; //$NON-NLS-1$
+	public static final String version = "1.8.95"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -135,7 +135,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.95"; //$NON-NLS-1$
+	public static final String version = "1.8.96"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/subframes/RoomFrame.java
+++ b/org/lateralgm/subframes/RoomFrame.java
@@ -3380,7 +3380,7 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 				// If the name of the object has been changed
 				if (!objectNewName.equals(pieceOriginalName))
 					{
-					// Record the effect of rotating an object for the undo
+					// Record the effect of renaming an object for the undo
 					UndoableEdit edit = new ModifyPieceInstance(this,selectedPiece,PInstance.NAME,pieceOriginalName,
 							objectNewName);
 					// notify the listeners

--- a/org/lateralgm/subframes/RoomFrame.java
+++ b/org/lateralgm/subframes/RoomFrame.java
@@ -140,7 +140,6 @@ import org.lateralgm.util.PropertyMap.PropertyUpdateEvent;
 import org.lateralgm.util.PropertyMap.PropertyUpdateListener;
 import org.lateralgm.util.RemovePieceInstance;
 import org.lateralgm.util.ShiftPieceInstances;
-import org.lateralgm.util.ModifyPieceInstance.Type;
 
 public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 		ListSelectionListener,CommandHandler,UpdateListener,FocusListener,ChangeListener
@@ -940,7 +939,7 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 			if (!originalColor.equals(newColour))
 				{
 				// Record the effect of modifying the color of an object for the undo
-				UndoableEdit edit = new ModifyPieceInstance(RoomFrame.this,selectedPiece,Type.COLOR,originalColor,
+				UndoableEdit edit = new ModifyPieceInstance(RoomFrame.this,selectedPiece,PInstance.COLOR,originalColor,
 						newColour);
 				// notify the listeners
 				undoSupport.postEdit(edit);
@@ -3377,11 +3376,11 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 				// Get the new name of the object
 				String objectNewName = new String(selectedPiece.getName());
 
-				// If the rotation of the object has been changed
-				if (objectNewName != pieceOriginalName)
+				// If the name of the object has been changed
+				if (!objectNewName.equals(pieceOriginalName))
 					{
 					// Record the effect of rotating an object for the undo
-					UndoableEdit edit = new ModifyPieceInstance(this,selectedPiece,Type.NAME,pieceOriginalName,
+					UndoableEdit edit = new ModifyPieceInstance(this,selectedPiece,PInstance.NAME,pieceOriginalName,
 							objectNewName);
 					// notify the listeners
 					undoSupport.postEdit(edit);
@@ -3398,10 +3397,13 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 				if (!objectNewPosition.equals(pieceOriginalPosition))
 					{
 					// Record the effect of moving an object for the undo
-					UndoableEdit edit = new ModifyPieceInstance(this,selectedPiece,Type.POSITION,pieceOriginalPosition,
-							objectNewPosition);
+					undoSupport.beginUpdate();
+					undoSupport.postEdit(new ModifyPieceInstance(this,selectedPiece,PInstance.X,pieceOriginalPosition.x,
+							objectNewPosition.x));
+					undoSupport.postEdit(new ModifyPieceInstance(this,selectedPiece,PInstance.Y,pieceOriginalPosition.y,
+							objectNewPosition.y));
 					// notify the listeners
-					undoSupport.postEdit(edit);
+					undoSupport.endUpdate();
 					}
 				}
 
@@ -3415,10 +3417,13 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 				if (!objectNewScale.equals(pieceOriginalScale))
 					{
 					// Record the effect of modifying the scale an object for the undo
-					UndoableEdit edit = new ModifyPieceInstance(this,selectedPiece,Type.SCALE,pieceOriginalScale,
-							new Point2D.Double(objectNewScale.getX(),objectNewScale.getY()));
+					undoSupport.beginUpdate();
+					undoSupport.postEdit(new ModifyPieceInstance(this,selectedPiece,PInstance.SCALE_X,pieceOriginalScale.getX(),
+							objectNewScale.getX()));
+					undoSupport.postEdit(new ModifyPieceInstance(this,selectedPiece,PInstance.SCALE_Y,pieceOriginalScale.getY(),
+							objectNewScale.getY()));
 					// notify the listeners
-					undoSupport.postEdit(edit);
+					undoSupport.endUpdate();
 					}
 				}
 
@@ -3429,10 +3434,10 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 				Double objectNewRotation = new Double(selectedPiece.getRotation());
 
 				// If the rotation of the object has been changed
-				if (objectNewRotation != pieceOriginalRotation)
+				if (!objectNewRotation.equals(pieceOriginalRotation))
 					{
 					// Record the effect of rotating an object for the undo
-					UndoableEdit edit = new ModifyPieceInstance(this,selectedPiece,Type.ROTATION,pieceOriginalRotation,
+					UndoableEdit edit = new ModifyPieceInstance(this,selectedPiece,PInstance.ROTATION,pieceOriginalRotation,
 							objectNewRotation);
 					// notify the listeners
 					undoSupport.postEdit(edit);
@@ -3446,10 +3451,10 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 				Integer objectNewAlpha = new Integer(selectedPiece.getAlpha());
 
 				// If the alpha value of the object has been changed
-				if (objectNewAlpha != pieceOriginalAlpha)
+				if (!objectNewAlpha.equals(pieceOriginalAlpha))
 					{
 					// Record the effect of modifying the alpha value of an object for the undo
-					UndoableEdit edit = new ModifyPieceInstance(this,selectedPiece,Type.ALPHA,pieceOriginalAlpha,
+					UndoableEdit edit = new ModifyPieceInstance(this,selectedPiece,PInstance.ALPHA,pieceOriginalAlpha,
 							objectNewAlpha);
 					// notify the listeners
 					undoSupport.postEdit(edit);
@@ -3470,10 +3475,13 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 			if (!tileNewPosition.equals(pieceOriginalPosition))
 				{
 				// Record the effect of moving an tile for the undo
-				UndoableEdit edit = new ModifyPieceInstance(this,selectedPiece,Type.POSITION,pieceOriginalPosition,
-						tileNewPosition);
+				undoSupport.beginUpdate();
+				undoSupport.postEdit(new ModifyPieceInstance(this,selectedPiece,PTile.ROOM_X,pieceOriginalPosition.x,
+						tileNewPosition.x));
+				undoSupport.postEdit(new ModifyPieceInstance(this,selectedPiece,PTile.ROOM_Y,pieceOriginalPosition.y,
+						tileNewPosition.y));
 				// notify the listeners
-				undoSupport.postEdit(edit);
+				undoSupport.endUpdate();
 				}
 
 			}

--- a/org/lateralgm/util/ModifyPieceInstance.java
+++ b/org/lateralgm/util/ModifyPieceInstance.java
@@ -12,39 +12,33 @@
 
 package org.lateralgm.util;
 
-import java.awt.Color;
-import java.awt.Point;
-import java.awt.geom.Point2D;
-
 import javax.swing.undo.AbstractUndoableEdit;
 import javax.swing.undo.CannotRedoException;
 import javax.swing.undo.CannotUndoException;
 
 import org.lateralgm.resources.Room.Piece;
 import org.lateralgm.resources.sub.Instance;
+import org.lateralgm.resources.sub.Instance.PInstance;
+import org.lateralgm.resources.sub.Tile;
+import org.lateralgm.resources.sub.Tile.PTile;
 import org.lateralgm.subframes.RoomFrame;
 
 public class ModifyPieceInstance extends AbstractUndoableEdit
 	{
-	public enum Type
-		{
-		NAME, POSITION, SCALE, ROTATION, ALPHA, COLOR
-		};
-
 	private static final long serialVersionUID = 1L;
 
 	private final Piece piece;
 	private RoomFrame roomFrame;
-	private Type type;
 	
+	private Object key;
 	private Object oldVal = null;
 	private Object newVal = null;
 
-	public ModifyPieceInstance(RoomFrame roomFrame, Piece piece, Type type, Object oldVal, Object newVal)
+	public ModifyPieceInstance(RoomFrame roomFrame, Piece piece, Object key, Object oldVal, Object newVal)
 		{
 		this.roomFrame = roomFrame;
 		this.piece = piece;
-		this.type = type;
+		this.key = key;
 		this.oldVal = oldVal;
 		this.newVal = newVal;
 		}
@@ -68,30 +62,20 @@ public class ModifyPieceInstance extends AbstractUndoableEdit
 	public void undo() throws CannotUndoException
 		{
 		selectPiece();
-		switch (type)
-			{
-			case NAME: piece.setName((String) oldVal); break;
-			case POSITION: piece.setPosition((Point) oldVal); break;
-			case SCALE: piece.setScale((Point2D) oldVal); break;
-			case ROTATION: piece.setRotation((double) oldVal); break;
-			case ALPHA: piece.setAlpha((int) oldVal); break;
-			case COLOR: piece.setColor((Color) oldVal); break;
-			}
+		if (piece instanceof Instance)
+			((Instance)piece).properties.put((PInstance) key, oldVal);
+		else if (piece instanceof Tile)
+			((Tile)piece).properties.put((PTile) key, oldVal);
 		}
 
 	@Override
 	public void redo() throws CannotRedoException
 		{
 		selectPiece();
-		switch (type)
-			{
-			case NAME: piece.setName((String) newVal); break;
-			case POSITION: piece.setPosition((Point) newVal); break;
-			case SCALE: piece.setScale((Point2D) newVal); break;
-			case ROTATION: piece.setRotation((double) newVal); break;
-			case ALPHA: piece.setAlpha((int) newVal); break;
-			case COLOR: piece.setColor((Color) newVal); break;
-			}
+		if (piece instanceof Instance)
+			((Instance)piece).properties.put((PInstance) key, newVal);
+		else if (piece instanceof Tile)
+			((Tile)piece).properties.put((PTile) key, newVal);
 		}
 
 	@Override
@@ -105,5 +89,4 @@ public class ModifyPieceInstance extends AbstractUndoableEdit
 		{
 		return true;
 		}
-
 	}


### PR DESCRIPTION
This was an alternative idea I had for recording the undoable instance/tile edits. Rather than create a new enum as I did in #468, we can reuse the existing PInstance and PTile enums for the key. We can make each undoable edit modify the property map directly rather than through the Piece interface.

This has the slight advantage of being more powerful as we can now easily use the class for any modifiable instance or tile property without actually changing the class. It has a slight disadvantage in that because of the way we separate X/Y coordinates in the property maps instead of keeping them as a point, we need to utilize compound edits and do some extra boxing. This also is a little odd because when we chain an undo for x to an undo for y as a compound edit, both of them will process selecting the piece in the instance or tile list when you attempt to undo them. We still haven't solved how to do the selection only once for compound edits, however it's negligible as the redundant selection probably isn't that costly.

I gave this some extensive testing and it does behave itself quite well, even if we decide we don't want to merge it and go this way.