### PR TITLE
Logical Equality for Instance/Tile Undo

### DIFF
--- a/org/lateralgm/components/visual/RoomEditor.java
+++ b/org/lateralgm/components/visual/RoomEditor.java
@@ -405,7 +405,7 @@ public class RoomEditor extends VisualPanel
 		// If the piece was moved
 		if (objectFirstPosition != null)
 			// For the undo, record that the object was moved
-			edit = new ModifyPieceInstance(frame,cursor,Type.POSITION,objectFirstPosition,new Point(lastPosition));
+			edit = new ModifyPieceInstance(frame,cursor,Type.POSITION,objectFirstPosition,lastPosition);
 		else
 			// A new piece has been added
 			{

--- a/org/lateralgm/components/visual/RoomEditor.java
+++ b/org/lateralgm/components/visual/RoomEditor.java
@@ -405,7 +405,7 @@ public class RoomEditor extends VisualPanel
 		// If the piece was moved
 		if (objectFirstPosition != null)
 			// For the undo, record that the object was moved
-			edit = new ModifyPieceInstance(frame,cursor,Type.POSITION,objectFirstPosition,lastPosition);
+			edit = new ModifyPieceInstance(frame,cursor,Type.POSITION,objectFirstPosition,new Point(lastPosition));
 		else
 			// A new piece has been added
 			{

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -135,7 +135,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.95"; //$NON-NLS-1$
+	public static final String version = "1.8.96"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/subframes/RoomFrame.java
+++ b/org/lateralgm/subframes/RoomFrame.java
@@ -3376,10 +3376,10 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 			if (pieceOriginalName != null)
 				{
 				// Get the new name of the object
-				String objectNewName = new String(selectedPiece.getName());
+				String objectNewName = selectedPiece.getName();
 
 				// If the name of the object has been changed
-				if (objectNewName != pieceOriginalName)
+				if (!pieceOriginalName.equals(objectNewName))
 					{
 					// Record the effect of renaming an object for the undo
 					UndoableEdit edit = new ModifyPieceInstance(this,selectedPiece,Type.NAME,pieceOriginalName,
@@ -3393,10 +3393,10 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 			if (pieceOriginalPosition != null)
 				{
 				// Get the new position of the object
-				Point objectNewPosition = new Point(selectedPiece.getPosition());
+				Point objectNewPosition = selectedPiece.getPosition();
 
 				// If the position of the object has been changed
-				if (!objectNewPosition.equals(pieceOriginalPosition))
+				if (!pieceOriginalPosition.equals(objectNewPosition))
 					{
 					// Record the effect of moving an object for the undo
 					UndoableEdit edit = new ModifyPieceInstance(this,selectedPiece,Type.POSITION,pieceOriginalPosition,
@@ -3413,11 +3413,11 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 				Point2D objectNewScale = selectedPiece.getScale();
 
 				// If the scale of the object has been modified
-				if (!objectNewScale.equals(pieceOriginalScale))
+				if (!pieceOriginalScale.equals(objectNewScale))
 					{
 					// Record the effect of modifying the scale an object for the undo
 					UndoableEdit edit = new ModifyPieceInstance(this,selectedPiece,Type.SCALE,pieceOriginalScale,
-							new Point2D.Double(objectNewScale.getX(),objectNewScale.getY()));
+							objectNewScale);
 					// notify the listeners
 					undoSupport.postEdit(edit);
 					}
@@ -3427,10 +3427,10 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 			if (pieceOriginalRotation != null)
 				{
 				// Get the new rotation of the object
-				Double objectNewRotation = new Double(selectedPiece.getRotation());
+				Double objectNewRotation = selectedPiece.getRotation();
 
 				// If the rotation of the object has been changed
-				if (objectNewRotation != pieceOriginalRotation)
+				if (!pieceOriginalRotation.equals(objectNewRotation))
 					{
 					// Record the effect of rotating an object for the undo
 					UndoableEdit edit = new ModifyPieceInstance(this,selectedPiece,Type.ROTATION,pieceOriginalRotation,
@@ -3444,10 +3444,10 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 			if (pieceOriginalAlpha != null)
 				{
 				// Get the new alpha of the object
-				Integer objectNewAlpha = new Integer(selectedPiece.getAlpha());
+				Integer objectNewAlpha = selectedPiece.getAlpha();
 
 				// If the alpha value of the object has been changed
-				if (objectNewAlpha != pieceOriginalAlpha)
+				if (!pieceOriginalAlpha.equals(objectNewAlpha))
 					{
 					// Record the effect of modifying the alpha value of an object for the undo
 					UndoableEdit edit = new ModifyPieceInstance(this,selectedPiece,Type.ALPHA,pieceOriginalAlpha,
@@ -3464,19 +3464,22 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 			int selectedIndex = tList.getSelectedIndex();
 			if (selectedIndex == -1) return;
 
-			// Get the new position of the tile
-			Point tileNewPosition = new Point(selectedPiece.getPosition());
-
-			// If the position of the tile has been changed
-			if (!tileNewPosition.equals(pieceOriginalPosition))
+			// If we have changed the position
+			if (pieceOriginalPosition != null)
 				{
-				// Record the effect of moving an tile for the undo
-				UndoableEdit edit = new ModifyPieceInstance(this,selectedPiece,Type.POSITION,pieceOriginalPosition,
-						tileNewPosition);
-				// notify the listeners
-				undoSupport.postEdit(edit);
+				// Get the new position of the tile
+				Point tileNewPosition = selectedPiece.getPosition();
+	
+				// If the position of the tile has been changed
+				if (!pieceOriginalPosition.equals(tileNewPosition))
+					{
+					// Record the effect of moving a tile for the undo
+					UndoableEdit edit = new ModifyPieceInstance(this,selectedPiece,Type.POSITION,pieceOriginalPosition,
+							tileNewPosition);
+					// notify the listeners
+					undoSupport.postEdit(edit);
+					}
 				}
-
 			}
 
 		selectedPiece = null;

--- a/org/lateralgm/subframes/RoomFrame.java
+++ b/org/lateralgm/subframes/RoomFrame.java
@@ -3393,7 +3393,7 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 			if (pieceOriginalPosition != null)
 				{
 				// Get the new position of the object
-				Point objectNewPosition = selectedPiece.getPosition();
+				Point objectNewPosition = new Point(selectedPiece.getPosition());
 
 				// If the position of the object has been changed
 				if (!pieceOriginalPosition.equals(objectNewPosition))
@@ -3410,7 +3410,8 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 			if (pieceOriginalScale != null)
 				{
 				// Get the new scale of the object
-				Point2D objectNewScale = selectedPiece.getScale();
+				Point2D objectNewScale = new Point2D.Double(selectedPiece.getScale().getX(),
+						selectedPiece.getScale().getY());
 
 				// If the scale of the object has been modified
 				if (!pieceOriginalScale.equals(objectNewScale))
@@ -3427,7 +3428,7 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 			if (pieceOriginalRotation != null)
 				{
 				// Get the new rotation of the object
-				Double objectNewRotation = selectedPiece.getRotation();
+				Double objectNewRotation = new Double(selectedPiece.getRotation());
 
 				// If the rotation of the object has been changed
 				if (!pieceOriginalRotation.equals(objectNewRotation))
@@ -3444,7 +3445,7 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 			if (pieceOriginalAlpha != null)
 				{
 				// Get the new alpha of the object
-				Integer objectNewAlpha = selectedPiece.getAlpha();
+				Integer objectNewAlpha = new Integer(selectedPiece.getAlpha());
 
 				// If the alpha value of the object has been changed
 				if (!pieceOriginalAlpha.equals(objectNewAlpha))
@@ -3468,7 +3469,7 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 			if (pieceOriginalPosition != null)
 				{
 				// Get the new position of the tile
-				Point tileNewPosition = selectedPiece.getPosition();
+				Point tileNewPosition = new Point(selectedPiece.getPosition());
 	
 				// If the position of the tile has been changed
 				if (!pieceOriginalPosition.equals(tileNewPosition))


### PR DESCRIPTION
I am proposing to change the undoable instance/tile edit tracking to use logical equality in determining when an undoable property has changed. Originally, egofree was using reference equality which was always true because he was unnecessarily boxing all of the already boxed properties.

I tested and it is in fact very difficult, while still possible, to implement this entire interface correctly using reference equality. We do not want to do this however because the Piece interface implemented by Tiles and Instances constructs a new Point object every time you call the position or scale getter, making it impossible to compare solely the references.

The reason for changing this is not just efficiency, but also to get rid of false-positive undos being added to the edit history which make the undo system very confusing. From my local testing, the undo seems to be behaving a lot better and undos are not being registered now when you haven't actually changed the values. Changing the name or color of an instance now also creates only a single undo instead of two.