### PR TITLE
Decouple Project Reader Interface from Swing

### DIFF
--- a/org/lateralgm/file/GMXFileReader.java
+++ b/org/lateralgm/file/GMXFileReader.java
@@ -43,17 +43,16 @@ import java.util.List;
 import java.util.Queue;
 
 import javax.imageio.ImageIO;
-import javax.swing.JProgressBar;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.lateralgm.components.impl.ResNode;
+import org.lateralgm.file.ProjectFile.InterfaceProvider;
 import org.lateralgm.file.ProjectFile.ResourceHolder;
 import org.lateralgm.file.iconio.ICOFile;
 import org.lateralgm.main.LGM;
 import org.lateralgm.main.Util;
-import org.lateralgm.messages.Messages;
 import org.lateralgm.resources.Background;
 import org.lateralgm.resources.Background.PBackground;
 import org.lateralgm.resources.Constants;
@@ -106,6 +105,7 @@ import org.lateralgm.resources.sub.Tile.PTile;
 import org.lateralgm.resources.sub.View;
 import org.lateralgm.resources.sub.View.PView;
 import org.lateralgm.util.PropertyMap;
+
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
@@ -226,9 +226,10 @@ public final class GMXFileReader
 	private static GmFormatException versionError(ProjectFile f, String error, String res, int i,
 			int ver)
 		{
-		return new GmFormatException(f,Messages.format(
-				"ProjectFileReader.ERROR_UNSUPPORTED",Messages.format(//$NON-NLS-1$
-						"ProjectFileReader." + error,Messages.getString("LGM." + res),i),ver)); //$NON-NLS-1$  //$NON-NLS-2$
+		InterfaceProvider ip = ProjectFile.interfaceProvider;
+		return new GmFormatException(f,ip.format(
+				"ProjectFileReader.ERROR_UNSUPPORTED",ip.format( //$NON-NLS-1$
+						"ProjectFileReader." + error,ip.translate("LGM." + res),i),ver)); //$NON-NLS-1$  //$NON-NLS-2$
 		}
 
 	public static void readProjectFile(InputStream stream, ProjectFile file, URI uri, ResNode root)
@@ -240,6 +241,8 @@ public final class GMXFileReader
 	public static void readProjectFile(InputStream stream, ProjectFile file, URI uri, ResNode root,
 			Charset forceCharset) throws GmFormatException
 		{
+		InterfaceProvider ip = ProjectFile.interfaceProvider;
+		ip.init(160,"ProgressDialog.GMX_LOADING"); //$NON-NLS-1$
 		file.format = ProjectFile.FormatFlavor.GMX;
 		if (documentBuilderFactory == null)
 			documentBuilderFactory = DocumentBuilderFactory.newInstance();
@@ -255,7 +258,6 @@ public final class GMXFileReader
 		RefList<Timeline> timeids = new RefList<Timeline>(Timeline.class); // timeline ids
 		RefList<GmObject> objids = new RefList<GmObject>(GmObject.class); // object ids
 		RefList<Room> rmids = new RefList<Room>(Room.class); // room id
-		long startTime = System.currentTimeMillis();
 
 		try
 			{
@@ -263,52 +265,46 @@ public final class GMXFileReader
 
 			ProjectFileContext c = new ProjectFileContext(file,document,timeids,objids,rmids);
 
-			JProgressBar progressBar = LGM.getProgressDialogBar();
-			progressBar.setMaximum(160);
-			LGM.setProgressTitle(Messages.getString("ProgressDialog.GMX_LOADING")); //$NON-NLS-1$
-
-			LGM.setProgress(0,Messages.getString("ProgressDialog.SPRITES")); //$NON-NLS-1$
+			ip.updateProgress(0,"ProgressDialog.SPRITES"); //$NON-NLS-1$
 			readGroup(c,root,Sprite.class);
-			LGM.setProgress(10,Messages.getString("ProgressDialog.SOUNDS")); //$NON-NLS-1$
+			ip.updateProgress(10,"ProgressDialog.SOUNDS"); //$NON-NLS-1$
 			readGroup(c,root,Sound.class);
-			LGM.setProgress(20,Messages.getString("ProgressDialog.BACKGROUNDS")); //$NON-NLS-1$
+			ip.updateProgress(20,"ProgressDialog.BACKGROUNDS"); //$NON-NLS-1$
 			readGroup(c,root,Background.class);
-			LGM.setProgress(30,Messages.getString("ProgressDialog.PATHS")); //$NON-NLS-1$
+			ip.updateProgress(30,"ProgressDialog.PATHS"); //$NON-NLS-1$
 			readGroup(c,root,Path.class);
-			LGM.setProgress(40,Messages.getString("ProgressDialog.SCRIPTS")); //$NON-NLS-1$
+			ip.updateProgress(40,"ProgressDialog.SCRIPTS"); //$NON-NLS-1$
 			readGroup(c,root,Script.class);
-			LGM.setProgress(50,Messages.getString("ProgressDialog.SHADERS")); //$NON-NLS-1$
+			ip.updateProgress(50,"ProgressDialog.SHADERS"); //$NON-NLS-1$
 			readGroup(c,root,Shader.class);
-			LGM.setProgress(60,Messages.getString("ProgressDialog.FONTS")); //$NON-NLS-1$
+			ip.updateProgress(60,"ProgressDialog.FONTS"); //$NON-NLS-1$
 			readGroup(c,root,Font.class);
-			LGM.setProgress(70,Messages.getString("ProgressDialog.TIMELINES")); //$NON-NLS-1$
+			ip.updateProgress(70,"ProgressDialog.TIMELINES"); //$NON-NLS-1$
 			readGroup(c,root,Timeline.class);
-			LGM.setProgress(80,Messages.getString("ProgressDialog.OBJECTS")); //$NON-NLS-1$
+			ip.updateProgress(80,"ProgressDialog.OBJECTS"); //$NON-NLS-1$
 			readGroup(c,root,GmObject.class);
-			LGM.setProgress(90,Messages.getString("ProgressDialog.ROOMS")); //$NON-NLS-1$
+			ip.updateProgress(90,"ProgressDialog.ROOMS"); //$NON-NLS-1$
 			readGroup(c,root,Room.class);
-			LGM.setProgress(100,Messages.getString("ProgressDialog.INCLUDEFILES")); //$NON-NLS-1$
+			ip.updateProgress(100,"ProgressDialog.INCLUDEFILES"); //$NON-NLS-1$
 			readGroup(c,root,Include.class);
-			LGM.setProgress(110,Messages.getString("ProgressDialog.EXTENSIONS")); //$NON-NLS-1$
+			ip.updateProgress(110,"ProgressDialog.EXTENSIONS"); //$NON-NLS-1$
 			readExtensions(c,root);
-			LGM.setProgress(120,Messages.getString("ProgressDialog.CONSTANTS")); //$NON-NLS-1$
+			ip.updateProgress(120,"ProgressDialog.CONSTANTS"); //$NON-NLS-1$
 			readDefaultConstants(c,root);
-			LGM.setProgress(130,Messages.getString("ProgressDialog.GAMEINFORMATION")); //$NON-NLS-1$
+			ip.updateProgress(130,"ProgressDialog.GAMEINFORMATION"); //$NON-NLS-1$
 			readGameInformation(c,root);
-			LGM.setProgress(140,Messages.getString("ProgressDialog.SETTINGS")); //$NON-NLS-1$
+			ip.updateProgress(140,"ProgressDialog.SETTINGS"); //$NON-NLS-1$
 			readConfigurations(c,root);
-			LGM.setProgress(150,Messages.getString("ProgressDialog.PACKAGES")); //$NON-NLS-1$
+			ip.updateProgress(150,"ProgressDialog.PACKAGES"); //$NON-NLS-1$
 			readPackages(c,root);
 
-			LGM.setProgress(160,Messages.getString("ProgressDialog.POSTPONED")); //$NON-NLS-1$
+			ip.updateProgress(160,"ProgressDialog.POSTPONED"); //$NON-NLS-1$
 			// All resources read, now we can invoke our postponed references.
 			for (PostponedRef i : postpone)
 				i.invoke();
 			postpone.clear();
 
-			LGM.setProgress(160,Messages.getString("ProgressDialog.FINISHED")); //$NON-NLS-1$
-			System.out.println(Messages.format("ProjectFileReader.LOADTIME",System.currentTimeMillis() //$NON-NLS-1$
-					- startTime));
+			ip.updateProgress(160,"ProgressDialog.FINISHED"); //$NON-NLS-1$
 			}
 		catch (Exception e)
 			{
@@ -327,7 +323,7 @@ public final class GMXFileReader
 				}
 			catch (IOException ex)
 				{
-				String key = Messages.getString("GmFileReader.ERROR_CLOSEFAILED"); //$NON-NLS-1$
+				String key = ip.translate("GmFileReader.ERROR_CLOSEFAILED"); //$NON-NLS-1$
 				throw new GmFormatException(file,key);
 				}
 			}

