### PR TITLE
Room Undo Selected Instance/Tile Value

### DIFF
--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -135,7 +135,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.98"; //$NON-NLS-1$
+	public static final String version = "1.8.99"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -135,7 +135,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.99"; //$NON-NLS-1$
+	public static final String version = "1.8.100"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/subframes/RoomFrame.java
+++ b/org/lateralgm/subframes/RoomFrame.java
@@ -3294,12 +3294,10 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 				|| event.getSource() == objectScaleY || event.getSource() == objectRotation
 				|| event.getSource() == objectAlpha)
 			{
-			// If no object is selected, return
-			int selectedIndex = oList.getSelectedIndex();
-			if (selectedIndex == -1) return;
-
 			// Save the selected instance
 			selectedPiece = oList.getSelectedValue();
+			// If no object is selected, return
+			if (selectedPiece == null) return;
 
 			// If we are modifying the name, save it for the undo
 			if (event.getSource() == objectName)
@@ -3342,12 +3340,10 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 		// We are modifying tiles
 		else
 			{
-			// If no tile is selected, return
-			int selectedIndex = tList.getSelectedIndex();
-			if (selectedIndex == -1) return;
-
 			// Save the selected tile
 			selectedPiece = tList.getSelectedValue();
+			// If no tile is selected, return
+			if (selectedPiece == null) return;
 
 			// Save the position of the tile for the undo
 			pieceOriginalPosition = new Point(selectedPiece.getPosition());

--- a/org/lateralgm/subframes/RoomFrame.java
+++ b/org/lateralgm/subframes/RoomFrame.java
@@ -926,10 +926,6 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 		@Override
 		public void itemStateChanged(ItemEvent e)
 		{
-			// If no object is selected, return
-			int selectedIndex = oList.getSelectedIndex();
-			if (selectedIndex == -1) return;
-
 			// Save the selected instance
 			selectedPiece = oList.getSelectedValue();
 			if (selectedPiece == null) return;


### PR DESCRIPTION
This is an attempt to resolve #482 by simply fixing the check in `focusGained` for whether there is an instance or tile selected. Egofree had the right idea, however, by right clicking to delete an instance it's possible for the instance list to still have a positive selection index that corresponds to a null value.

My local testing indicates this does resolve #482 and there doesn't seem to be any side effects.