### PR TITLE
Use New Reflection Based Class Construction

### DIFF
--- a/org/lateralgm/file/RefList.java
+++ b/org/lateralgm/file/RefList.java
@@ -32,7 +32,7 @@ public class RefList<R extends InstantiableResource<R,?>>
 		R r = null;
 		try
 			{
-			r = clazz.newInstance();
+			r = clazz.getDeclaredConstructor().newInstance();
 			}
 		catch (Exception e)
 			{

--- a/org/lateralgm/file/ResourceList.java
+++ b/org/lateralgm/file/ResourceList.java
@@ -100,7 +100,7 @@ public class ResourceList<R extends InstantiableResource<R,?>> extends TreeSet<R
 		R res = null;
 		try
 			{
-			res = type.newInstance();
+			res = type.getDeclaredConstructor().newInstance();
 			}
 		catch (Exception e)
 			{

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -135,7 +135,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.101"; //$NON-NLS-1$
+	public static final String version = "1.8.102"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.
@@ -702,7 +702,7 @@ public final class LGM
 				if (clastr == null)
 					throw new Exception(Messages.format("LGM.PLUGIN_MISSING_ENTRY",pluginEntry)); //$NON-NLS-1$
 				URLClassLoader ucl = new URLClassLoader(new URL[] { f.toURI().toURL() });
-				ucl.loadClass(clastr).newInstance();
+				ucl.loadClass(clastr).getDeclaredConstructor().newInstance();
 				classLoaders.add(ucl);
 				}
 			catch (Exception e)


### PR DESCRIPTION
We were getting warnings about Class.newInstance() being deprecated which it was for exception safety. Simply using the recommended replacement here which is capable of throwing the missing exceptions.
https://docs.oracle.com/en/java/javase/13/docs/api/java.base/java/lang/Class.html#newInstance()