### PR TITLE
Revitalize Background Frame

### DIFF
--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -132,7 +132,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.117"; //$NON-NLS-1$
+	public static final String version = "1.8.118"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/subframes/BackgroundFrame.java
+++ b/org/lateralgm/subframes/BackgroundFrame.java
@@ -84,6 +84,7 @@ public class BackgroundFrame extends InstantiableResourceFrame<Background,PBackg
 
 	public MouseAdapter mouseAdapter = null;
 
+	public JPanel groupPanel;
 	public NumberField tWidth;
 	public NumberField tHeight;
 	public NumberField hOffset;
@@ -281,7 +282,7 @@ public class BackgroundFrame extends InstantiableResourceFrame<Background,PBackg
 		panel.add(preload);
 		panel.add(tileset);
 
-		JPanel groupPanel = new JPanel();
+		groupPanel = new JPanel();
 		GroupLayout pLayout = new GroupLayout(groupPanel);
 		groupPanel.setLayout(pLayout);
 		String tileProps = Messages.getString("BackgroundFrame.TILE_PROPERTIES"); //$NON-NLS-1$
@@ -368,8 +369,6 @@ public class BackgroundFrame extends InstantiableResourceFrame<Background,PBackg
 		/*		*/.addComponent(vSep))
 		/**/.addContainerGap(8,8));
 
-		//groupPanel.setVisible(tileset.isSelected());
-
 		JLabel nameLabel = new JLabel(Messages.getString("SpriteFrame.NAME")); //$NON-NLS-1$
 		save.setText(Messages.getString("SpriteFrame.SAVE")); //$NON-NLS-1$
 
@@ -395,6 +394,13 @@ public class BackgroundFrame extends InstantiableResourceFrame<Background,PBackg
 		/**/.addComponent(groupPanel)
 		/**/.addGap(0,0,MAX_VALUE)
 		/**/.addComponent(save));
+
+		// pretend like the group panel is always there
+		// so toggling tileset doesn't resize everything
+		// like the name field and save button
+		layout.setHonorsVisibility(groupPanel,false);
+		// set the tile group visible if we're a tile
+		groupPanel.setVisible(tileset.isSelected());
 
 		return panel;
 		}
@@ -692,10 +698,8 @@ public class BackgroundFrame extends InstantiableResourceFrame<Background,PBackg
 		{
 		public void updated(PropertyUpdateEvent<PBackground> e)
 			{
-			//TODO: Maybe remove this
 			//USE_AS_TILESET
-			//side2.setVisible((Boolean)
-			//res.get(PBackground.USE_AS_TILESET));
+			groupPanel.setVisible((Boolean)res.get(PBackground.USE_AS_TILESET));
 			}
 		}
 

--- a/org/lateralgm/subframes/BackgroundFrame.java
+++ b/org/lateralgm/subframes/BackgroundFrame.java
@@ -277,11 +277,6 @@ public class BackgroundFrame extends InstantiableResourceFrame<Background,PBackg
 		tileset = new JCheckBox(Messages.getString("BackgroundFrame.USE_AS_TILESET")); //$NON-NLS-1$
 		plf.make(tileset,PBackground.USE_AS_TILESET);
 
-		panel.add(transparent);
-		panel.add(smooth);
-		panel.add(preload);
-		panel.add(tileset);
-
 		groupPanel = new JPanel();
 		GroupLayout pLayout = new GroupLayout(groupPanel);
 		groupPanel.setLayout(pLayout);

--- a/org/lateralgm/subframes/BackgroundFrame.java
+++ b/org/lateralgm/subframes/BackgroundFrame.java
@@ -142,6 +142,7 @@ public class BackgroundFrame extends InstantiableResourceFrame<Background,PBackg
 	public BackgroundFrame(Background res, ResNode node)
 		{
 		super(res,node);
+		this.getRootPane().setDefaultButton(save);
 		res.properties.getUpdateSource(PBackground.USE_AS_TILESET).addListener(bpl);
 		res.reference.updateSource.addListener(this);
 

--- a/org/lateralgm/subframes/BackgroundFrame.java
+++ b/org/lateralgm/subframes/BackgroundFrame.java
@@ -36,6 +36,7 @@ import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
 import javax.swing.GroupLayout;
 import javax.swing.GroupLayout.Alignment;
+import javax.swing.LayoutStyle.ComponentPlacement;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JFormattedTextField;
@@ -202,7 +203,7 @@ public class BackgroundFrame extends InstantiableResourceFrame<Background,PBackg
 		updateScrollBars();
 
 		pack();
-		this.setSize(640,400);
+		this.setSize(640,432);
 		}
 
 	private JButton makeJButton(String key)