--- a/org/lateralgm/file/GMXFileReader.java
+++ b/org/lateralgm/file/GMXFileReader.java
@@ -265,46 +265,46 @@ public final class GMXFileReader
 
 			ProjectFileContext c = new ProjectFileContext(file,document,timeids,objids,rmids);
 
-			ip.updateProgress(0,"ProgressDialog.SPRITES"); //$NON-NLS-1$
+			ip.setProgress(0,"ProgressDialog.SPRITES"); //$NON-NLS-1$
 			readGroup(c,root,Sprite.class);
-			ip.updateProgress(10,"ProgressDialog.SOUNDS"); //$NON-NLS-1$
+			ip.setProgress(10,"ProgressDialog.SOUNDS"); //$NON-NLS-1$
 			readGroup(c,root,Sound.class);
-			ip.updateProgress(20,"ProgressDialog.BACKGROUNDS"); //$NON-NLS-1$
+			ip.setProgress(20,"ProgressDialog.BACKGROUNDS"); //$NON-NLS-1$
 			readGroup(c,root,Background.class);
-			ip.updateProgress(30,"ProgressDialog.PATHS"); //$NON-NLS-1$
+			ip.setProgress(30,"ProgressDialog.PATHS"); //$NON-NLS-1$
 			readGroup(c,root,Path.class);
-			ip.updateProgress(40,"ProgressDialog.SCRIPTS"); //$NON-NLS-1$
+			ip.setProgress(40,"ProgressDialog.SCRIPTS"); //$NON-NLS-1$
 			readGroup(c,root,Script.class);
-			ip.updateProgress(50,"ProgressDialog.SHADERS"); //$NON-NLS-1$
+			ip.setProgress(50,"ProgressDialog.SHADERS"); //$NON-NLS-1$
 			readGroup(c,root,Shader.class);
-			ip.updateProgress(60,"ProgressDialog.FONTS"); //$NON-NLS-1$
+			ip.setProgress(60,"ProgressDialog.FONTS"); //$NON-NLS-1$
 			readGroup(c,root,Font.class);
-			ip.updateProgress(70,"ProgressDialog.TIMELINES"); //$NON-NLS-1$
+			ip.setProgress(70,"ProgressDialog.TIMELINES"); //$NON-NLS-1$
 			readGroup(c,root,Timeline.class);
-			ip.updateProgress(80,"ProgressDialog.OBJECTS"); //$NON-NLS-1$
+			ip.setProgress(80,"ProgressDialog.OBJECTS"); //$NON-NLS-1$
 			readGroup(c,root,GmObject.class);
-			ip.updateProgress(90,"ProgressDialog.ROOMS"); //$NON-NLS-1$
+			ip.setProgress(90,"ProgressDialog.ROOMS"); //$NON-NLS-1$
 			readGroup(c,root,Room.class);
-			ip.updateProgress(100,"ProgressDialog.INCLUDEFILES"); //$NON-NLS-1$
+			ip.setProgress(100,"ProgressDialog.INCLUDEFILES"); //$NON-NLS-1$
 			readGroup(c,root,Include.class);
-			ip.updateProgress(110,"ProgressDialog.EXTENSIONS"); //$NON-NLS-1$
+			ip.setProgress(110,"ProgressDialog.EXTENSIONS"); //$NON-NLS-1$
 			readExtensions(c,root);
-			ip.updateProgress(120,"ProgressDialog.CONSTANTS"); //$NON-NLS-1$
+			ip.setProgress(120,"ProgressDialog.CONSTANTS"); //$NON-NLS-1$
 			readDefaultConstants(c,root);
-			ip.updateProgress(130,"ProgressDialog.GAMEINFORMATION"); //$NON-NLS-1$
+			ip.setProgress(130,"ProgressDialog.GAMEINFORMATION"); //$NON-NLS-1$
 			readGameInformation(c,root);
-			ip.updateProgress(140,"ProgressDialog.SETTINGS"); //$NON-NLS-1$
+			ip.setProgress(140,"ProgressDialog.SETTINGS"); //$NON-NLS-1$
 			readConfigurations(c,root);
-			ip.updateProgress(150,"ProgressDialog.PACKAGES"); //$NON-NLS-1$
+			ip.setProgress(150,"ProgressDialog.PACKAGES"); //$NON-NLS-1$
 			readPackages(c,root);
 
