### PR TITLE
Decouple GMX from LGM Main Class

### DIFF
--- a/org/lateralgm/file/GMXFileReader.java
+++ b/org/lateralgm/file/GMXFileReader.java
@@ -189,7 +189,7 @@ public final class GMXFileReader
 				}
 			catch (GmFormatException e)
 				{
-				interfaceProvider.handleRecoverableException(e);
+				interfaceProvider.handleException(e);
 				}
 			return doc;
 		}
@@ -523,7 +523,7 @@ public final class GMXFileReader
 					}
 				catch (IOException e)
 					{
-					interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "failed to read: " + icopath, e));
+					interfaceProvider.handleException(new GmFormatException(c.f, "failed to read: " + icopath, e));
 					}
 				pSet.put(PGameSettings.GAME_ID,
 						Integer.parseInt(setdoc.getElementsByTagName("option_gameid").item(0).getTextContent())); //$NON-NLS-1$
@@ -664,7 +664,7 @@ public final class GMXFileReader
 					}
 				catch (IOException e)
 					{
-					interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "failed to read: " + imgfile.getAbsolutePath(), e));
+					interfaceProvider.handleException(new GmFormatException(c.f, "failed to read: " + imgfile.getAbsolutePath(), e));
 					}
 				}
 			}
@@ -725,7 +725,7 @@ public final class GMXFileReader
 				}
 			catch (IOException e)
 				{
-				interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "failed to read: " + fname, e));
+				interfaceProvider.handleException(new GmFormatException(c.f, "failed to read: " + fname, e));
 				}
 			}
 		}
@@ -785,7 +785,7 @@ public final class GMXFileReader
 				}
 			catch (IOException e)
 				{
-				interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "failed to read: " + imgfile.getAbsolutePath(), e));
+				interfaceProvider.handleException(new GmFormatException(c.f, "failed to read: " + imgfile.getAbsolutePath(), e));
 				}
 			}
 		}
@@ -895,11 +895,11 @@ public final class GMXFileReader
 			}
 		catch (FileNotFoundException e)
 			{
-			interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "file not found: " + path, e));
+			interfaceProvider.handleException(new GmFormatException(c.f, "file not found: " + path, e));
 			}
 		catch (IOException e)
 			{
-			interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "unable to read file: " + path, e));
+			interfaceProvider.handleException(new GmFormatException(c.f, "unable to read file: " + path, e));
 			}
 		}
 
@@ -926,11 +926,11 @@ public final class GMXFileReader
 			}
 		catch (FileNotFoundException e)
 			{
-			interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "file not found: " + path, e));
+			interfaceProvider.handleException(new GmFormatException(c.f, "file not found: " + path, e));
 			}
 		catch (IOException e)
 			{
-			interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "unable to read file: " + path, e));
+			interfaceProvider.handleException(new GmFormatException(c.f, "unable to read file: " + path, e));
 			}
 
 		String[] splitcode = code.split(STUPID_SHADER_MARKER);
@@ -1624,7 +1624,7 @@ public final class GMXFileReader
 			}
 		catch (IOException e)
 			{
-			interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "failed to read: " + dataFile.getAbsolutePath(), e));
+			interfaceProvider.handleException(new GmFormatException(c.f, "failed to read: " + dataFile.getAbsolutePath(), e));
 			}
 		}
 
@@ -1711,11 +1711,11 @@ public final class GMXFileReader
 			}
 		catch (FileNotFoundException e)
 			{
-			interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "file not found: " + path, e));
+			interfaceProvider.handleException(new GmFormatException(c.f, "file not found: " + path, e));
 			}
 		catch (IOException e)
 			{
-			interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "unable to read file: " + path, e));
+			interfaceProvider.handleException(new GmFormatException(c.f, "unable to read file: " + path, e));
 			}
 
 		gameInfo.put(PGameInformation.TEXT,text);

--- a/org/lateralgm/file/GMXFileReader.java
+++ b/org/lateralgm/file/GMXFileReader.java
@@ -23,6 +23,8 @@
 
 package org.lateralgm.file;
 
+import static org.lateralgm.file.ProjectFile.interfaceProvider;
+
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Point;
@@ -187,7 +189,7 @@ public final class GMXFileReader
 				}
 			catch (GmFormatException e)
 				{
-				ProjectFile.interfaceProvider.handleRecoverableException(e);
+				interfaceProvider.handleRecoverableException(e);
 				}
 			return doc;
 		}