@@ -279,6 +280,7 @@ public class BackgroundFrame extends InstantiableResourceFrame<Background,PBackg
 
 		groupPanel = new JPanel();
 		GroupLayout pLayout = new GroupLayout(groupPanel);
+		pLayout.setAutoCreateContainerGaps(true);
 		groupPanel.setLayout(pLayout);
 		String tileProps = Messages.getString("BackgroundFrame.TILE_PROPERTIES"); //$NON-NLS-1$
 		groupPanel.setBorder(BorderFactory.createTitledBorder(tileProps));
@@ -320,7 +322,6 @@ public class BackgroundFrame extends InstantiableResourceFrame<Background,PBackg
 		vSep.setColumns(3);
 
 		pLayout.setHorizontalGroup(pLayout.createSequentialGroup()
-		/**/.addContainerGap(4,4)
 		/**/.addGroup(pLayout.createParallelGroup(Alignment.TRAILING)
 		/*		*/.addComponent(twLabel)
 		/*		*/.addComponent(thLabel)
@@ -328,41 +329,38 @@ public class BackgroundFrame extends InstantiableResourceFrame<Background,PBackg
 		/*		*/.addComponent(voLabel)
 		/*		*/.addComponent(hsLabel)
 		/*		*/.addComponent(vsLabel))
-		/**/.addGap(4)
+		/**/.addPreferredGap(ComponentPlacement.RELATED)
 		/**/.addGroup(pLayout.createParallelGroup()
 		/*		*/.addComponent(tWidth,PREFERRED_SIZE,DEFAULT_SIZE,DEFAULT_SIZE)
 		/*		*/.addComponent(tHeight,PREFERRED_SIZE,DEFAULT_SIZE,DEFAULT_SIZE)
 		/*		*/.addComponent(hOffset,PREFERRED_SIZE,DEFAULT_SIZE,DEFAULT_SIZE)
 		/*		*/.addComponent(vOffset,PREFERRED_SIZE,DEFAULT_SIZE,DEFAULT_SIZE)
 		/*		*/.addComponent(hSep,PREFERRED_SIZE,DEFAULT_SIZE,DEFAULT_SIZE)
-		/*		*/.addComponent(vSep,PREFERRED_SIZE,DEFAULT_SIZE,DEFAULT_SIZE))
-		/**/.addContainerGap(4,4));
+		/*		*/.addComponent(vSep,PREFERRED_SIZE,DEFAULT_SIZE,DEFAULT_SIZE)));
 		pLayout.setVerticalGroup(pLayout.createSequentialGroup()
-		/**/.addGap(2)
 		/**/.addGroup(pLayout.createParallelGroup(Alignment.BASELINE)
 		/*		*/.addComponent(twLabel)
 		/*		*/.addComponent(tWidth))
-		/**/.addGap(2)
+		/**/.addPreferredGap(ComponentPlacement.RELATED)
 		/**/.addGroup(pLayout.createParallelGroup(Alignment.BASELINE)
 		/*		*/.addComponent(thLabel)
 		/*		*/.addComponent(tHeight))
-		/**/.addGap(8)
+		/**/.addPreferredGap(ComponentPlacement.UNRELATED)
 		/**/.addGroup(pLayout.createParallelGroup(Alignment.BASELINE)
 		/*		*/.addComponent(hoLabel)
 		/*		*/.addComponent(hOffset))
-		/**/.addGap(2)
+		/**/.addPreferredGap(ComponentPlacement.RELATED)
 		/**/.addGroup(pLayout.createParallelGroup(Alignment.BASELINE)
 		/*		*/.addComponent(voLabel)
 		/*		*/.addComponent(vOffset))
-		/**/.addGap(8)
+		/**/.addPreferredGap(ComponentPlacement.UNRELATED)
 		/**/.addGroup(pLayout.createParallelGroup(Alignment.BASELINE)
 		/*		*/.addComponent(hsLabel)
 		/*		*/.addComponent(hSep))
-		/**/.addGap(2)
+		/**/.addPreferredGap(ComponentPlacement.RELATED)
 		/**/.addGroup(pLayout.createParallelGroup(Alignment.BASELINE)
 		/*		*/.addComponent(vsLabel)
-		/*		*/.addComponent(vSep))
-		/**/.addContainerGap(8,8));
+		/*		*/.addComponent(vSep)));
 
 		JLabel nameLabel = new JLabel(Messages.getString("SpriteFrame.NAME")); //$NON-NLS-1$
 		save.setText(Messages.getString("SpriteFrame.SAVE")); //$NON-NLS-1$