-			ip.updateProgress(160,"ProgressDialog.POSTPONED"); //$NON-NLS-1$
+			ip.setProgress(160,"ProgressDialog.POSTPONED"); //$NON-NLS-1$
 			// All resources read, now we can invoke our postponed references.
 			for (PostponedRef i : postpone)
 				i.invoke();
 			postpone.clear();
 
-			ip.updateProgress(160,"ProgressDialog.FINISHED"); //$NON-NLS-1$
+			ip.setProgress(160,"ProgressDialog.FINISHED"); //$NON-NLS-1$
 			}
 		catch (Exception e)
 			{

--- a/org/lateralgm/file/GMXFileWriter.java
+++ b/org/lateralgm/file/GMXFileWriter.java
@@ -211,44 +211,44 @@ public final class GMXFileWriter
 
 		ProjectFileContext c = new ProjectFileContext(f,dom);
 		Element root = dom.createElement("assets"); //$NON-NLS-1$
-		ip.updateProgress(0,"ProgressDialog.SETTINGS"); //$NON-NLS-1$
+		ip.setProgress(0,"ProgressDialog.SETTINGS"); //$NON-NLS-1$
 		writeConfigurations(c,root,savetime);
 
-		ip.updateProgress(10,"ProgressDialog.SPRITES"); //$NON-NLS-1$
+		ip.setProgress(10,"ProgressDialog.SPRITES"); //$NON-NLS-1$
 		writeGroup(c,root,Sprite.class);
-		ip.updateProgress(20,"ProgressDialog.SOUNDS"); //$NON-NLS-1$
+		ip.setProgress(20,"ProgressDialog.SOUNDS"); //$NON-NLS-1$
 		writeGroup(c,root,Sound.class);
-		ip.updateProgress(30,"ProgressDialog.BACKGROUNDS"); //$NON-NLS-1$
+		ip.setProgress(30,"ProgressDialog.BACKGROUNDS"); //$NON-NLS-1$
 		writeGroup(c,root,Background.class);
-		ip.updateProgress(40,"ProgressDialog.PATHS"); //$NON-NLS-1$
+		ip.setProgress(40,"ProgressDialog.PATHS"); //$NON-NLS-1$
 		writeGroup(c,root,Path.class);
-		ip.updateProgress(50,"ProgressDialog.SCRIPTS"); //$NON-NLS-1$
+		ip.setProgress(50,"ProgressDialog.SCRIPTS"); //$NON-NLS-1$
 		writeGroup(c,root,Script.class);
-		ip.updateProgress(60,"ProgressDialog.SHADERS"); //$NON-NLS-1$
+		ip.setProgress(60,"ProgressDialog.SHADERS"); //$NON-NLS-1$
 		writeGroup(c,root,Shader.class);
-		ip.updateProgress(70,"ProgressDialog.FONTS"); //$NON-NLS-1$
+		ip.setProgress(70,"ProgressDialog.FONTS"); //$NON-NLS-1$
 		writeGroup(c,root,Font.class);
-		ip.updateProgress(80,"ProgressDialog.TIMELINES"); //$NON-NLS-1$
+		ip.setProgress(80,"ProgressDialog.TIMELINES"); //$NON-NLS-1$
 		writeGroup(c,root,Timeline.class);
-		ip.updateProgress(90,"ProgressDialog.OBJECTS"); //$NON-NLS-1$
+		ip.setProgress(90,"ProgressDialog.OBJECTS"); //$NON-NLS-1$
 		writeGroup(c,root,GmObject.class);
-		ip.updateProgress(100,"ProgressDialog.ROOMS"); //$NON-NLS-1$
+		ip.setProgress(100,"ProgressDialog.ROOMS"); //$NON-NLS-1$
 		writeGroup(c,root,Room.class);
-		ip.updateProgress(110,"ProgressDialog.INCLUDEFILES"); //$NON-NLS-1$
+		ip.setProgress(110,"ProgressDialog.INCLUDEFILES"); //$NON-NLS-1$
 		writeGroup(c,root,Include.class);
-		ip.updateProgress(120,"ProgressDialog.PACKAGES"); //$NON-NLS-1$
+		ip.setProgress(120,"ProgressDialog.PACKAGES"); //$NON-NLS-1$
 		//writePackages(c, root);
-		ip.updateProgress(130,"ProgressDialog.CONSTANTS"); //$NON-NLS-1$
+		ip.setProgress(130,"ProgressDialog.CONSTANTS"); //$NON-NLS-1$
 		writeDefaultConstants(c, root);
-		ip.updateProgress(140,"ProgressDialog.EXTENSIONS"); //$NON-NLS-1$
+		ip.setProgress(140,"ProgressDialog.EXTENSIONS"); //$NON-NLS-1$
 		//writeExtensions(c, root);
-		ip.updateProgress(150,"ProgressDialog.GAMEINFORMATION"); //$NON-NLS-1$
+		ip.setProgress(150,"ProgressDialog.GAMEINFORMATION"); //$NON-NLS-1$
 		writeGameInformation(c,root);
 
 		dom.appendChild(root);
 
 		// Now take the serialized XML data and format and write it to the actual file
-		ip.updateProgress(150,"ProgressDialog.DOCUMENT"); //$NON-NLS-1$
+		ip.setProgress(150,"ProgressDialog.DOCUMENT"); //$NON-NLS-1$
 		try
 			{
 			// send DOM to file
@@ -263,7 +263,7 @@ public final class GMXFileWriter
 			// close up the stream and release the lock on the file
 			os.close();
 			}
-		ip.updateProgress(160,"ProgressDialog.FINISHED"); //$NON-NLS-1$
+		ip.setProgress(160,"ProgressDialog.FINISHED"); //$NON-NLS-1$
 		}
 
 	private static Element createElement(Document dom, String name, String value)

--- a/org/lateralgm/file/GMXFileWriter.java
+++ b/org/lateralgm/file/GMXFileWriter.java
@@ -43,7 +43,6 @@ import java.util.List;
 import java.util.Vector;
 
 import javax.imageio.ImageIO;
-import javax.swing.JProgressBar;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -57,10 +56,10 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
 import org.lateralgm.components.impl.ResNode;
+import org.lateralgm.file.ProjectFile.InterfaceProvider;
 import org.lateralgm.file.iconio.ICOFile;
 import org.lateralgm.main.LGM;
 import org.lateralgm.main.Util;
-import org.lateralgm.messages.Messages;
 import org.lateralgm.resources.Background;
 import org.lateralgm.resources.Background.PBackground;
 import org.lateralgm.resources.Constants;