@@ -225,7 +227,7 @@ public final class GMXFileReader
 	private static GmFormatException versionError(ProjectFile f, String error, String res, int i,
 			int ver)
 		{
-		InterfaceProvider ip = ProjectFile.interfaceProvider;
+		InterfaceProvider ip = interfaceProvider;
 		return new GmFormatException(f,ip.format(
 				"ProjectFileReader.ERROR_UNSUPPORTED",ip.format( //$NON-NLS-1$
 						"ProjectFileReader." + error,ip.translate("LGM." + res),i),ver)); //$NON-NLS-1$  //$NON-NLS-2$
@@ -240,8 +242,7 @@ public final class GMXFileReader
 	public static void readProjectFile(InputStream stream, ProjectFile file, URI uri, ResNode root,
 			Charset forceCharset) throws GmFormatException
 		{
-		InterfaceProvider ip = ProjectFile.interfaceProvider;
-		ip.init(160,"ProgressDialog.GMX_LOADING"); //$NON-NLS-1$
+		interfaceProvider.init(160,"ProgressDialog.GMX_LOADING"); //$NON-NLS-1$
 		file.format = ProjectFile.FormatFlavor.GMX;
 		if (documentBuilderFactory == null)
 			documentBuilderFactory = DocumentBuilderFactory.newInstance();
@@ -264,46 +265,46 @@ public final class GMXFileReader
 
 			ProjectFileContext c = new ProjectFileContext(file,document,timeids,objids,rmids);
 
-			ip.setProgress(0,"ProgressDialog.SPRITES"); //$NON-NLS-1$
+			interfaceProvider.setProgress(0,"ProgressDialog.SPRITES"); //$NON-NLS-1$
 			readGroup(c,root,Sprite.class);
-			ip.setProgress(10,"ProgressDialog.SOUNDS"); //$NON-NLS-1$
+			interfaceProvider.setProgress(10,"ProgressDialog.SOUNDS"); //$NON-NLS-1$
 			readGroup(c,root,Sound.class);
-			ip.setProgress(20,"ProgressDialog.BACKGROUNDS"); //$NON-NLS-1$
+			interfaceProvider.setProgress(20,"ProgressDialog.BACKGROUNDS"); //$NON-NLS-1$
 			readGroup(c,root,Background.class);
-			ip.setProgress(30,"ProgressDialog.PATHS"); //$NON-NLS-1$
+			interfaceProvider.setProgress(30,"ProgressDialog.PATHS"); //$NON-NLS-1$
 			readGroup(c,root,Path.class);
-			ip.setProgress(40,"ProgressDialog.SCRIPTS"); //$NON-NLS-1$
+			interfaceProvider.setProgress(40,"ProgressDialog.SCRIPTS"); //$NON-NLS-1$
 			readGroup(c,root,Script.class);
-			ip.setProgress(50,"ProgressDialog.SHADERS"); //$NON-NLS-1$
+			interfaceProvider.setProgress(50,"ProgressDialog.SHADERS"); //$NON-NLS-1$
 			readGroup(c,root,Shader.class);
-			ip.setProgress(60,"ProgressDialog.FONTS"); //$NON-NLS-1$
+			interfaceProvider.setProgress(60,"ProgressDialog.FONTS"); //$NON-NLS-1$
 			readGroup(c,root,Font.class);
-			ip.setProgress(70,"ProgressDialog.TIMELINES"); //$NON-NLS-1$
+			interfaceProvider.setProgress(70,"ProgressDialog.TIMELINES"); //$NON-NLS-1$
 			readGroup(c,root,Timeline.class);
-			ip.setProgress(80,"ProgressDialog.OBJECTS"); //$NON-NLS-1$
+			interfaceProvider.setProgress(80,"ProgressDialog.OBJECTS"); //$NON-NLS-1$
 			readGroup(c,root,GmObject.class);
-			ip.setProgress(90,"ProgressDialog.ROOMS"); //$NON-NLS-1$
+			interfaceProvider.setProgress(90,"ProgressDialog.ROOMS"); //$NON-NLS-1$
 			readGroup(c,root,Room.class);
-			ip.setProgress(100,"ProgressDialog.INCLUDEFILES"); //$NON-NLS-1$
+			interfaceProvider.setProgress(100,"ProgressDialog.INCLUDEFILES"); //$NON-NLS-1$
 			readGroup(c,root,Include.class);
-			ip.setProgress(110,"ProgressDialog.EXTENSIONS"); //$NON-NLS-1$
+			interfaceProvider.setProgress(110,"ProgressDialog.EXTENSIONS"); //$NON-NLS-1$
 			readExtensions(c,root);
-			ip.setProgress(120,"ProgressDialog.CONSTANTS"); //$NON-NLS-1$
+			interfaceProvider.setProgress(120,"ProgressDialog.CONSTANTS"); //$NON-NLS-1$
 			readDefaultConstants(c,root);
-			ip.setProgress(130,"ProgressDialog.GAMEINFORMATION"); //$NON-NLS-1$
+			interfaceProvider.setProgress(130,"ProgressDialog.GAMEINFORMATION"); //$NON-NLS-1$
 			readGameInformation(c,root);
-			ip.setProgress(140,"ProgressDialog.SETTINGS"); //$NON-NLS-1$
+			interfaceProvider.setProgress(140,"ProgressDialog.SETTINGS"); //$NON-NLS-1$
 			readConfigurations(c,root);
-			ip.setProgress(150,"ProgressDialog.PACKAGES"); //$NON-NLS-1$
+			interfaceProvider.setProgress(150,"ProgressDialog.PACKAGES"); //$NON-NLS-1$
 			readPackages(c,root);
 
-			ip.setProgress(160,"ProgressDialog.POSTPONED"); //$NON-NLS-1$
+			interfaceProvider.setProgress(160,"ProgressDialog.POSTPONED"); //$NON-NLS-1$
 			// All resources read, now we can invoke our postponed references.
 			for (PostponedRef i : postpone)
 				i.invoke();
 			postpone.clear();
 
-			ip.setProgress(160,"ProgressDialog.FINISHED"); //$NON-NLS-1$
+			interfaceProvider.setProgress(160,"ProgressDialog.FINISHED"); //$NON-NLS-1$
 			}
 		catch (Exception e)
 			{
@@ -322,7 +323,7 @@ public final class GMXFileReader
 				}
 			catch (IOException ex)
 				{
-				String key = ip.translate("GmFileReader.ERROR_CLOSEFAILED"); //$NON-NLS-1$
+				String key = interfaceProvider.translate("GmFileReader.ERROR_CLOSEFAILED"); //$NON-NLS-1$
 				throw new GmFormatException(file,key);
 				}
 			}
@@ -522,7 +523,7 @@ public final class GMXFileReader
 					}
 				catch (IOException e)
 					{
-					ProjectFile.interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "failed to read: " + icopath, e));
+					interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "failed to read: " + icopath, e));
 					}
 				pSet.put(PGameSettings.GAME_ID,
 						Integer.parseInt(setdoc.getElementsByTagName("option_gameid").item(0).getTextContent())); //$NON-NLS-1$