--- a/org/lateralgm/subframes/BackgroundFrame.java
+++ b/org/lateralgm/subframes/BackgroundFrame.java
@@ -146,6 +146,7 @@ public class BackgroundFrame extends InstantiableResourceFrame<Background,PBackg
 
 		this.setLayout(new BorderLayout());
 
+		JPanel previewPanel = new JPanel(new BorderLayout());
 		preview = new BackgroundPreview(res);
 		preview.setVerticalAlignment(SwingConstants.TOP);
 
@@ -178,18 +179,18 @@ public class BackgroundFrame extends InstantiableResourceFrame<Background,PBackg
 					preview.setCursor(LGM.zoomCursor);
 					}
 			};
-
 		previewScroll = new JScrollPane(preview);
+		previewPanel.add(previewScroll,BorderLayout.CENTER);
+		previewPanel.add(makeToolBar(),BorderLayout.NORTH);
 
-		this.add(makeToolBar(),BorderLayout.NORTH);
 		JSplitPane orientationSplit = new JSplitPane();
 		if (Prefs.rightOrientation) {
 			orientationSplit = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT,
-					previewScroll,makeOptionsPanel());
+					previewPanel,makeOptionsPanel());
 			orientationSplit.setResizeWeight(1d);
 		} else {
 			orientationSplit = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT,
-					makeOptionsPanel(),previewScroll);
+					makeOptionsPanel(),previewPanel);
 		}
 		this.add(orientationSplit, BorderLayout.CENTER);
 		this.add(makeStatusBar(),BorderLayout.SOUTH);

--- a/org/lateralgm/subframes/BackgroundFrame.java
+++ b/org/lateralgm/subframes/BackgroundFrame.java
@@ -10,6 +10,7 @@
 
 package org.lateralgm.subframes;
 
+import static java.lang.Integer.MAX_VALUE;
 import static javax.swing.GroupLayout.DEFAULT_SIZE;
 import static javax.swing.GroupLayout.PREFERRED_SIZE;
 
@@ -242,13 +243,6 @@ public class BackgroundFrame extends InstantiableResourceFrame<Background,PBackg
 		tool.add(makeJButton("BackgroundFrame.ZOOM_IN"));
 		tool.add(makeJButton("BackgroundFrame.ZOOM_OUT"));
 
-		tool.addSeparator();
-
-		name.setColumns(13);
-		name.setMaximumSize(name.getPreferredSize());
-		tool.add(new JLabel(Messages.getString("BackgroundFrame.NAME"))); //$NON-NLS-1$
-		tool.add(name);
-
 		return tool;
 		}
 
@@ -270,6 +264,7 @@ public class BackgroundFrame extends InstantiableResourceFrame<Background,PBackg
 		{
 		JPanel panel = new JPanel(new BorderLayout());
 		GroupLayout layout = new GroupLayout(panel);
+		layout.setAutoCreateGaps(true);
 		layout.setAutoCreateContainerGaps(true);
 
 		panel.setLayout(layout);
@@ -376,14 +371,23 @@ public class BackgroundFrame extends InstantiableResourceFrame<Background,PBackg
 		/**/.addContainerGap(8,8));
 
 		//groupPanel.setVisible(tileset.isSelected());
