### PR TITLE
Update Deprecated Input Modifiers

### DIFF
--- a/org/lateralgm/components/visual/SpriteStripPreview.java
+++ b/org/lateralgm/components/visual/SpriteStripPreview.java
@@ -74,7 +74,7 @@ public class SpriteStripPreview extends AbstractImagePreview implements ValueCha
 
 	protected void processMouseMotionEvent(MouseEvent e)
 		{
-		if (e.getID() == MouseEvent.MOUSE_DRAGGED && (e.getModifiers() & MouseEvent.BUTTON1_MASK) != 0)
+		if (e.getID() == MouseEvent.MOUSE_DRAGGED && (e.getModifiersEx() & MouseEvent.BUTTON1_DOWN_MASK) != 0)
 			{
 			Point pnt = this.translatePoint(e.getPoint());
 			setBoundedOrigin(pnt.x,pnt.y);

--- a/org/lateralgm/components/visual/SubimagePreview.java
+++ b/org/lateralgm/components/visual/SubimagePreview.java
@@ -148,7 +148,7 @@ public class SubimagePreview extends AbstractImagePreview implements UpdateListe
 		if (enableMouse)
 			{
 			if (e.getID() == MouseEvent.MOUSE_DRAGGED
-					&& (e.getModifiers() & MouseEvent.BUTTON1_MASK) != 0)
+					&& (e.getModifiersEx() & MouseEvent.BUTTON1_DOWN_MASK) != 0)
 				{
 				Point pnt = this.translatePoint(e.getPoint());
 				setBoundedOrigin(pnt.x,pnt.y);

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -132,7 +132,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.200"; //$NON-NLS-1$
+	public static final String version = "1.8.201"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/main/Listener.java
+++ b/org/lateralgm/main/Listener.java
@@ -19,7 +19,6 @@ import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.Transferable;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.InputEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.io.File;
@@ -931,7 +930,7 @@ public class Listener extends TransferHandler implements ActionListener,CellEdit
 					}
 				}
 
-			if (e.getModifiers() == InputEvent.BUTTON1_MASK && inpath)
+			if (e.getButton() == MouseEvent.BUTTON1 && inpath)
 				{
 				LGM.tree.setSelectionPath(path);
 				}
@@ -939,7 +938,7 @@ public class Listener extends TransferHandler implements ActionListener,CellEdit
 			ResNode node = (ResNode) path.getLastPathComponent();
 			if (node == null) return;
 			//Isn't Java supposed to handle ctrl+click for us? For some reason it doesn't.
-			if (e.getModifiers() == InputEvent.BUTTON3_MASK && e.getClickCount() == 1)
+			if (e.getButton() == MouseEvent.BUTTON3 && e.getClickCount() == 1)
 				{
 				// Yes the right click button does change the selection,
 				// go ahead and experiment with Eclipse, CodeBlocks, Visual Studio
@@ -953,7 +952,7 @@ public class Listener extends TransferHandler implements ActionListener,CellEdit
 				node.showMenu(e);
 				return;
 				}
-			if (e.getModifiers() == InputEvent.BUTTON1_MASK && e.getClickCount() == 2)
+			if (e.getButton() == MouseEvent.BUTTON1 && e.getClickCount() == 2)
 				{
 				// kind must be a Resource kind
 				if (node.status != ResNode.STATUS_SECONDARY) return;

--- a/org/lateralgm/main/Search.java
+++ b/org/lateralgm/main/Search.java
@@ -10,7 +10,6 @@ import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.StringSelection;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.InputEvent;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.awt.event.MouseAdapter;
@@ -1560,13 +1559,13 @@ public class Search
 							}
 						}
 
-					if (me.getModifiers() == InputEvent.BUTTON1_MASK && inpath)
+					if (me.getButton() == MouseEvent.BUTTON1 && inpath)
 						{
 						tree.setSelectionPath(path);
 						}
 					}
 				//Isn't Java supposed to handle ctrl+click for us? For some reason it doesn't.
-				if (me.getModifiers() == InputEvent.BUTTON3_MASK && me.getClickCount() == 1)
+				if (me.getButton() == MouseEvent.BUTTON3 && me.getClickCount() == 1)
 					{
 					// Yes the right click button does change the selection,
 					// go ahead and experiment with Eclipse, CodeBlocks, Visual Studio
@@ -1584,7 +1583,7 @@ public class Search
 				if (path == null) return;
 				DefaultMutableTreeNode node = (DefaultMutableTreeNode) path.getLastPathComponent();
 				if (node == null) return;
-				if (me.getModifiers() == InputEvent.BUTTON1_MASK && me.getClickCount() >= 2
+				if (me.getButton() == MouseEvent.BUTTON1 && me.getClickCount() >= 2
 						&& ((me.getClickCount() & 1) == 0))
 					{
 					if (node instanceof SearchResultNode)

--- a/org/lateralgm/subframes/EventPanel.java
+++ b/org/lateralgm/subframes/EventPanel.java
@@ -14,7 +14,6 @@ import static org.lateralgm.main.Util.deRef;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
@@ -130,7 +129,7 @@ public class EventPanel extends JPanel implements ActionListener,PropertyChangeL
 					{
 					f.functionEvent(function.getValue(),mid,sid,other,null);
 					f.toTop();
-					boolean ctrlDown = (e.getModifiers() & InputEvent.CTRL_MASK) != 0;
+					boolean ctrlDown = (e.getModifiers() & ActionEvent.CTRL_MASK) != 0;
 					if (!stayOpen.isSelected() ^ ctrlDown) LGM.hideEventPanel();
 					}
 				}


### PR DESCRIPTION
I finally figured out how to deal with the `e.getModifiers()` deprecation warning and decided to get it done. It's a little confusing because you have to understand the different event types and ways of checking which buttons are down.

* `e.getButton()`: Which buttons have changed state.
* `e.getModifiers()`: Which modifiers have changed state. (deprecated)
* `e.getModifiersEx()`: Current state of the modifiers.

The fact that `e.getModifiers()` behaves closer to `e.getButton()` is why it's not always correct to use the recommended `e.getModifiersEx()` in place of the deprecated one. This is the case for mouse motion events which would behave differently if we were trying to check that a button was being held during drag using `e.getButton()` because the button would only change state once, we would need `e.getModifiersEx()` to check that said button was held continuously.