@@ -663,7 +664,7 @@ public final class GMXFileReader
 					}
 				catch (IOException e)
 					{
-					ProjectFile.interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "failed to read: " + imgfile.getAbsolutePath(), e));
+					interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "failed to read: " + imgfile.getAbsolutePath(), e));
 					}
 				}
 			}
@@ -724,7 +725,7 @@ public final class GMXFileReader
 				}
 			catch (IOException e)
 				{
-				ProjectFile.interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "failed to read: " + fname, e));
+				interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "failed to read: " + fname, e));
 				}
 			}
 		}
@@ -784,7 +785,7 @@ public final class GMXFileReader
 				}
 			catch (IOException e)
 				{
-				ProjectFile.interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "failed to read: " + imgfile.getAbsolutePath(), e));
+				interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "failed to read: " + imgfile.getAbsolutePath(), e));
 				}
 			}
 		}
@@ -894,11 +895,11 @@ public final class GMXFileReader
 			}
 		catch (FileNotFoundException e)
 			{
-			ProjectFile.interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "file not found: " + path, e));
+			interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "file not found: " + path, e));
 			}
 		catch (IOException e)
 			{
-			ProjectFile.interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "unable to read file: " + path, e));
+			interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "unable to read file: " + path, e));
 			}
 		}
 
@@ -925,11 +926,11 @@ public final class GMXFileReader
 			}
 		catch (FileNotFoundException e)
 			{
-			ProjectFile.interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "file not found: " + path, e));
+			interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "file not found: " + path, e));
 			}
 		catch (IOException e)
 			{
-			ProjectFile.interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "unable to read file: " + path, e));
+			interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "unable to read file: " + path, e));
 			}
 
 		String[] splitcode = code.split(STUPID_SHADER_MARKER);
@@ -1623,7 +1624,7 @@ public final class GMXFileReader
 			}
 		catch (IOException e)
 			{
-			ProjectFile.interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "failed to read: " + dataFile.getAbsolutePath(), e));
+			interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "failed to read: " + dataFile.getAbsolutePath(), e));
 			}
 		}
 
@@ -1710,11 +1711,11 @@ public final class GMXFileReader
 			}
 		catch (FileNotFoundException e)
 			{
-			ProjectFile.interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "file not found: " + path, e));
+			interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "file not found: " + path, e));
 			}
 		catch (IOException e)
 			{
-			ProjectFile.interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "unable to read file: " + path, e));
+			interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "unable to read file: " + path, e));
 			}
 
 		gameInfo.put(PGameInformation.TEXT,text);

--- a/org/lateralgm/file/GMXFileReader.java
+++ b/org/lateralgm/file/GMXFileReader.java
@@ -51,7 +51,6 @@ import org.lateralgm.components.impl.ResNode;
 import org.lateralgm.file.ProjectFile.InterfaceProvider;
 import org.lateralgm.file.ProjectFile.ResourceHolder;
 import org.lateralgm.file.iconio.ICOFile;
-import org.lateralgm.main.LGM;
 import org.lateralgm.main.Util;
 import org.lateralgm.resources.Background;
 import org.lateralgm.resources.Background.PBackground;
@@ -188,7 +187,7 @@ public final class GMXFileReader
 				}
 			catch (GmFormatException e)
 				{
-				LGM.showDefaultExceptionHandler(e);
+				ProjectFile.interfaceProvider.handleRecoverableException(e);
 				}
 			return doc;
 		}
@@ -523,7 +522,7 @@ public final class GMXFileReader
 					}
 				catch (IOException e)
 					{
-					LGM.showDefaultExceptionHandler(new GmFormatException(c.f, "failed to read: " + icopath, e));
+					ProjectFile.interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "failed to read: " + icopath, e));
 					}
 				pSet.put(PGameSettings.GAME_ID,
 						Integer.parseInt(setdoc.getElementsByTagName("option_gameid").item(0).getTextContent())); //$NON-NLS-1$
@@ -664,7 +663,7 @@ public final class GMXFileReader
 					}
 				catch (IOException e)
 					{
-					LGM.showDefaultExceptionHandler(new GmFormatException(c.f, "failed to read: " + imgfile.getAbsolutePath(), e));
+					ProjectFile.interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "failed to read: " + imgfile.getAbsolutePath(), e));
 					}
 				}
 			}
@@ -725,7 +724,7 @@ public final class GMXFileReader
 				}
 			catch (IOException e)
 				{
-				LGM.showDefaultExceptionHandler(new GmFormatException(c.f, "failed to read: " + fname, e));
+				ProjectFile.interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "failed to read: " + fname, e));
 				}
 			}
 		}
@@ -785,7 +784,7 @@ public final class GMXFileReader
 				}
 			catch (IOException e)
 				{
-				LGM.showDefaultExceptionHandler(new GmFormatException(c.f, "failed to read: " + imgfile.getAbsolutePath(), e));
+				ProjectFile.interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "failed to read: " + imgfile.getAbsolutePath(), e));
 				}
 			}
 		}
@@ -895,11 +894,11 @@ public final class GMXFileReader
 			}
 		catch (FileNotFoundException e)
 			{
-			LGM.showDefaultExceptionHandler(new GmFormatException(c.f, "file not found: " + path, e));
+			ProjectFile.interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "file not found: " + path, e));
 			}
 		catch (IOException e)
 			{
-			LGM.showDefaultExceptionHandler(new GmFormatException(c.f, "unable to read file: " + path, e));
+			ProjectFile.interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "unable to read file: " + path, e));
 			}
 		}
 