-		panel.add(groupPanel);
+
+		JLabel nameLabel = new JLabel(Messages.getString("SpriteFrame.NAME")); //$NON-NLS-1$
+		save.setText(Messages.getString("SpriteFrame.SAVE")); //$NON-NLS-1$
+
 		layout.setHorizontalGroup(layout.createParallelGroup()
+		/**/.addGroup(layout.createSequentialGroup()
+		/*	*/.addComponent(nameLabel)
+		/*	*/.addComponent(name,DEFAULT_SIZE,120,MAX_VALUE))
 		/**/.addComponent(smooth)
 		/**/.addComponent(preload)
 		/**/.addComponent(transparent)
 		/**/.addComponent(tileset)
 		/**/.addComponent(groupPanel));
 		layout.setVerticalGroup(layout.createSequentialGroup()
+		/**/.addGroup(layout.createParallelGroup(Alignment.BASELINE)
+		/*	*/.addComponent(nameLabel)
+		/*	*/.addComponent(name))
 		/**/.addComponent(smooth)
 		/**/.addComponent(preload)
 		/**/.addComponent(transparent)

--- a/org/lateralgm/subframes/BackgroundFrame.java
+++ b/org/lateralgm/subframes/BackgroundFrame.java
@@ -219,27 +219,27 @@ public class BackgroundFrame extends InstantiableResourceFrame<Background,PBackg
 		tool.setFloatable(false);
 		tool.setAlignmentX(0);
 
-		tool.add(makeJButton("BackgroundFrame.CREATE"));
-		tool.add(makeJButton("BackgroundFrame.LOAD"));
-		tool.add(makeJButton("BackgroundFrame.SAVE"));
-		tool.add(makeJButton("BackgroundFrame.EDIT"));
-		tool.add(makeJButton("BackgroundFrame.EFFECT"));
+		tool.add(makeJButton("BackgroundFrame.CREATE")); //$NON-NLS-1$
+		tool.add(makeJButton("BackgroundFrame.LOAD")); //$NON-NLS-1$
+		tool.add(makeJButton("BackgroundFrame.SAVE")); //$NON-NLS-1$
+		tool.add(makeJButton("BackgroundFrame.EDIT")); //$NON-NLS-1$
+		tool.add(makeJButton("BackgroundFrame.EFFECT")); //$NON-NLS-1$
 
 		tool.addSeparator();
 
 		// TODO: Implement undo/redo
-		//tool.add(makeJButton("BackgroundFrame.UNDO"));
-		//tool.add(makeJButton("BackgroundFrame.REDO"));
+		//tool.add(makeJButton("BackgroundFrame.UNDO")); //$NON-NLS-1$
+		//tool.add(makeJButton("BackgroundFrame.REDO")); //$NON-NLS-1$
 
 		//tool.addSeparator();
 
-		zoomButton = new JToggleButton(LGM.getIconForKey("BackgroundFrame.ZOOM"));
-		zoomButton.setToolTipText(Messages.getString("BackgroundFrame.ZOOM"));
+		zoomButton = new JToggleButton(LGM.getIconForKey("BackgroundFrame.ZOOM")); //$NON-NLS-1$
+		zoomButton.setToolTipText(Messages.getString("BackgroundFrame.ZOOM")); //$NON-NLS-1$
 		zoomButton.addActionListener(this);
-		zoomButton.setActionCommand("BackgroundFrame.ZOOM");
+		zoomButton.setActionCommand("BackgroundFrame.ZOOM"); //$NON-NLS-1$
 		tool.add(zoomButton);
-		tool.add(makeJButton("BackgroundFrame.ZOOM_IN"));
-		tool.add(makeJButton("BackgroundFrame.ZOOM_OUT"));
+		tool.add(makeJButton("BackgroundFrame.ZOOM_IN")); //$NON-NLS-1$
+		tool.add(makeJButton("BackgroundFrame.ZOOM_OUT")); //$NON-NLS-1$
 
 		return tool;
 		}
@@ -471,7 +471,7 @@ public class BackgroundFrame extends InstantiableResourceFrame<Background,PBackg
 
 	public void handleToolBar(String cmd)
 		{
-		if (cmd.endsWith(".LOAD"))
+		if (cmd.endsWith(".LOAD")) //$NON-NLS-1$
 			{
 			BufferedImage img = Util.getValidImage();
 			if (img != null)
@@ -482,7 +482,7 @@ public class BackgroundFrame extends InstantiableResourceFrame<Background,PBackg
 				}
 			return;
 			}
-		else if (cmd.endsWith(".SAVE"))
+		else if (cmd.endsWith(".SAVE")) //$NON-NLS-1$
 			{
 			BufferedImage img = res.getBackgroundImage();
 			// utility function will check if the image is null and display an appropriate warning
@@ -490,11 +490,11 @@ public class BackgroundFrame extends InstantiableResourceFrame<Background,PBackg
 			Util.saveImage(img);
 			return;
 			}
-		else if (cmd.endsWith(".CREATE"))
+		else if (cmd.endsWith(".CREATE")) //$NON-NLS-1$
 			{
 			createNewImage(true);
 			}
-		else if (cmd.endsWith(".EDIT"))
+		else if (cmd.endsWith(".EDIT")) //$NON-NLS-1$
 			{
 			try
 				{
@@ -509,15 +509,16 @@ public class BackgroundFrame extends InstantiableResourceFrame<Background,PBackg
 				}
 			return;
 			}
-		else if (cmd.endsWith(".EFFECT")) {
+		else if (cmd.endsWith(".EFFECT")) //$NON-NLS-1$
+			{
 			List<BufferedImage> imgs = new ArrayList<BufferedImage>(1);
 			imgs.add(res.getBackgroundImage());
 
 			EffectsFrame ef = EffectsFrame.getInstance();
 			ef.setEffectsListener(this, imgs);
 			ef.setVisible(true);
-		}
-		else if (cmd.endsWith(".ZOOM"))
+			}
+		else if (cmd.endsWith(".ZOOM")) //$NON-NLS-1$
 			{
 			if (zoomButton.isSelected())
 				{
@@ -530,12 +531,12 @@ public class BackgroundFrame extends InstantiableResourceFrame<Background,PBackg
 				preview.setCursor(Cursor.getDefaultCursor());
 				}
 			}
