### PR TITLE
Initial Thread Safety

### DIFF
--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -1023,11 +1023,8 @@ public final class LGM
 		}
 	}
 
-	public static void main(final String[] args) throws InvocationTargetException, InterruptedException
+	private static void createAndShowGUI(String[] args)
 		{
-		// Set the default uncaught exception handler.
-		LGM.setDefaultExceptionHandler();
-
 		LGM.applyPreferences();
 		Messages.updateLangPack();
 
@@ -1036,10 +1033,6 @@ public final class LGM
 		System.setProperty("apple.laf.useScreenMenuBar","true"); //$NON-NLS-1$ //$NON-NLS-2$
 		//Set the Mac menu bar title to the correct name (also adds a useless About entry, so disabled)
 		//System.setProperty("com.apple.mrj.application.apple.menu.about.name",Messages.getString("LGM.NAME")); //$NON-NLS-1$ //$NON-NLS-2$
-
-		System.out.format("Java Version: %d (%s)\n",javaVersion,System.getProperty("java.version")); //$NON-NLS-1$
-		if (javaVersion < 10700)
-			System.out.println("Some program functionality will be limited due to your outdated Java version"); //$NON-NLS-1$
 
 		iconspack = Prefs.iconPack;
 		setLookAndFeel(Prefs.swingTheme);
@@ -1164,6 +1157,29 @@ public final class LGM
 			{
 			LOADING_PROJECT = false;
 			}
+		}
+
+	// Swing component GUI stuff does NOT go in the main method!
+	// The initial thread is not running on the EDT and is not
+	// safe to perform any GUI work.
+	public static void main(final String[] args)
+		{
+		// Set the default uncaught exception handler.
+		LGM.setDefaultExceptionHandler();
+
+		System.out.format("Java Version: %d (%s)\n",javaVersion,System.getProperty("java.version")); //$NON-NLS-1$
+		if (javaVersion < 10700)
+			System.out.println("Some program functionality will be limited due to your outdated Java version"); //$NON-NLS-1$
+
+		// Create the main window on the EDT for safety.
+		SwingUtilities.invokeLater(new Runnable()
+			{
+				@Override
+				public void run()
+					{
+					createAndShowGUI(args);
+					}
+			});
 		}
 
 	public static int getTabIndex(JTabbedPane tabs, String title) {

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -42,7 +42,6 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
@@ -133,7 +132,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.114"; //$NON-NLS-1$
+	public static final String version = "1.8.115"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -1171,6 +1171,7 @@ public final class LGM
 			System.out.println("Some program functionality will be limited due to your outdated Java version"); //$NON-NLS-1$
 
 		// Create the main window on the EDT for safety.
+		// https://docs.oracle.com/javase/tutorial/uiswing/concurrency/initial.html
 		SwingUtilities.invokeLater(new Runnable()
 			{
 				@Override


### PR DESCRIPTION
Resolve #505 and move the main frame creation to the EDT. Also removes two vestigial exceptions I had main throwing in ec03f8a16da9f4bb8799b729043ba78d7c048271 when initially adding attempting this.