@@ -926,11 +925,11 @@ public final class GMXFileReader
 			}
 		catch (FileNotFoundException e)
 			{
-			LGM.showDefaultExceptionHandler(new GmFormatException(c.f, "file not found: " + path, e));
+			ProjectFile.interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "file not found: " + path, e));
 			}
 		catch (IOException e)
 			{
-			LGM.showDefaultExceptionHandler(new GmFormatException(c.f, "unable to read file: " + path, e));
+			ProjectFile.interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "unable to read file: " + path, e));
 			}
 
 		String[] splitcode = code.split(STUPID_SHADER_MARKER);
@@ -1624,7 +1623,7 @@ public final class GMXFileReader
 			}
 		catch (IOException e)
 			{
-			LGM.showDefaultExceptionHandler(new GmFormatException(c.f, "failed to read: " + dataFile.getAbsolutePath(), e));
+			ProjectFile.interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "failed to read: " + dataFile.getAbsolutePath(), e));
 			}
 		}
 
@@ -1711,11 +1710,11 @@ public final class GMXFileReader
 			}
 		catch (FileNotFoundException e)
 			{
-			LGM.showDefaultExceptionHandler(new GmFormatException(c.f, "file not found: " + path, e));
+			ProjectFile.interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "file not found: " + path, e));
 			}
 		catch (IOException e)
 			{
-			LGM.showDefaultExceptionHandler(new GmFormatException(c.f, "unable to read file: " + path, e));
+			ProjectFile.interfaceProvider.handleRecoverableException(new GmFormatException(c.f, "unable to read file: " + path, e));
 			}
 
 		gameInfo.put(PGameInformation.TEXT,text);

--- a/org/lateralgm/file/GMXFileWriter.java
+++ b/org/lateralgm/file/GMXFileWriter.java
@@ -58,7 +58,6 @@ import javax.xml.transform.stream.StreamResult;
 import org.lateralgm.components.impl.ResNode;
 import org.lateralgm.file.ProjectFile.InterfaceProvider;
 import org.lateralgm.file.iconio.ICOFile;
-import org.lateralgm.main.LGM;
 import org.lateralgm.main.Util;
 import org.lateralgm.resources.Background;
 import org.lateralgm.resources.Background.PBackground;
@@ -294,7 +293,7 @@ public final class GMXFileWriter
 			}
 		catch (GmFormatException e)
 			{
-			LGM.showDefaultExceptionHandler(e);
+			ProjectFile.interfaceProvider.handleRecoverableException(e);
 			}
 		}
 

--- a/org/lateralgm/file/GMXFileWriter.java
+++ b/org/lateralgm/file/GMXFileWriter.java
@@ -292,7 +292,7 @@ public final class GMXFileWriter
 			}
 		catch (GmFormatException e)
 			{
-			interfaceProvider.handleRecoverableException(e);
+			interfaceProvider.handleException(e);
 			}
 		}
 

--- a/org/lateralgm/file/GMXFileWriter.java
+++ b/org/lateralgm/file/GMXFileWriter.java
@@ -24,6 +24,7 @@
 package org.lateralgm.file;
 
 import static org.lateralgm.main.Util.deRef;
+import static org.lateralgm.file.ProjectFile.interfaceProvider;
 
 import java.awt.Color;
 import java.awt.geom.Point2D;
@@ -56,7 +57,6 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
 import org.lateralgm.components.impl.ResNode;
-import org.lateralgm.file.ProjectFile.InterfaceProvider;
 import org.lateralgm.file.iconio.ICOFile;
 import org.lateralgm.main.Util;
 import org.lateralgm.resources.Background;