-		else if (cmd.endsWith(".ZOOM_IN"))
+		else if (cmd.endsWith(".ZOOM_IN")) //$NON-NLS-1$
 			{
 			zoomIn();
 			return;
 			}
-		else if (cmd.endsWith(".ZOOM_OUT"))
+		else if (cmd.endsWith(".ZOOM_OUT")) //$NON-NLS-1$
 			{
 			zoomOut();
 			return;
@@ -575,12 +576,13 @@ public class BackgroundFrame extends InstantiableResourceFrame<Background,PBackg
 			JPanel myPanel = new JPanel();
 			GridLayout layout = new GridLayout(0,2,0,3);
 			myPanel.setLayout(layout);
-			myPanel.add(new JLabel(Messages.getString("BackgroundFrame.NEW_WIDTH")));
+			myPanel.add(new JLabel(Messages.getString("BackgroundFrame.NEW_WIDTH"))); //$NON-NLS-1$
 			myPanel.add(wField);
-			myPanel.add(new JLabel(Messages.getString("BackgroundFrame.NEW_HEIGHT")));
+			myPanel.add(new JLabel(Messages.getString("BackgroundFrame.NEW_HEIGHT"))); //$NON-NLS-1$
 			myPanel.add(hField);
 
-			int result = JOptionPane.showConfirmDialog(LGM.frame,myPanel,Messages.getString("BackgroundFrame.NEW_TITLE"),
+			int result = JOptionPane.showConfirmDialog(
+					LGM.frame,myPanel,Messages.getString("BackgroundFrame.NEW_TITLE"), //$NON-NLS-1$
 					JOptionPane.OK_CANCEL_OPTION,JOptionPane.PLAIN_MESSAGE);
 			if (result == JOptionPane.CANCEL_OPTION)
 				{

--- a/org/lateralgm/subframes/BackgroundFrame.java
+++ b/org/lateralgm/subframes/BackgroundFrame.java
@@ -218,9 +218,6 @@ public class BackgroundFrame extends InstantiableResourceFrame<Background,PBackg
 		tool.setFloatable(false);
 		tool.setAlignmentX(0);
 
-		tool.add(save);
-		tool.addSeparator();
-
 		tool.add(makeJButton("BackgroundFrame.CREATE"));
 		tool.add(makeJButton("BackgroundFrame.LOAD"));
 		tool.add(makeJButton("BackgroundFrame.SAVE"));
@@ -383,7 +380,8 @@ public class BackgroundFrame extends InstantiableResourceFrame<Background,PBackg
 		/**/.addComponent(preload)
 		/**/.addComponent(transparent)
 		/**/.addComponent(tileset)
-		/**/.addComponent(groupPanel));
+		/**/.addComponent(groupPanel)
+		/**/.addComponent(save,DEFAULT_SIZE,DEFAULT_SIZE,MAX_VALUE));
 		layout.setVerticalGroup(layout.createSequentialGroup()
 		/**/.addGroup(layout.createParallelGroup(Alignment.BASELINE)
 		/*	*/.addComponent(nameLabel)
@@ -393,7 +391,9 @@ public class BackgroundFrame extends InstantiableResourceFrame<Background,PBackg
 		/**/.addComponent(transparent)
 		/**/.addComponent(tileset)
 		/**/.addGap(8)
-		/**/.addComponent(groupPanel));
+		/**/.addComponent(groupPanel)
+		/**/.addGap(0,0,MAX_VALUE)
+		/**/.addComponent(save));
 
 		return panel;
 		}


### PR DESCRIPTION
* Follow up #508 for the background frame.
* Move name/save to the left properties side like Timelines/Objects/GM8 for consistency.
* Make main toolbar the toolbar of the preview panel since all options are related.
* Added missing `//$NON-NLS-1$` tags to already translated string keys.
* Made the save button the default button like Timelines/Objects/GM8 for consistency.
* Removed the redundant adding of some of the property controls to the layout since they are in `GroupLayout` now.
* Reverted earlier change that makes the tile properties always visible, they are now hidden if not a tileset, like GM.
* I reasoned because it's less confusing/clutter and you can always set tileset temporarily to change them if not a tileset.
* Replaced hardcoded gaps in tileset properties layout with preferred gaps using related/unrelated components.