@@ -177,6 +176,8 @@ public final class GMXFileWriter
 	public static void writeProjectFile(OutputStream os, ProjectFile f, ResNode rootRes)
 			throws IOException,GmFormatException
 		{
+		InterfaceProvider ip = ProjectFile.interfaceProvider;
+		ip.init(160,"ProgressDialog.GMX_SAVING"); //$NON-NLS-1$
 		f.format = ProjectFile.FormatFlavor.GMX;
 		long savetime = System.currentTimeMillis();
 
@@ -208,50 +209,46 @@ public final class GMXFileWriter
 				}
 		Document dom = documentBuilder.newDocument();
 
-		JProgressBar progressBar = LGM.getProgressDialogBar();
-		progressBar.setMaximum(160);
-		LGM.setProgressTitle(Messages.getString("ProgressDialog.GMX_SAVING")); //$NON-NLS-1$
-
 		ProjectFileContext c = new ProjectFileContext(f,dom);
 		Element root = dom.createElement("assets"); //$NON-NLS-1$
-		LGM.setProgress(0,Messages.getString("ProgressDialog.SETTINGS")); //$NON-NLS-1$
+		ip.updateProgress(0,"ProgressDialog.SETTINGS"); //$NON-NLS-1$
 		writeConfigurations(c,root,savetime);
 
-		LGM.setProgress(10,Messages.getString("ProgressDialog.SPRITES")); //$NON-NLS-1$
+		ip.updateProgress(10,"ProgressDialog.SPRITES"); //$NON-NLS-1$
 		writeGroup(c,root,Sprite.class);
-		LGM.setProgress(20,Messages.getString("ProgressDialog.SOUNDS")); //$NON-NLS-1$
+		ip.updateProgress(20,"ProgressDialog.SOUNDS"); //$NON-NLS-1$
 		writeGroup(c,root,Sound.class);
-		LGM.setProgress(30,Messages.getString("ProgressDialog.BACKGROUNDS")); //$NON-NLS-1$
+		ip.updateProgress(30,"ProgressDialog.BACKGROUNDS"); //$NON-NLS-1$
 		writeGroup(c,root,Background.class);
-		LGM.setProgress(40,Messages.getString("ProgressDialog.PATHS")); //$NON-NLS-1$
+		ip.updateProgress(40,"ProgressDialog.PATHS"); //$NON-NLS-1$
 		writeGroup(c,root,Path.class);
-		LGM.setProgress(50,Messages.getString("ProgressDialog.SCRIPTS")); //$NON-NLS-1$
+		ip.updateProgress(50,"ProgressDialog.SCRIPTS"); //$NON-NLS-1$
 		writeGroup(c,root,Script.class);
-		LGM.setProgress(60,Messages.getString("ProgressDialog.SHADERS")); //$NON-NLS-1$
+		ip.updateProgress(60,"ProgressDialog.SHADERS"); //$NON-NLS-1$
 		writeGroup(c,root,Shader.class);
-		LGM.setProgress(70,Messages.getString("ProgressDialog.FONTS")); //$NON-NLS-1$
+		ip.updateProgress(70,"ProgressDialog.FONTS"); //$NON-NLS-1$
 		writeGroup(c,root,Font.class);
-		LGM.setProgress(80,Messages.getString("ProgressDialog.TIMELINES")); //$NON-NLS-1$
+		ip.updateProgress(80,"ProgressDialog.TIMELINES"); //$NON-NLS-1$
 		writeGroup(c,root,Timeline.class);
-		LGM.setProgress(90,Messages.getString("ProgressDialog.OBJECTS")); //$NON-NLS-1$
+		ip.updateProgress(90,"ProgressDialog.OBJECTS"); //$NON-NLS-1$
 		writeGroup(c,root,GmObject.class);
-		LGM.setProgress(100,Messages.getString("ProgressDialog.ROOMS")); //$NON-NLS-1$
+		ip.updateProgress(100,"ProgressDialog.ROOMS"); //$NON-NLS-1$
 		writeGroup(c,root,Room.class);
-		LGM.setProgress(110,Messages.getString("ProgressDialog.INCLUDEFILES")); //$NON-NLS-1$
+		ip.updateProgress(110,"ProgressDialog.INCLUDEFILES"); //$NON-NLS-1$
 		writeGroup(c,root,Include.class);
-		LGM.setProgress(120,Messages.getString("ProgressDialog.PACKAGES")); //$NON-NLS-1$
+		ip.updateProgress(120,"ProgressDialog.PACKAGES"); //$NON-NLS-1$
 		//writePackages(c, root);
-		LGM.setProgress(130,Messages.getString("ProgressDialog.CONSTANTS")); //$NON-NLS-1$
+		ip.updateProgress(130,"ProgressDialog.CONSTANTS"); //$NON-NLS-1$
 		writeDefaultConstants(c, root);
-		LGM.setProgress(140,Messages.getString("ProgressDialog.EXTENSIONS")); //$NON-NLS-1$
+		ip.updateProgress(140,"ProgressDialog.EXTENSIONS"); //$NON-NLS-1$
 		//writeExtensions(c, root);
-		LGM.setProgress(150,Messages.getString("ProgressDialog.GAMEINFORMATION")); //$NON-NLS-1$
+		ip.updateProgress(150,"ProgressDialog.GAMEINFORMATION"); //$NON-NLS-1$
 		writeGameInformation(c,root);
 
 		dom.appendChild(root);
 
 		// Now take the serialized XML data and format and write it to the actual file
-		LGM.setProgress(150,Messages.getString("ProgressDialog.DOCUMENT")); //$NON-NLS-1$
+		ip.updateProgress(150,"ProgressDialog.DOCUMENT"); //$NON-NLS-1$
 		try
 			{
 			// send DOM to file
@@ -266,7 +263,7 @@ public final class GMXFileWriter
 			// close up the stream and release the lock on the file
 			os.close();
 			}
-		LGM.setProgress(160,Messages.getString("ProgressDialog.FINISHED")); //$NON-NLS-1$
+		ip.updateProgress(160,"ProgressDialog.FINISHED"); //$NON-NLS-1$
 		}
 
 	private static Element createElement(Document dom, String name, String value)