@@ -175,8 +175,7 @@ public final class GMXFileWriter
 	public static void writeProjectFile(OutputStream os, ProjectFile f, ResNode rootRes)
 			throws IOException,GmFormatException
 		{
-		InterfaceProvider ip = ProjectFile.interfaceProvider;
-		ip.init(160,"ProgressDialog.GMX_SAVING"); //$NON-NLS-1$
+		interfaceProvider.init(160,"ProgressDialog.GMX_SAVING"); //$NON-NLS-1$
 		f.format = ProjectFile.FormatFlavor.GMX;
 		long savetime = System.currentTimeMillis();
 
@@ -210,44 +209,44 @@ public final class GMXFileWriter
 
 		ProjectFileContext c = new ProjectFileContext(f,dom);
 		Element root = dom.createElement("assets"); //$NON-NLS-1$
-		ip.setProgress(0,"ProgressDialog.SETTINGS"); //$NON-NLS-1$
+		interfaceProvider.setProgress(0,"ProgressDialog.SETTINGS"); //$NON-NLS-1$
 		writeConfigurations(c,root,savetime);
 
-		ip.setProgress(10,"ProgressDialog.SPRITES"); //$NON-NLS-1$
+		interfaceProvider.setProgress(10,"ProgressDialog.SPRITES"); //$NON-NLS-1$
 		writeGroup(c,root,Sprite.class);
-		ip.setProgress(20,"ProgressDialog.SOUNDS"); //$NON-NLS-1$
+		interfaceProvider.setProgress(20,"ProgressDialog.SOUNDS"); //$NON-NLS-1$
 		writeGroup(c,root,Sound.class);
-		ip.setProgress(30,"ProgressDialog.BACKGROUNDS"); //$NON-NLS-1$
+		interfaceProvider.setProgress(30,"ProgressDialog.BACKGROUNDS"); //$NON-NLS-1$
 		writeGroup(c,root,Background.class);
-		ip.setProgress(40,"ProgressDialog.PATHS"); //$NON-NLS-1$
+		interfaceProvider.setProgress(40,"ProgressDialog.PATHS"); //$NON-NLS-1$
 		writeGroup(c,root,Path.class);
-		ip.setProgress(50,"ProgressDialog.SCRIPTS"); //$NON-NLS-1$
+		interfaceProvider.setProgress(50,"ProgressDialog.SCRIPTS"); //$NON-NLS-1$
 		writeGroup(c,root,Script.class);
-		ip.setProgress(60,"ProgressDialog.SHADERS"); //$NON-NLS-1$
+		interfaceProvider.setProgress(60,"ProgressDialog.SHADERS"); //$NON-NLS-1$
 		writeGroup(c,root,Shader.class);
-		ip.setProgress(70,"ProgressDialog.FONTS"); //$NON-NLS-1$
+		interfaceProvider.setProgress(70,"ProgressDialog.FONTS"); //$NON-NLS-1$
 		writeGroup(c,root,Font.class);
-		ip.setProgress(80,"ProgressDialog.TIMELINES"); //$NON-NLS-1$
+		interfaceProvider.setProgress(80,"ProgressDialog.TIMELINES"); //$NON-NLS-1$
 		writeGroup(c,root,Timeline.class);
-		ip.setProgress(90,"ProgressDialog.OBJECTS"); //$NON-NLS-1$
+		interfaceProvider.setProgress(90,"ProgressDialog.OBJECTS"); //$NON-NLS-1$
 		writeGroup(c,root,GmObject.class);
-		ip.setProgress(100,"ProgressDialog.ROOMS"); //$NON-NLS-1$
+		interfaceProvider.setProgress(100,"ProgressDialog.ROOMS"); //$NON-NLS-1$
 		writeGroup(c,root,Room.class);
-		ip.setProgress(110,"ProgressDialog.INCLUDEFILES"); //$NON-NLS-1$
+		interfaceProvider.setProgress(110,"ProgressDialog.INCLUDEFILES"); //$NON-NLS-1$
 		writeGroup(c,root,Include.class);
-		ip.setProgress(120,"ProgressDialog.PACKAGES"); //$NON-NLS-1$
+		interfaceProvider.setProgress(120,"ProgressDialog.PACKAGES"); //$NON-NLS-1$
 		//writePackages(c, root);
-		ip.setProgress(130,"ProgressDialog.CONSTANTS"); //$NON-NLS-1$
+		interfaceProvider.setProgress(130,"ProgressDialog.CONSTANTS"); //$NON-NLS-1$
 		writeDefaultConstants(c, root);
-		ip.setProgress(140,"ProgressDialog.EXTENSIONS"); //$NON-NLS-1$
+		interfaceProvider.setProgress(140,"ProgressDialog.EXTENSIONS"); //$NON-NLS-1$
 		//writeExtensions(c, root);
-		ip.setProgress(150,"ProgressDialog.GAMEINFORMATION"); //$NON-NLS-1$
+		interfaceProvider.setProgress(150,"ProgressDialog.GAMEINFORMATION"); //$NON-NLS-1$
 		writeGameInformation(c,root);
 
 		dom.appendChild(root);
 
 		// Now take the serialized XML data and format and write it to the actual file
-		ip.setProgress(150,"ProgressDialog.DOCUMENT"); //$NON-NLS-1$
+		interfaceProvider.setProgress(150,"ProgressDialog.DOCUMENT"); //$NON-NLS-1$
 		try
 			{
 			// send DOM to file
@@ -262,7 +261,7 @@ public final class GMXFileWriter
 			// close up the stream and release the lock on the file
 			os.close();
 			}
-		ip.setProgress(160,"ProgressDialog.FINISHED"); //$NON-NLS-1$
+		interfaceProvider.setProgress(160,"ProgressDialog.FINISHED"); //$NON-NLS-1$
 		}
 
 	private static Element createElement(Document dom, String name, String value)
@@ -293,7 +292,7 @@ public final class GMXFileWriter
 			}
 		catch (GmFormatException e)
 			{
-			ProjectFile.interfaceProvider.handleRecoverableException(e);
+			interfaceProvider.handleRecoverableException(e);
 			}
 		}
 

--- a/org/lateralgm/file/GmFileReader.java
+++ b/org/lateralgm/file/GmFileReader.java
@@ -11,6 +11,8 @@
 
 package org.lateralgm.file;
 
+import static org.lateralgm.file.ProjectFile.interfaceProvider;
+
 import java.awt.Dimension;
 import java.awt.Point;
 import java.io.File;
