### PR TITLE
Revert Tile Delete Button Patch

### DIFF
--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -135,7 +135,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.100"; //$NON-NLS-1$
+	public static final String version = "1.8.101"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/subframes/RoomFrame.java
+++ b/org/lateralgm/subframes/RoomFrame.java
@@ -2718,7 +2718,7 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 		if (eventSource == deleteTileButton)
 			{
 			int selectedIndex = tList.getSelectedIndex();
-			if (selectedIndex >= res.tiles.size() || selectedIndex < 0) return;
+			if (selectedIndex == -1) return;
 
 			Piece selectedPiece = editor.getSelectedPiece();
 


### PR DESCRIPTION
This undoes #69 which did not actually fix the underlying issue. The underlying issue was the selection model was not being told that a tile had been deselected due to a mistake in the `ArrayListModel` which #484 finally resolved for uses of the model class.

The reason #69 seemed to work is because while the selection was not being updated, removing the tile did in fact decrease the size of the tiles collection. However, it's an extraneous check to make now that the underlying issue is fixed.

I did some testing to make sure reverting this is ok now. I undid #69 and then tried to reproduce #29 which was successful only once #484 was also undone.