--- a/org/lateralgm/file/GmFileReader.java
+++ b/org/lateralgm/file/GmFileReader.java
@@ -178,7 +178,6 @@ public final class GmFileReader
 		RefList<Room> rmids = new RefList<Room>(Room.class); // room id
 		try
 			{
-			long startTime = System.currentTimeMillis();
 			in = new GmStreamDecoder(stream);
 			ProjectFileContext c = new ProjectFileContext(file,in,timeids,objids,rmids);
 			int identifier = in.read4();
@@ -255,7 +254,8 @@ public final class GmFileReader
 			ip.updateProgress(120,"ProgressDialog.ROOMS"); //$NON-NLS-1$
 			readRooms(c);
 
-			//If the "use as tileset" flag was not part of this version, try to infer it from the backgrounds used in room tiles.
+			//If the "use as tileset" flag was not part of this version,
+			//try to infer it from the backgrounds used in room tiles.
 			if (bgVer <= 400) {
 				for (Room rm : file.resMap.getList(Room.class)) {
 					for (Tile tl : rm.tiles) {
@@ -315,8 +315,6 @@ public final class GmFileReader
 			readTree(c,root,ver);
 
 			ip.updateProgress(200,"ProgressDialog.FINISHED"); //$NON-NLS-1$
-			System.out.println(ip.format("ProjectFileReader.LOADTIME",System.currentTimeMillis() //$NON-NLS-1$
-					- startTime));
 			}
 		catch (Exception e)
 			{

--- a/org/lateralgm/file/GmFileReader.java
+++ b/org/lateralgm/file/GmFileReader.java
@@ -202,7 +202,7 @@ public final class GmFileReader
 
 			GameSettings gs = c.f.gameSettings.get(0);
 
-			ip.updateProgress(0,"ProgressDialog.SETTINGS"); //$NON-NLS-1$
+			ip.setProgress(0,"ProgressDialog.SETTINGS"); //$NON-NLS-1$
 			if (ver == 530) in.skip(4); //reserved 0
 			if (ver == 701)
 				{
@@ -224,32 +224,32 @@ public final class GmFileReader
 
 			if (ver >= 800)
 				{
-				ip.updateProgress(10,"ProgressDialog.TRIGGERS"); //$NON-NLS-1$
+				ip.setProgress(10,"ProgressDialog.TRIGGERS"); //$NON-NLS-1$
 				readTriggers(c);
-				ip.updateProgress(20,"ProgressDialog.CONSTANTS"); //$NON-NLS-1$
+				ip.setProgress(20,"ProgressDialog.CONSTANTS"); //$NON-NLS-1$
 				readConstants(c,gs);
 				}
 
-			ip.updateProgress(30,"ProgressDialog.SOUNDS"); //$NON-NLS-1$
+			ip.setProgress(30,"ProgressDialog.SOUNDS"); //$NON-NLS-1$
 			readSounds(c);
-			ip.updateProgress(40,"ProgressDialog.SPRITES"); //$NON-NLS-1$
+			ip.setProgress(40,"ProgressDialog.SPRITES"); //$NON-NLS-1$
 			readSprites(c);
-			ip.updateProgress(50,"ProgressDialog.BACKGROUNDS"); //$NON-NLS-1$
+			ip.setProgress(50,"ProgressDialog.BACKGROUNDS"); //$NON-NLS-1$
 			int bgVer = readBackgrounds(c);
-			ip.updateProgress(60,"ProgressDialog.PATHS"); //$NON-NLS-1$
+			ip.setProgress(60,"ProgressDialog.PATHS"); //$NON-NLS-1$
 			readPaths(c);
-			ip.updateProgress(70,"ProgressDialog.SCRIPTS"); //$NON-NLS-1$
+			ip.setProgress(70,"ProgressDialog.SCRIPTS"); //$NON-NLS-1$
 			readScripts(c);
-			ip.updateProgress(80,"ProgressDialog.SHADERS"); //$NON-NLS-1$
+			ip.setProgress(80,"ProgressDialog.SHADERS"); //$NON-NLS-1$
 			//TODO: GMK 820 reads shaders first
-			ip.updateProgress(90,"ProgressDialog.FONTS"); //$NON-NLS-1$
+			ip.setProgress(90,"ProgressDialog.FONTS"); //$NON-NLS-1$
 			int rver = in.read4();
 			readFonts(c,rver);
-			ip.updateProgress(100,"ProgressDialog.TIMELINES"); //$NON-NLS-1$
+			ip.setProgress(100,"ProgressDialog.TIMELINES"); //$NON-NLS-1$
 			readTimelines(c);
-			ip.updateProgress(110,"ProgressDialog.OBJECTS"); //$NON-NLS-1$
+			ip.setProgress(110,"ProgressDialog.OBJECTS"); //$NON-NLS-1$
 			readGmObjects(c);
-			ip.updateProgress(120,"ProgressDialog.ROOMS"); //$NON-NLS-1$
+			ip.setProgress(120,"ProgressDialog.ROOMS"); //$NON-NLS-1$
 			readRooms(c);
 
 			//If the "use as tileset" flag was not part of this version,
@@ -270,28 +270,28 @@ public final class GmFileReader
 
 			if (ver >= 700)
 				{
-				ip.updateProgress(130,"ProgressDialog.INCLUDEFILES"); //$NON-NLS-1$
+				ip.setProgress(130,"ProgressDialog.INCLUDEFILES"); //$NON-NLS-1$
 				readIncludedFiles(c);
-				ip.updateProgress(140,"ProgressDialog.PACKAGES"); //$NON-NLS-1$
+				ip.setProgress(140,"ProgressDialog.PACKAGES"); //$NON-NLS-1$
 				readPackages(c);
 				}
 
-			ip.updateProgress(150,"ProgressDialog.GAMEINFORMATION"); //$NON-NLS-1$
+			ip.setProgress(150,"ProgressDialog.GAMEINFORMATION"); //$NON-NLS-1$
 			readGameInformation(c);
 
-			ip.updateProgress(160,"ProgressDialog.POSTPONED"); //$NON-NLS-1$
+			ip.setProgress(160,"ProgressDialog.POSTPONED"); //$NON-NLS-1$
 			//Resources read. Now we can invoke our postpones.
 			int percent = 0;
 			for (PostponedRef i : postpone)
 				{
 				i.invoke();
 				percent += 1;
-				ip.updateProgress(160 + percent / postpone.size(),
+				ip.setProgress(160 + percent / postpone.size(),
 						"ProgressDialog.POSTPONED"); //$NON-NLS-1$
 				}
 			postpone.clear();
 
-			ip.updateProgress(170,"ProgressDialog.LIBRARYCREATION"); //$NON-NLS-1$
+			ip.setProgress(170,"ProgressDialog.LIBRARYCREATION"); //$NON-NLS-1$
 			//Library Creation Code
 			ver = in.read4();
 			if (ver != 500)
@@ -301,7 +301,7 @@ public final class GmFileReader
 			for (int j = 0; j < no; j++)
 				in.skip(in.read4());
 
-			ip.updateProgress(180,"ProgressDialog.ROOMEXECUTION"); //$NON-NLS-1$
+			ip.setProgress(180,"ProgressDialog.ROOMEXECUTION"); //$NON-NLS-1$
 			//Room Execution Order
 			ver = in.read4();
 			if (ver != 500 && ver != 540 && ver != 700)
@@ -309,10 +309,10 @@ public final class GmFileReader
 						ip.translate("ProjectFileReader.AFTERINFO2"),ver)); //$NON-NLS-1$
 			in.skip(in.read4() * 4);
 
-			ip.updateProgress(190,"ProgressDialog.FILETREE"); //$NON-NLS-1$
+			ip.setProgress(190,"ProgressDialog.FILETREE"); //$NON-NLS-1$
 			readTree(c,root,ver);
 
-			ip.updateProgress(200,"ProgressDialog.FINISHED"); //$NON-NLS-1$
+			ip.setProgress(200,"ProgressDialog.FINISHED"); //$NON-NLS-1$
 			}
 		catch (Exception e)
 			{

--- a/org/lateralgm/file/GmFileReader.java
+++ b/org/lateralgm/file/GmFileReader.java
@@ -23,8 +23,6 @@ import java.util.Queue;
 import java.util.Stack;
 import java.util.zip.DataFormatException;
 
-import javax.swing.tree.TreeNode;
-
 import org.lateralgm.components.impl.ResNode;
 import org.lateralgm.file.ProjectFile.InterfaceProvider;
 import org.lateralgm.file.ProjectFile.ResourceHolder;
@@ -1246,7 +1244,7 @@ public final class GmFileReader
 			{
 			// For GameMaker 5 we need to move the "Data Files" folder
 			// to the place of the "Includes" folder in LGM's default tree
-			TreeNode dataFileNode = root.getChildAt(6);
+			ResNode dataFileNode = (ResNode) root.getChildAt(6);
 			if (dataFileNode instanceof ResNode)
 				{
 				incRoot = (ResNode)dataFileNode;

--- a/org/lateralgm/file/GmFileWriter.java
+++ b/org/lateralgm/file/GmFileWriter.java
@@ -21,13 +21,10 @@ import java.nio.charset.Charset;
 import java.util.Enumeration;
 import java.util.List;
 
-import javax.swing.JProgressBar;
-
 import org.lateralgm.components.impl.ResNode;
+import org.lateralgm.file.ProjectFile.InterfaceProvider;
 import org.lateralgm.file.iconio.ICOFile;
-import org.lateralgm.main.LGM;
 import org.lateralgm.main.Util;
-import org.lateralgm.messages.Messages;
 import org.lateralgm.resources.Background;
 import org.lateralgm.resources.Background.PBackground;
 import org.lateralgm.resources.Constants;
@@ -89,17 +86,15 @@ public final class GmFileWriter
 	public static void writeProjectFile(OutputStream os, ProjectFile f, ResNode root, int ver)
 			throws IOException
 		{
+		InterfaceProvider ip = ProjectFile.interfaceProvider;
+		ip.init(200,"ProgressDialog.GMK_SAVING"); //$NON-NLS-1$
 		f.format = ProjectFile.FormatFlavor.getVersionFlavor(ver);
 		long savetime = System.currentTimeMillis();
 		GmStreamEncoder out = new GmStreamEncoder(os);
 
-		JProgressBar progressBar = LGM.getProgressDialogBar();
-		progressBar.setMaximum(200);
-		LGM.setProgressTitle(Messages.getString("ProgressDialog.GMK_SAVING"));
-
 		GameSettings gs = f.gameSettings.get(0);
 
-		LGM.setProgress(0,Messages.getString("ProgressDialog.SETTINGS"));
+		ip.updateProgress(0,"ProgressDialog.SETTINGS");
 		if (ver >= 810)
 			out.setCharset(Charset.forName("UTF-8"));
 		else
@@ -125,29 +120,29 @@ public final class GmFileWriter
 
 		if (ver >= 800)
 			{
-			LGM.setProgress(10,Messages.getString("ProgressDialog.TRIGGERS"));
+			ip.updateProgress(10,"ProgressDialog.TRIGGERS");
 			writeTriggers(f,out,ver,gs);
-			LGM.setProgress(20,Messages.getString("ProgressDialog.CONSTANTS"));
+			ip.updateProgress(20,"ProgressDialog.CONSTANTS");
 			writeConstants(f,out,ver,gs);
 			}
 
-		LGM.setProgress(30,Messages.getString("ProgressDialog.SOUNDS"));
+		ip.updateProgress(30,"ProgressDialog.SOUNDS");
 		writeSounds(f,out,ver,gs);
-		LGM.setProgress(40,Messages.getString("ProgressDialog.SPRITES"));
+		ip.updateProgress(40,"ProgressDialog.SPRITES");
 		writeSprites(f,out,ver,gs);
-		LGM.setProgress(50,Messages.getString("ProgressDialog.BACKGROUNDS"));
+		ip.updateProgress(50,"ProgressDialog.BACKGROUNDS");
 		writeBackgrounds(f,out,ver,gs);
-		LGM.setProgress(60,Messages.getString("ProgressDialog.PATHS"));
+		ip.updateProgress(60,"ProgressDialog.PATHS");
 		writePaths(f,out,ver,gs);
-		LGM.setProgress(70,Messages.getString("ProgressDialog.SCRIPTS"));
+		ip.updateProgress(70,"ProgressDialog.SCRIPTS");
 		writeScripts(f,out,ver,gs);
-		LGM.setProgress(80,Messages.getString("ProgressDialog.FONTS"));
+		ip.updateProgress(80,"ProgressDialog.FONTS");
 		writeFonts(f,out,ver,gs);
-		LGM.setProgress(90,Messages.getString("ProgressDialog.TIMELINES"));
+		ip.updateProgress(90,"ProgressDialog.TIMELINES");
 		writeTimelines(f,out,ver,gs);
-		LGM.setProgress(100,Messages.getString("ProgressDialog.OBJECTS"));
+		ip.updateProgress(100,"ProgressDialog.OBJECTS");
 		writeGmObjects(f,out,ver,gs);
-		LGM.setProgress(110,Messages.getString("ProgressDialog.ROOMS"));
+		ip.updateProgress(110,"ProgressDialog.ROOMS");
 		writeRooms(f,out,ver,gs);
 
 		out.write4(f.lastInstanceId);
@@ -155,29 +150,29 @@ public final class GmFileWriter
 
 		if (ver >= 700)
 			{
-			LGM.setProgress(120,Messages.getString("ProgressDialog.INCLUDEFILES"));
+			ip.updateProgress(120,"ProgressDialog.INCLUDEFILES");
 			writeIncludedFiles(f,out,ver,gs);
-			LGM.setProgress(130,Messages.getString("ProgressDialog.PACKAGES"));
+			ip.updateProgress(130,"ProgressDialog.PACKAGES");
 			writePackages(f,out,ver);
 			}
 
-		LGM.setProgress(140,Messages.getString("ProgressDialog.GAMEINFORMATION"));
+		ip.updateProgress(140,"ProgressDialog.GAMEINFORMATION");
 		writeGameInformation(f,out,ver,gs);
 
-		LGM.setProgress(150,Messages.getString("ProgressDialog.LIBRARYCREATION"));
+		ip.updateProgress(150,"ProgressDialog.LIBRARYCREATION");
 		//Library Creation Code
 		out.write4(500);
 		out.write4(0);
 
-		LGM.setProgress(160,Messages.getString("ProgressDialog.ROOMEXECUTION"));
+		ip.updateProgress(160,"ProgressDialog.ROOMEXECUTION");
 		//Room Execution Order
 		out.write4(ver >= 700 ? 700 : 540);
 		out.write4(0);
 
-		LGM.setProgress(170,Messages.getString("ProgressDialog.FILETREE"));
+		ip.updateProgress(170,"ProgressDialog.FILETREE");
 		writeTree(out,root);
 		out.close();
-		LGM.setProgress(200,Messages.getString("ProgressDialog.FINISHED"));
+		ip.updateProgress(200,"ProgressDialog.FINISHED");
 		}
 
 	public static void writeSettings(ProjectFile f, GmStreamEncoder out, int ver, long savetime, GameSettings g)

--- a/org/lateralgm/file/GmFileWriter.java
+++ b/org/lateralgm/file/GmFileWriter.java
@@ -94,7 +94,7 @@ public final class GmFileWriter
 
 		GameSettings gs = f.gameSettings.get(0);
 
-		ip.updateProgress(0,"ProgressDialog.SETTINGS");
+		ip.setProgress(0,"ProgressDialog.SETTINGS");
 		if (ver >= 810)
 			out.setCharset(Charset.forName("UTF-8"));
 		else
@@ -120,29 +120,29 @@ public final class GmFileWriter
 
 		if (ver >= 800)
 			{
-			ip.updateProgress(10,"ProgressDialog.TRIGGERS");
+			ip.setProgress(10,"ProgressDialog.TRIGGERS");
 			writeTriggers(f,out,ver,gs);
-			ip.updateProgress(20,"ProgressDialog.CONSTANTS");
+			ip.setProgress(20,"ProgressDialog.CONSTANTS");
 			writeConstants(f,out,ver,gs);
 			}
 
-		ip.updateProgress(30,"ProgressDialog.SOUNDS");
+		ip.setProgress(30,"ProgressDialog.SOUNDS");
 		writeSounds(f,out,ver,gs);
-		ip.updateProgress(40,"ProgressDialog.SPRITES");
+		ip.setProgress(40,"ProgressDialog.SPRITES");
 		writeSprites(f,out,ver,gs);
-		ip.updateProgress(50,"ProgressDialog.BACKGROUNDS");
+		ip.setProgress(50,"ProgressDialog.BACKGROUNDS");
 		writeBackgrounds(f,out,ver,gs);
-		ip.updateProgress(60,"ProgressDialog.PATHS");
+		ip.setProgress(60,"ProgressDialog.PATHS");
 		writePaths(f,out,ver,gs);
-		ip.updateProgress(70,"ProgressDialog.SCRIPTS");
+		ip.setProgress(70,"ProgressDialog.SCRIPTS");
 		writeScripts(f,out,ver,gs);
-		ip.updateProgress(80,"ProgressDialog.FONTS");
+		ip.setProgress(80,"ProgressDialog.FONTS");
 		writeFonts(f,out,ver,gs);
-		ip.updateProgress(90,"ProgressDialog.TIMELINES");
+		ip.setProgress(90,"ProgressDialog.TIMELINES");
 		writeTimelines(f,out,ver,gs);
-		ip.updateProgress(100,"ProgressDialog.OBJECTS");
+		ip.setProgress(100,"ProgressDialog.OBJECTS");
 		writeGmObjects(f,out,ver,gs);
-		ip.updateProgress(110,"ProgressDialog.ROOMS");
+		ip.setProgress(110,"ProgressDialog.ROOMS");
 		writeRooms(f,out,ver,gs);
 
 		out.write4(f.lastInstanceId);
@@ -150,29 +150,29 @@ public final class GmFileWriter
 
 		if (ver >= 700)
 			{
-			ip.updateProgress(120,"ProgressDialog.INCLUDEFILES");
+			ip.setProgress(120,"ProgressDialog.INCLUDEFILES");
 			writeIncludedFiles(f,out,ver,gs);
-			ip.updateProgress(130,"ProgressDialog.PACKAGES");
+			ip.setProgress(130,"ProgressDialog.PACKAGES");
 			writePackages(f,out,ver);
 			}
 
-		ip.updateProgress(140,"ProgressDialog.GAMEINFORMATION");
+		ip.setProgress(140,"ProgressDialog.GAMEINFORMATION");
 		writeGameInformation(f,out,ver,gs);
 
-		ip.updateProgress(150,"ProgressDialog.LIBRARYCREATION");
+		ip.setProgress(150,"ProgressDialog.LIBRARYCREATION");
 		//Library Creation Code
 		out.write4(500);
 		out.write4(0);
 
-		ip.updateProgress(160,"ProgressDialog.ROOMEXECUTION");
+		ip.setProgress(160,"ProgressDialog.ROOMEXECUTION");
 		//Room Execution Order
 		out.write4(ver >= 700 ? 700 : 540);
 		out.write4(0);
 
-		ip.updateProgress(170,"ProgressDialog.FILETREE");
+		ip.setProgress(170,"ProgressDialog.FILETREE");
 		writeTree(out,root);
 		out.close();
-		ip.updateProgress(200,"ProgressDialog.FINISHED");
+		ip.setProgress(200,"ProgressDialog.FINISHED");
 		}
 
 	public static void writeSettings(ProjectFile f, GmStreamEncoder out, int ver, long savetime, GameSettings g)

--- a/org/lateralgm/file/ProjectFile.java
+++ b/org/lateralgm/file/ProjectFile.java
@@ -293,7 +293,7 @@ public class ProjectFile implements UpdateListener
 	public static interface InterfaceProvider
 		{
 		public void init(int max, String titleKey);
-		public void updateProgress(int percent, String messageKey);
+		public void setProgress(int percent, String messageKey);
 		public String translate(String key);
 		public String format(String key, Object...arguments);
 		}
@@ -302,7 +302,7 @@ public class ProjectFile implements UpdateListener
 	public static InterfaceProvider interfaceProvider = new InterfaceProvider()
 		{
 		@Override
-		public void updateProgress(int percent, String messageKey) {}
+		public void setProgress(int percent, String messageKey) {}
 		@Override
 		public String translate(String key) { return key; }
 		@Override

--- a/org/lateralgm/file/ProjectFile.java
+++ b/org/lateralgm/file/ProjectFile.java
@@ -286,12 +286,36 @@ public class ProjectFile implements UpdateListener
 			}
 		}
 
+	/* This interface is used by the file readers
+	 * to report progress to the UI or to ask the
+	 * frontend to translate a message.
+	 */
+	public static interface InterfaceProvider
+		{
+			public void init(int max, String titleKey);
+			public void updateProgress(int percent, String messageKey);
+			public String translate(String key);
+			public String format(String key, Object...arguments);
+		}
+
+	// The default interface will just sink the progress of the project loading.
+	public static InterfaceProvider interfaceProvider = new InterfaceProvider()
+		{
+		@Override
+		public void updateProgress(int percent, String messageKey) {}
+		@Override
+		public String translate(String key) { return key; }
+		@Override
+		public String format(String key, Object...arguments) { return key; }
+		@Override
+		public void init(int max, String titleKey) {}
+		};
+
 	public ProjectFile()
 		{
 		resMap = new ResourceMap();
 		for (Class<?> kind : Resource.kinds)
 			if (InstantiableResource.class.isAssignableFrom(kind)) resMap.addList(kind);
-
 
 		// Default initial configuration
 		GameSettings gs = createDefaultConfig();

--- a/org/lateralgm/file/ProjectFile.java
+++ b/org/lateralgm/file/ProjectFile.java
@@ -292,10 +292,10 @@ public class ProjectFile implements UpdateListener
 	 */
 	public static interface InterfaceProvider
 		{
-			public void init(int max, String titleKey);
-			public void updateProgress(int percent, String messageKey);
-			public String translate(String key);
-			public String format(String key, Object...arguments);
+		public void init(int max, String titleKey);
+		public void updateProgress(int percent, String messageKey);
+		public String translate(String key);
+		public String format(String key, Object...arguments);
 		}
 
 	// The default interface will just sink the progress of the project loading.

--- a/org/lateralgm/file/ProjectFile.java
+++ b/org/lateralgm/file/ProjectFile.java
@@ -286,9 +286,8 @@ public class ProjectFile implements UpdateListener
 			}
 		}
 
-	/* This interface is used by the file readers
-	 * to report progress to the UI or to ask the
-	 * frontend to translate a message.
+	/* This interface is used by the file readers to report progress to the UI
+	 * or to ask the frontend to translate a message.
 	 */
 	public static interface InterfaceProvider
 		{

--- a/org/lateralgm/main/FileChooser.java
+++ b/org/lateralgm/main/FileChooser.java
@@ -91,7 +91,7 @@ public class FileChooser
 		ProjectFile.interfaceProvider = new ProjectFile.InterfaceProvider()
 			{
 			@Override
-			public void updateProgress(int percent, String messageKey)
+			public void setProgress(int percent, String messageKey)
 				{
 				LGM.setProgress(percent,Messages.getString(messageKey));
 				}

--- a/org/lateralgm/main/FileChooser.java
+++ b/org/lateralgm/main/FileChooser.java
@@ -677,7 +677,11 @@ public class FileChooser
 						{
 						ProjectFile f =  new ProjectFile();
 						f.uri = uri;
+						long startTime = System.currentTimeMillis();
 						reader.read(uri.toURL().openStream(),f,uri,LGM.newRoot());
+						long delta = System.currentTimeMillis() - startTime;
+						System.out.println(ProjectFile.interfaceProvider.format(
+								"ProjectFileReader.LOADTIME",delta)); //$NON-NLS-1$
 						LGM.currentFile = f;
 						}
 					catch (ProjectFormatException ex)

--- a/org/lateralgm/main/FileChooser.java
+++ b/org/lateralgm/main/FileChooser.java
@@ -85,6 +85,38 @@ public class FileChooser
 	FilterSet openFs = new FilterSet(), saveFs = new FilterSet();
 	FilterUnion openAllFilter = new FilterUnion(), saveAllFilter = new FilterUnion();
 
+	static
+		{
+		// Replace the default project UI provider with one coupled to Swing.
+		ProjectFile.interfaceProvider = new ProjectFile.InterfaceProvider()
+			{
+			@Override
+			public void updateProgress(int percent, String messageKey)
+				{
+				LGM.setProgress(percent,Messages.getString(messageKey));
+				}
+		
+			@Override
+			public String translate(String key)
+				{
+				return Messages.getString(key);
+				}
+		
+			@Override
+			public String format(String key, Object...arguments)
+				{
+				return Messages.format(key,arguments);
+				}
+		
+			@Override
+			public void init(int max, String titleKey)
+				{
+				LGM.getProgressDialogBar().setMaximum(max);
+				LGM.setProgressTitle(translate(titleKey));
+				}
+			};
+		}
+	
 	public static void addDefaultReadersAndWriters()
 		{
 		if (gmxIO == null)
@@ -625,7 +657,7 @@ public class FileChooser
 		ErrorDialog.getInstance().setMessage(Messages.getString("FileChooser.ERROR_LOAD")); //$NON-NLS-1$
 		ErrorDialog.getInstance().setTitle(Messages.getString("FileChooser.ERROR_LOAD_TITLE")); //$NON-NLS-1$
 		}
-	
+
 	/**
 	 * Both open() methods are not headless. For a headless open:
 	 * <code>findReader(uri).read(uriStream,uri,root)</code>
@@ -633,7 +665,9 @@ public class FileChooser
 	public void open(final URI uri, final FileReader reader)
 		{
 		if (uri == null) return;
+
 		LGM.getProgressDialog().setVisible(false);
+
 		Thread t = new Thread(new Runnable()
 			{
 				public void run()

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -133,7 +133,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.110"; //$NON-NLS-1$
+	public static final String version = "1.8.111"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.


### PR DESCRIPTION
* You people have got a LOT to learn about component and interface coupling!
* Add a new `ProjectFile.InterfaceProvider` Java interface to service UI/UX needs of readers & writers.
* Create a default `ProjectFile.interfaceProvider` used by the readers which can be overwritten.
* Have `FileChooser` replace the default interface provider with one that uses LGM & Swing to show the progress.
* Move the loading time benchmark to `FileChooser` and out of the GMK reader.
* Update the GMK reader to use interface provider and remove all Swing/LGM direct dependency.
* Decouple the GMK writer.
* Decouple the GMX reader.
* Decouple the GMX writer.