### PR TITLE
Fix Instance Creation Flicker

### DIFF
--- a/org/lateralgm/components/visual/RoomEditor.java
+++ b/org/lateralgm/components/visual/RoomEditor.java
@@ -330,6 +330,7 @@ public class RoomEditor extends VisualPanel
 			newInstance.setCode(instance.getCode());
 			newInstance.setCreationCode(instance.getCreationCode());
 			newInstance.setPosition(newPosition);
+			room.instances.add(newInstance);
 
 			// Record the effect of adding a new instance for the undo
 			UndoableEdit edit = new AddPieceInstance(frame,newInstance,room.instances.size() - 1);
@@ -591,6 +592,7 @@ public class RoomEditor extends VisualPanel
 			Instance instance = room.addInstance();
 			instance.properties.put(PInstance.OBJECT,obj);
 			instance.setPosition(position);
+			room.instances.add(instance);
 
 			setCursor(instance);
 			}

--- a/org/lateralgm/file/GMXFileReader.java
+++ b/org/lateralgm/file/GMXFileReader.java
@@ -1493,6 +1493,7 @@ public final class GMXFileReader
 						inst.setRotation(rot);
 						inst.setCreationCode(inode.getAttributes().getNamedItem("code").getNodeValue()); //$NON-NLS-1$
 						inst.setLocked(Integer.parseInt(inode.getAttributes().getNamedItem("locked").getNodeValue()) != 0); //$NON-NLS-1$
+						rmn.instances.add(inst);
 						}
 					}
 				}

--- a/org/lateralgm/file/GmFileReader.java
+++ b/org/lateralgm/file/GmFileReader.java
@@ -1075,6 +1075,7 @@ public final class GmFileReader
 				inst.properties.put(PInstance.ID,in.read4());
 				inst.setCreationCode(in.readStr());
 				inst.setLocked(in.readBool());
+				rm.instances.add(inst);
 				}
 			int notiles = in.read4();
 			for (int j = 0; j < notiles; j++)

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -135,7 +135,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.97"; //$NON-NLS-1$
+	public static final String version = "1.8.98"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/resources/Room.java
+++ b/org/lateralgm/resources/Room.java
@@ -87,6 +87,12 @@ public class Room extends InstantiableResource<Room,Room.PRoom> implements CodeH
 		return new Room(r);
 		}
 
+	/**
+	 * Allocates a new instance in this room.
+	 * Callers are responsible for adding the instance to the room's visual instance list only
+	 * once they have fully initialized all of its properties.
+	 * @return A new instance allocated in this room.
+	 */
 	public Instance addInstance()
 		{
 		Instance inst = new Instance(this);

--- a/org/lateralgm/resources/Room.java
+++ b/org/lateralgm/resources/Room.java
@@ -91,7 +91,6 @@ public class Room extends InstantiableResource<Room,Room.PRoom> implements CodeH
 		{
 		Instance inst = new Instance(this);
 		inst.properties.put(PInstance.ID,++LGM.currentFile.lastInstanceId);
-		instances.add(inst);
 		return inst;
 		}
 
@@ -123,6 +122,7 @@ public class Room extends InstantiableResource<Room,Room.PRoom> implements CodeH
 			{
 			Instance inst2 = dest.addInstance();
 			inst2.properties.putAll(inst.properties);
+			dest.instances.add(inst2);
 			}
 		for (Tile tile : tiles)
 			{

--- a/org/lateralgm/subframes/RoomFrame.java
+++ b/org/lateralgm/subframes/RoomFrame.java
@@ -2335,7 +2335,7 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 						Instance newInstance = res.addInstance();
 						newInstance.properties.put(PInstance.OBJECT,oNew.getSelected());
 						newInstance.setPosition(newPosition);
-
+						res.instances.add(newInstance);
 						// Record the effect of adding a new instance for the undo
 						UndoableEdit edit = new AddPieceInstance(this,newInstance,
 								currentRoom.instances.size() - 1);


### PR DESCRIPTION
This is an attempt to resolve #472 by not having the `Room.addInstance` method immediately add new instances to the visual list. This allows time for the caller to fully initialize properties of the new instance (such as location based on mouse cursor position) before the new instance becomes visible.

With this change, instance creation is super slick now and there is no flicker or perceivable lag. This way is arguably more efficient as well because instances are initialized with the correct properties rather than having the room visual unnecessarily respond to all of the property change events. 