### PR TITLE
Code Editor Font Setting

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry excluding="modules/" kind="src" path=""/>
-	<classpathentry kind="src" path="modules/joshedit"/>
+	<classpathentry kind="src" path="modules/joshedit/src/main/java"/>
+	<classpathentry kind="src" path="modules/joshedit/src/main/resources"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
 		<attributes>
 			<attribute name="module" value="true"/>

--- a/org/lateralgm/components/CodeTextArea.java
+++ b/org/lateralgm/components/CodeTextArea.java
@@ -121,7 +121,7 @@ public class CodeTextArea extends JoshTextPanel implements UpdateListener,Action
 
 	public CodeTextArea(String code, DefaultTokenMarker marker)
 		{
-		super(code);
+		super(code, Prefs.codeFont);
 
 		tokenMarker = marker;
 
@@ -130,7 +130,6 @@ public class CodeTextArea extends JoshTextPanel implements UpdateListener,Action
 		setupKeywords();
 		updateKeywords();
 		updateResourceKeywords();
-		text.setFont(Prefs.codeFont);
 		//painter.setStyles(PrefsStore.getSyntaxStyles());
 		text.getActionMap().put("COMPLETIONS",completionAction);
 		LGM.currentFile.updateSource.addListener(this);

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -135,7 +135,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.105"; //$NON-NLS-1$
+	public static final String version = "1.8.106"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.


### PR DESCRIPTION
A couple of changes here so Hugar can use the code editor font settings, even though there's no UI for them yet and this does not add one. I'm basically just updating the JoshEdit submodule to pull my fixes that allow specifying a font to the JoshEdit constructor.
https://github.com/JoshDreamland/JoshEdit/pull/62

However, I also ran into some building issues here after I noticed Josh pulled somebody's fix to allow Apache Maven building and CI testing. I just had to change the build path/class path entry for where the JoshEdit submodule was located and provide a second entry for the resources since they are in a parallel directory structure.