@@ -168,8 +170,7 @@ public final class GmFileReader
 	public static void readProjectFile(InputStream stream, ProjectFile file, URI uri, ResNode root,
 			Charset forceCharset) throws GmFormatException
 		{
-		InterfaceProvider ip = ProjectFile.interfaceProvider;
-		ip.init(200,"ProgressDialog.GMK_LOADING"); //$NON-NLS-1$
+		interfaceProvider.init(200,"ProgressDialog.GMK_LOADING"); //$NON-NLS-1$
 		GmStreamDecoder in = null;
 		RefList<Timeline> timeids = new RefList<Timeline>(Timeline.class); // timeline ids
 		RefList<GmObject> objids = new RefList<GmObject>(GmObject.class); // object ids
@@ -180,13 +181,14 @@ public final class GmFileReader
 			ProjectFileContext c = new ProjectFileContext(file,in,timeids,objids,rmids);
 			int identifier = in.read4();
 			if (identifier != 1234321)
-				throw new GmFormatException(file,ip.format("ProjectFileReader.ERROR_INVALID",uri, //$NON-NLS-1$
-						identifier));
+				throw new GmFormatException(file,
+						interfaceProvider.format("ProjectFileReader.ERROR_INVALID", //$NON-NLS-1$
+						uri,identifier));
 			int ver = in.read4();
 			file.format = ProjectFile.FormatFlavor.getVersionFlavor(ver);
 			if (ver != 530 && ver != 600 && ver != 701 && ver != 800 && ver != 810)
 				{
-				String msg = ip.format("ProjectFileReader.ERROR_UNSUPPORTED",uri,ver); //$NON-NLS-1$
+				String msg = interfaceProvider.format("ProjectFileReader.ERROR_UNSUPPORTED",uri,ver); //$NON-NLS-1$
 				throw new GmFormatException(file,msg);
 				}
 
@@ -202,7 +204,7 @@ public final class GmFileReader
 
 			GameSettings gs = c.f.gameSettings.get(0);
 
-			ip.setProgress(0,"ProgressDialog.SETTINGS"); //$NON-NLS-1$
+			interfaceProvider.setProgress(0,"ProgressDialog.SETTINGS"); //$NON-NLS-1$
 			if (ver == 530) in.skip(4); //reserved 0
 			if (ver == 701)
 				{
@@ -224,32 +226,32 @@ public final class GmFileReader
 
 			if (ver >= 800)
 				{
-				ip.setProgress(10,"ProgressDialog.TRIGGERS"); //$NON-NLS-1$
+				interfaceProvider.setProgress(10,"ProgressDialog.TRIGGERS"); //$NON-NLS-1$
 				readTriggers(c);
-				ip.setProgress(20,"ProgressDialog.CONSTANTS"); //$NON-NLS-1$
+				interfaceProvider.setProgress(20,"ProgressDialog.CONSTANTS"); //$NON-NLS-1$
 				readConstants(c,gs);
 				}
 
-			ip.setProgress(30,"ProgressDialog.SOUNDS"); //$NON-NLS-1$
+			interfaceProvider.setProgress(30,"ProgressDialog.SOUNDS"); //$NON-NLS-1$
 			readSounds(c);
-			ip.setProgress(40,"ProgressDialog.SPRITES"); //$NON-NLS-1$
+			interfaceProvider.setProgress(40,"ProgressDialog.SPRITES"); //$NON-NLS-1$
 			readSprites(c);
-			ip.setProgress(50,"ProgressDialog.BACKGROUNDS"); //$NON-NLS-1$
+			interfaceProvider.setProgress(50,"ProgressDialog.BACKGROUNDS"); //$NON-NLS-1$
 			int bgVer = readBackgrounds(c);
-			ip.setProgress(60,"ProgressDialog.PATHS"); //$NON-NLS-1$
+			interfaceProvider.setProgress(60,"ProgressDialog.PATHS"); //$NON-NLS-1$
 			readPaths(c);
-			ip.setProgress(70,"ProgressDialog.SCRIPTS"); //$NON-NLS-1$
+			interfaceProvider.setProgress(70,"ProgressDialog.SCRIPTS"); //$NON-NLS-1$
 			readScripts(c);
-			ip.setProgress(80,"ProgressDialog.SHADERS"); //$NON-NLS-1$
+			interfaceProvider.setProgress(80,"ProgressDialog.SHADERS"); //$NON-NLS-1$
 			//TODO: GMK 820 reads shaders first
-			ip.setProgress(90,"ProgressDialog.FONTS"); //$NON-NLS-1$
+			interfaceProvider.setProgress(90,"ProgressDialog.FONTS"); //$NON-NLS-1$
 			int rver = in.read4();
 			readFonts(c,rver);
-			ip.setProgress(100,"ProgressDialog.TIMELINES"); //$NON-NLS-1$
+			interfaceProvider.setProgress(100,"ProgressDialog.TIMELINES"); //$NON-NLS-1$
 			readTimelines(c);
-			ip.setProgress(110,"ProgressDialog.OBJECTS"); //$NON-NLS-1$
+			interfaceProvider.setProgress(110,"ProgressDialog.OBJECTS"); //$NON-NLS-1$
 			readGmObjects(c);
-			ip.setProgress(120,"ProgressDialog.ROOMS"); //$NON-NLS-1$
+			interfaceProvider.setProgress(120,"ProgressDialog.ROOMS"); //$NON-NLS-1$
 			readRooms(c);
 
 			//If the "use as tileset" flag was not part of this version,
@@ -270,49 +272,51 @@ public final class GmFileReader
 
 			if (ver >= 700)
 				{
-				ip.setProgress(130,"ProgressDialog.INCLUDEFILES"); //$NON-NLS-1$
+				interfaceProvider.setProgress(130,"ProgressDialog.INCLUDEFILES"); //$NON-NLS-1$
 				readIncludedFiles(c);
-				ip.setProgress(140,"ProgressDialog.PACKAGES"); //$NON-NLS-1$
+				interfaceProvider.setProgress(140,"ProgressDialog.PACKAGES"); //$NON-NLS-1$
 				readPackages(c);
 				}
 
-			ip.setProgress(150,"ProgressDialog.GAMEINFORMATION"); //$NON-NLS-1$
+			interfaceProvider.setProgress(150,"ProgressDialog.GAMEINFORMATION"); //$NON-NLS-1$
 			readGameInformation(c);
 
-			ip.setProgress(160,"ProgressDialog.POSTPONED"); //$NON-NLS-1$
+			interfaceProvider.setProgress(160,"ProgressDialog.POSTPONED"); //$NON-NLS-1$
 			//Resources read. Now we can invoke our postpones.
 			int percent = 0;
 			for (PostponedRef i : postpone)
 				{
 				i.invoke();
 				percent += 1;
-				ip.setProgress(160 + percent / postpone.size(),
+				interfaceProvider.setProgress(160 + percent / postpone.size(),
 						"ProgressDialog.POSTPONED"); //$NON-NLS-1$
 				}
 			postpone.clear();
 
-			ip.setProgress(170,"ProgressDialog.LIBRARYCREATION"); //$NON-NLS-1$
+			interfaceProvider.setProgress(170,"ProgressDialog.LIBRARYCREATION"); //$NON-NLS-1$
 			//Library Creation Code
 			ver = in.read4();
 			if (ver != 500)
-				throw new GmFormatException(file,ip.format("ProjectFileReader.ERROR_UNSUPPORTED", //$NON-NLS-1$
-						ip.translate("ProjectFileReader.AFTERINFO"),ver)); //$NON-NLS-1$
+				throw new GmFormatException(file,
+						interfaceProvider.format("ProjectFileReader.ERROR_UNSUPPORTED", //$NON-NLS-1$
+						interfaceProvider.translate("ProjectFileReader.AFTERINFO"),ver)); //$NON-NLS-1$
 			int no = in.read4();
 			for (int j = 0; j < no; j++)
 				in.skip(in.read4());
 
-			ip.setProgress(180,"ProgressDialog.ROOMEXECUTION"); //$NON-NLS-1$
+			interfaceProvider.setProgress(180,"ProgressDialog.ROOMEXECUTION"); //$NON-NLS-1$
 			//Room Execution Order
 			ver = in.read4();
 			if (ver != 500 && ver != 540 && ver != 700)
-				throw new GmFormatException(file,ip.format("ProjectFileReader.ERROR_UNSUPPORTED", //$NON-NLS-1$
-						ip.translate("ProjectFileReader.AFTERINFO2"),ver)); //$NON-NLS-1$
+				throw new GmFormatException(file,
+						interfaceProvider.format("ProjectFileReader.ERROR_UNSUPPORTED", //$NON-NLS-1$
+						interfaceProvider.translate("ProjectFileReader.AFTERINFO2"),ver)); //$NON-NLS-1$
 			in.skip(in.read4() * 4);
 
-			ip.setProgress(190,"ProgressDialog.FILETREE"); //$NON-NLS-1$
+			interfaceProvider.setProgress(190,"ProgressDialog.FILETREE"); //$NON-NLS-1$
 			readTree(c,root,ver);
 
-			ip.setProgress(200,"ProgressDialog.FINISHED"); //$NON-NLS-1$
+			interfaceProvider.setProgress(200,"ProgressDialog.FINISHED"); //$NON-NLS-1$
 			}
 		catch (Exception e)
 			{
@@ -331,7 +335,7 @@ public final class GmFileReader
 				}
 			catch (IOException ex)
 				{
-				String key = ip.translate("GmFileReader.ERROR_CLOSEFAILED"); //$NON-NLS-1$
+				String key = interfaceProvider.translate("GmFileReader.ERROR_CLOSEFAILED"); //$NON-NLS-1$
 				throw new GmFormatException(file,key);
 				}
 			}

--- a/org/lateralgm/file/GmFileWriter.java
+++ b/org/lateralgm/file/GmFileWriter.java
@@ -11,6 +11,7 @@
 package org.lateralgm.file;
 
 import static org.lateralgm.main.Util.deRef;
+import static org.lateralgm.file.ProjectFile.interfaceProvider;
 
 import java.awt.Color;
 import java.awt.image.BufferedImage;
@@ -22,7 +23,6 @@ import java.util.Enumeration;
 import java.util.List;
 
 import org.lateralgm.components.impl.ResNode;
-import org.lateralgm.file.ProjectFile.InterfaceProvider;
 import org.lateralgm.file.iconio.ICOFile;
 import org.lateralgm.main.Util;
 import org.lateralgm.resources.Background;
@@ -86,15 +86,14 @@ public final class GmFileWriter
 	public static void writeProjectFile(OutputStream os, ProjectFile f, ResNode root, int ver)
 			throws IOException
 		{
-		InterfaceProvider ip = ProjectFile.interfaceProvider;
-		ip.init(200,"ProgressDialog.GMK_SAVING"); //$NON-NLS-1$
+		interfaceProvider.init(200,"ProgressDialog.GMK_SAVING"); //$NON-NLS-1$
 		f.format = ProjectFile.FormatFlavor.getVersionFlavor(ver);
 		long savetime = System.currentTimeMillis();
 		GmStreamEncoder out = new GmStreamEncoder(os);
 
 		GameSettings gs = f.gameSettings.get(0);
 
-		ip.setProgress(0,"ProgressDialog.SETTINGS");
+		interfaceProvider.setProgress(0,"ProgressDialog.SETTINGS");
 		if (ver >= 810)
 			out.setCharset(Charset.forName("UTF-8"));
 		else
@@ -120,29 +119,29 @@ public final class GmFileWriter
 
 		if (ver >= 800)
 			{
-			ip.setProgress(10,"ProgressDialog.TRIGGERS");
+			interfaceProvider.setProgress(10,"ProgressDialog.TRIGGERS");
 			writeTriggers(f,out,ver,gs);
-			ip.setProgress(20,"ProgressDialog.CONSTANTS");
+			interfaceProvider.setProgress(20,"ProgressDialog.CONSTANTS");
 			writeConstants(f,out,ver,gs);
 			}
 
-		ip.setProgress(30,"ProgressDialog.SOUNDS");
+		interfaceProvider.setProgress(30,"ProgressDialog.SOUNDS");
 		writeSounds(f,out,ver,gs);
-		ip.setProgress(40,"ProgressDialog.SPRITES");
+		interfaceProvider.setProgress(40,"ProgressDialog.SPRITES");
 		writeSprites(f,out,ver,gs);
-		ip.setProgress(50,"ProgressDialog.BACKGROUNDS");
+		interfaceProvider.setProgress(50,"ProgressDialog.BACKGROUNDS");
 		writeBackgrounds(f,out,ver,gs);
-		ip.setProgress(60,"ProgressDialog.PATHS");
+		interfaceProvider.setProgress(60,"ProgressDialog.PATHS");
 		writePaths(f,out,ver,gs);
-		ip.setProgress(70,"ProgressDialog.SCRIPTS");
+		interfaceProvider.setProgress(70,"ProgressDialog.SCRIPTS");
 		writeScripts(f,out,ver,gs);
-		ip.setProgress(80,"ProgressDialog.FONTS");
+		interfaceProvider.setProgress(80,"ProgressDialog.FONTS");
 		writeFonts(f,out,ver,gs);
-		ip.setProgress(90,"ProgressDialog.TIMELINES");
+		interfaceProvider.setProgress(90,"ProgressDialog.TIMELINES");
 		writeTimelines(f,out,ver,gs);
-		ip.setProgress(100,"ProgressDialog.OBJECTS");
+		interfaceProvider.setProgress(100,"ProgressDialog.OBJECTS");
 		writeGmObjects(f,out,ver,gs);
-		ip.setProgress(110,"ProgressDialog.ROOMS");
+		interfaceProvider.setProgress(110,"ProgressDialog.ROOMS");
 		writeRooms(f,out,ver,gs);
 
 		out.write4(f.lastInstanceId);
@@ -150,29 +149,29 @@ public final class GmFileWriter
 
 		if (ver >= 700)
 			{
-			ip.setProgress(120,"ProgressDialog.INCLUDEFILES");
+			interfaceProvider.setProgress(120,"ProgressDialog.INCLUDEFILES");
 			writeIncludedFiles(f,out,ver,gs);
-			ip.setProgress(130,"ProgressDialog.PACKAGES");
+			interfaceProvider.setProgress(130,"ProgressDialog.PACKAGES");
 			writePackages(f,out,ver);
 			}
 
-		ip.setProgress(140,"ProgressDialog.GAMEINFORMATION");
+		interfaceProvider.setProgress(140,"ProgressDialog.GAMEINFORMATION");
 		writeGameInformation(f,out,ver,gs);
 
-		ip.setProgress(150,"ProgressDialog.LIBRARYCREATION");
+		interfaceProvider.setProgress(150,"ProgressDialog.LIBRARYCREATION");
 		//Library Creation Code
 		out.write4(500);
 		out.write4(0);
 
-		ip.setProgress(160,"ProgressDialog.ROOMEXECUTION");
+		interfaceProvider.setProgress(160,"ProgressDialog.ROOMEXECUTION");
 		//Room Execution Order
 		out.write4(ver >= 700 ? 700 : 540);
 		out.write4(0);
 
-		ip.setProgress(170,"ProgressDialog.FILETREE");
+		interfaceProvider.setProgress(170,"ProgressDialog.FILETREE");
 		writeTree(out,root);
 		out.close();
-		ip.setProgress(200,"ProgressDialog.FINISHED");
+		interfaceProvider.setProgress(200,"ProgressDialog.FINISHED");
 		}
 
 	public static void writeSettings(ProjectFile f, GmStreamEncoder out, int ver, long savetime, GameSettings g)

--- a/org/lateralgm/file/ProjectFile.java
+++ b/org/lateralgm/file/ProjectFile.java
@@ -295,7 +295,7 @@ public class ProjectFile implements UpdateListener
 		public void setProgress(int percent, String messageKey);
 		public String translate(String key);
 		public String format(String key, Object...arguments);
-		public void handleRecoverableException(Exception e);
+		public void handleException(Exception e);
 		}
 
 	// The default interface will just sink the progress of the project loading.
