### PR TITLE
Alternative Instance Creation Solution

### DIFF
--- a/org/lateralgm/components/visual/RoomEditor.java
+++ b/org/lateralgm/components/visual/RoomEditor.java
@@ -321,7 +321,7 @@ public class RoomEditor extends VisualPanel
 			Point newPosition = new Point(position.x - selectedPiecesOrigin.x + mousePosition.x,
 					position.y - selectedPiecesOrigin.y + mousePosition.y);
 
-			Instance newInstance = room.addInstance();
+			Instance newInstance = new Instance(room);
 			newInstance.properties.put(PInstance.OBJECT,instance.properties.get(PInstance.OBJECT));
 			newInstance.setRotation(instance.getRotation());
 			newInstance.setScale(instance.getScale());
@@ -330,6 +330,8 @@ public class RoomEditor extends VisualPanel
 			newInstance.setCode(instance.getCode());
 			newInstance.setCreationCode(instance.getCreationCode());
 			newInstance.setPosition(newPosition);
+			newInstance.properties.put(PInstance.ID,++LGM.currentFile.lastInstanceId);
+			room.addInstance(newInstance);
 
 			// Record the effect of adding a new instance for the undo
 			UndoableEdit edit = new AddPieceInstance(frame,newInstance,room.instances.size() - 1);
@@ -588,10 +590,12 @@ public class RoomEditor extends VisualPanel
 			{
 			ResourceReference<GmObject> obj = frame.oNew.getSelected();
 			if (obj == null) return; //I'd rather just break out of this IF, but this works
-			Instance instance = room.addInstance();
+			Instance instance = new Instance(room);
 			instance.properties.put(PInstance.OBJECT,obj);
+			instance.properties.put(PInstance.ID,++LGM.currentFile.lastInstanceId);
 			instance.setPosition(position);
-
+			room.addInstance(instance);
+			
 			setCursor(instance);
 			}
 		}

--- a/org/lateralgm/file/GMXFileReader.java
+++ b/org/lateralgm/file/GMXFileReader.java
@@ -1446,7 +1446,7 @@ public final class GMXFileReader
 						}
 					else if (iname.equals("instance") && inode.getAttributes().getLength() > 0) //$NON-NLS-1$
 						{
-						Instance inst = rmn.addInstance();
+						Instance inst = new Instance(rmn);
 
 						// TODO: Replace this with DelayedRef
 						String objname = inode.getAttributes().getNamedItem("objName").getTextContent(); //$NON-NLS-1$
@@ -1493,6 +1493,7 @@ public final class GMXFileReader
 						inst.setRotation(rot);
 						inst.setCreationCode(inode.getAttributes().getNamedItem("code").getNodeValue()); //$NON-NLS-1$
 						inst.setLocked(Integer.parseInt(inode.getAttributes().getNamedItem("locked").getNodeValue()) != 0); //$NON-NLS-1$
+						rmn.addInstance(inst);
 						}
 					}
 				}

--- a/org/lateralgm/file/GmFileReader.java
+++ b/org/lateralgm/file/GmFileReader.java
@@ -1068,13 +1068,14 @@ public final class GmFileReader
 			int noinstances = in.read4();
 			for (int j = 0; j < noinstances; j++)
 				{
-				Instance inst = rm.addInstance();
+				Instance inst = new Instance(rm);
 				inst.setPosition(new Point(in.read4(),in.read4()));
 				GmObject temp = f.resMap.getList(GmObject.class).getUnsafe(in.read4());
 				if (temp != null) inst.properties.put(PInstance.OBJECT,temp.reference);
 				inst.properties.put(PInstance.ID,in.read4());
 				inst.setCreationCode(in.readStr());
 				inst.setLocked(in.readBool());
+				rm.addInstance(inst);
 				}
 			int notiles = in.read4();
 			for (int j = 0; j < notiles; j++)

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -135,7 +135,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.97"; //$NON-NLS-1$
+	public static final String version = "1.8.98"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/resources/Room.java
+++ b/org/lateralgm/resources/Room.java
@@ -87,12 +87,13 @@ public class Room extends InstantiableResource<Room,Room.PRoom> implements CodeH
 		return new Room(r);
 		}
 
-	public Instance addInstance()
+	/**
+	 * Adds a fully initialized instance to this room.
+	 * Callers are responsible for allocating the instance and initializing its properties.
+	 */
+	public void addInstance(Instance inst)
 		{
-		Instance inst = new Instance(this);
-		inst.properties.put(PInstance.ID,++LGM.currentFile.lastInstanceId);
 		instances.add(inst);
-		return inst;
 		}
 
 	public int getWidth()
@@ -121,8 +122,10 @@ public class Room extends InstantiableResource<Room,Room.PRoom> implements CodeH
 		super.postCopy(dest);
 		for (Instance inst : instances)
 			{
-			Instance inst2 = dest.addInstance();
+			Instance inst2 = new Instance(dest);
 			inst2.properties.putAll(inst.properties);
+			inst2.properties.put(PInstance.ID,++LGM.currentFile.lastInstanceId);
+			dest.addInstance(inst2);
 			}
 		for (Tile tile : tiles)
 			{

--- a/org/lateralgm/subframes/RoomFrame.java
+++ b/org/lateralgm/subframes/RoomFrame.java
@@ -2332,9 +2332,11 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 					// If object's tab is selected, add a new object
 					if (objectsTabIsSelected)
 						{
-						Instance newInstance = res.addInstance();
+						Instance newInstance = new Instance(res);
 						newInstance.properties.put(PInstance.OBJECT,oNew.getSelected());
 						newInstance.setPosition(newPosition);
+						newInstance.properties.put(PInstance.ID,++LGM.currentFile.lastInstanceId);
+						res.addInstance(newInstance);
 
 						// Record the effect of adding a new instance for the undo
 						UndoableEdit edit = new AddPieceInstance(this,newInstance,
@@ -2671,10 +2673,12 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 			if (selectedPiece != null) selectedPiece.setSelected(false);
 
 			// Add the new object instance
-			Instance newObject = res.addInstance();
+			Instance newObject = new Instance(res);
 			newObject.properties.put(PInstance.OBJECT,oNew.getSelected());
+			newObject.properties.put(PInstance.ID,++LGM.currentFile.lastInstanceId);
 			newObject.setPosition(new Point());
-
+			res.addInstance(newObject);
+			
 			int numberOfObjects = res.instances.size();
 
 			// Record the effect of adding an object for the undo


### PR DESCRIPTION
This is an alternative to #476 that also addresses #472 but in a different way. The idea here is instead of moving the responsibility of updating the room instance visual list to the caller, we move the responsibility of allocating and initializing the instance to the caller.