### PR TITLE
Postpone Visual List Updates

### DIFF
--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -135,7 +135,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.97"; //$NON-NLS-1$
+	public static final String version = "1.8.98"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/resources/Room.java
+++ b/org/lateralgm/resources/Room.java
@@ -90,8 +90,8 @@ public class Room extends InstantiableResource<Room,Room.PRoom> implements CodeH
 	/**
 	 * Allocates a new instance in this room and assigns it a valid id.
 	 * Callers are responsible for finishing initialization of the instance
-	 * so that when the instance visual list is later updated on the event
-	 * dispatch thread, the instance will appear correctly.
+	 * so that when the instance visual is later validated on the event
+	 * dispatch thread, the instance will paint correctly.
 	 * @return A new instance allocated in this room.
 	 */
 	public Instance addInstance()

--- a/org/lateralgm/resources/Room.java
+++ b/org/lateralgm/resources/Room.java
@@ -87,6 +87,13 @@ public class Room extends InstantiableResource<Room,Room.PRoom> implements CodeH
 		return new Room(r);
 		}
 
+	/**
+	 * Allocates a new instance in this room and assigns it a valid id.
+	 * Callers are responsible for finishing initialization of the instance
+	 * so that when the instance visual list is later updated on the event
+	 * dispatch thread, the instance will appear correctly.
+	 * @return A new instance allocated in this room.
+	 */
 	public Instance addInstance()
 		{
 		Instance inst = new Instance(this);

--- a/org/lateralgm/ui/swing/visuals/RoomVisual.java
+++ b/org/lateralgm/ui/swing/visuals/RoomVisual.java
@@ -1165,9 +1165,19 @@ public class RoomVisual extends AbstractVisual implements BoundedVisual,UpdateLi
 				case ADDED:
 					for (int i = lue.fromIndex; i <= lue.toIndex; i++)
 						{
-						T t = tList.get(i);
-						V v = createVisual(t);
-						vList.add(i,v);
+						// postpone adding new visuals to the list so
+						// the caller has a chance to fully initialize
+						// the visual before it becomes visible to the user
+						final T t = tList.get(i);
+						final int ind = i;
+						SwingUtilities.invokeLater(new Runnable() {
+							@Override
+							public void run()
+								{
+								V v = createVisual(t);
+								vList.add(ind,v);
+								}
+						});
 						}
 					break;
 				case REMOVED:

--- a/org/lateralgm/ui/swing/visuals/RoomVisual.java
+++ b/org/lateralgm/ui/swing/visuals/RoomVisual.java
@@ -677,17 +677,6 @@ public class RoomVisual extends AbstractVisual implements BoundedVisual,UpdateLi
 		 * thread allowing the caller to fully initialize
 		 * the visual before it becomes visible to the user.
 		 */
-		protected final void validateLater()
-			{
-			SwingUtilities.invokeLater(new Runnable() {
-				@Override
-				public void run()
-					{
-					validate();
-					}
-			});
-			}
-
 		protected final void invalidate()
 			{
 			if (invalid) return;
@@ -766,7 +755,7 @@ public class RoomVisual extends AbstractVisual implements BoundedVisual,UpdateLi
 			super(i);
 			i.updateSource.addListener(rul);
 			i.properties.updateSource.addListener(ipl);
-			validateLater();
+			invalidate();
 			}
 
 		@Override
@@ -1001,7 +990,7 @@ public class RoomVisual extends AbstractVisual implements BoundedVisual,UpdateLi
 			super(t);
 			t.updateSource.addListener(rul);
 			t.properties.updateSource.addListener(tpl);
-			validateLater();
+			invalidate();
 			}
 
 		@Override

--- a/org/lateralgm/ui/swing/visuals/RoomVisual.java
+++ b/org/lateralgm/ui/swing/visuals/RoomVisual.java
@@ -671,6 +671,22 @@ public class RoomVisual extends AbstractVisual implements BoundedVisual,UpdateLi
 			}
 
 		protected abstract void validate();
+		
+		/**
+		 * Validate the visual later on the event dispatch
+		 * thread allowing the caller to fully initialize
+		 * the visual before it becomes visible to the user.
+		 */
+		protected final void validateLater()
+			{
+			SwingUtilities.invokeLater(new Runnable() {
+				@Override
+				public void run()
+					{
+					validate();
+					}
+			});
+			}
 
 		protected final void invalidate()
 			{
@@ -750,7 +766,7 @@ public class RoomVisual extends AbstractVisual implements BoundedVisual,UpdateLi
 			super(i);
 			i.updateSource.addListener(rul);
 			i.properties.updateSource.addListener(ipl);
-			validate();
+			validateLater();
 			}
 
 		@Override
@@ -985,7 +1001,7 @@ public class RoomVisual extends AbstractVisual implements BoundedVisual,UpdateLi
 			super(t);
 			t.updateSource.addListener(rul);
 			t.properties.updateSource.addListener(tpl);
-			validate();
+			validateLater();
 			}
 
 		@Override
@@ -1165,19 +1181,9 @@ public class RoomVisual extends AbstractVisual implements BoundedVisual,UpdateLi
 				case ADDED:
 					for (int i = lue.fromIndex; i <= lue.toIndex; i++)
 						{
-						// postpone adding new visuals to the list so
-						// the caller has a chance to fully initialize
-						// the visual before it becomes visible to the user
-						final T t = tList.get(i);
-						final int ind = i;
-						SwingUtilities.invokeLater(new Runnable() {
-							@Override
-							public void run()
-								{
-								V v = createVisual(t);
-								vList.add(ind,v);
-								}
-						});
+						T t = tList.get(i);
+						V v = createVisual(t);
+						vList.add(i,v);
 						}
 					break;
 				case REMOVED:


### PR DESCRIPTION
This is a third alternative to fixing #472 based off an idea Josh proposed to me in #479. Rather than change the contract of the existing instance creation API, we can simply postpone the creation of the instance and tile visuals on the event dispatch thread. This allows the caller and `Room.addInstance()` to immediately add the instance or tile to its lists and allow the caller to finish initializing the instance before the visual is made visible to the user.

You may be inclined to ask why I would put the `Runnable` in `VisualListManager` instead of `Room.addInstance` and I have two good reasons. First, putting it in `VisualListManager` makes it automatically apply to tiles too. Second, `VisualListManager` is already tightly coupled with other Swing interfaces, but our `Room` resource class is not. Ideally we do not want LGM's resource model classes, like `Room`, to be coupled with Swing.

Now, I will say I feel a little uneasy about putting this in `VisualListmanager` as I am not too familiar with how it works entirely. I am also not sure why it seems to have two lists internally, one of which seems to be one of our own custom collections. However, I will say this works just as good as #476 and #479 and there doesn't seem to be any regressions.