@@ -310,7 +310,7 @@ public class ProjectFile implements UpdateListener
 		@Override
 		public void init(int max, String titleKey) {}
 		@Override
-		public void handleRecoverableException(Exception e)
+		public void handleException(Exception e)
 			{
 			Thread t = Thread.currentThread();
 			t.getUncaughtExceptionHandler().uncaughtException(t,e);

--- a/org/lateralgm/file/ProjectFile.java
+++ b/org/lateralgm/file/ProjectFile.java
@@ -295,10 +295,11 @@ public class ProjectFile implements UpdateListener
 		public void setProgress(int percent, String messageKey);
 		public String translate(String key);
 		public String format(String key, Object...arguments);
+		public void handleRecoverableException(Exception e);
 		}
 
 	// The default interface will just sink the progress of the project loading.
-	public static InterfaceProvider interfaceProvider = new InterfaceProvider()
+	public static class DefaultInterfaceProvider implements InterfaceProvider
 		{
 		@Override
 		public void setProgress(int percent, String messageKey) {}
@@ -308,7 +309,16 @@ public class ProjectFile implements UpdateListener
 		public String format(String key, Object...arguments) { return key; }
 		@Override
 		public void init(int max, String titleKey) {}
+		@Override
+		public void handleRecoverableException(Exception e)
+			{
+			Thread t = Thread.currentThread();
+			t.getUncaughtExceptionHandler().uncaughtException(t,e);
+			}
 		};
+
+	// This is the one that the project readers will actually use and depend upon.
+	public static InterfaceProvider interfaceProvider = new DefaultInterfaceProvider();
 
 	public ProjectFile()
 		{

--- a/org/lateralgm/main/FileChooser.java
+++ b/org/lateralgm/main/FileChooser.java
@@ -88,7 +88,7 @@ public class FileChooser
 	static
 		{
 		// Replace the default project UI provider with one coupled to Swing.
-		ProjectFile.interfaceProvider = new ProjectFile.InterfaceProvider()
+		ProjectFile.interfaceProvider = new ProjectFile.DefaultInterfaceProvider()
 			{
 			@Override
 			public void setProgress(int percent, String messageKey)

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -133,7 +133,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.111"; //$NON-NLS-1$
+	public static final String version = "1.8.112"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.


### PR DESCRIPTION
* Add a new `ProjectFile.InterfaceProvider.handleException` to allow the UI to handle recoverable exceptions.
* Forward the recoverable exceptions to the interface provider instead of the LGM default exception handler.
* Change the default interface provider into an actual class which is more easily instantiated without overriding all methods.
* The above is a workaround to default interface methods in Java prior to Java 8 (equivalent to e.g, MouseAdapter).
* Have the default interface provider forward recoverable exceptions to the current thread's uncaught exception handler.
* Statically import the `interfaceProvider` instance in all readers & writers since it's so commonly needed.
