### PR TITLE
New Shader Template

### DIFF
--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -131,7 +131,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.213"; //$NON-NLS-1$
+	public static final String version = "1.8.214"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/resources/Shader.java
+++ b/org/lateralgm/resources/Shader.java
@@ -23,19 +23,41 @@
 
 package org.lateralgm.resources;
 
+import java.io.InputStream;
 import java.util.EnumMap;
 
+import org.lateralgm.main.LGM;
+import org.lateralgm.main.Util;
 import org.lateralgm.util.PropertyMap;
 
 public class Shader extends InstantiableResource<Shader,Shader.PShader>
 	{
+	// plugins may override these to change contents of newly created shaders
+	public static String TEMPLATE_VERTEX = "";
+	public static String TEMPLATE_FRAGMENT = "";
+
+	static
+		{
+		ClassLoader cl = Shader.class.getClassLoader();
+		try (InputStream vis = cl.getResourceAsStream("org/lateralgm/resources/shader_template.vert");
+				 InputStream fis = cl.getResourceAsStream("org/lateralgm/resources/shader_template.frag"))
+			{
+			TEMPLATE_VERTEX = new String(Util.readFully(vis).toByteArray());
+			TEMPLATE_FRAGMENT = new String(Util.readFully(fis).toByteArray());
+			}
+		catch (Exception e)
+			{
+			LGM.showDefaultExceptionHandler(e);
+			}
+		}
+
 	public enum PShader
 		{
 		VERTEX,FRAGMENT,TYPE,PRECOMPILE
 		}
 
-	private static final EnumMap<PShader,Object> DEFS = PropertyMap.makeDefaultMap(PShader.class,"",
-			"","GLSLES",true);
+	private static final EnumMap<PShader,Object> DEFS = PropertyMap.makeDefaultMap(PShader.class,TEMPLATE_VERTEX,
+			TEMPLATE_FRAGMENT,"GLSLES",true);
 
 	public Shader()
 		{

--- a/org/lateralgm/resources/shader_template.frag
+++ b/org/lateralgm/resources/shader_template.frag
@@ -1,0 +1,12 @@
+/**
+ * A simple passthrough fragment shader for GLSLES version 100.
+ * @author John Doe
+ */
+
+varying vec2 v_TextureCoord;
+varying vec4 v_Colour;
+
+void main() {
+    // write the fragment color by combining vertex color and texture
+    gl_FragColor = v_Colour * texture2D(gm_BaseTexture, v_TextureCoord);
+}

--- a/org/lateralgm/resources/shader_template.frag
+++ b/org/lateralgm/resources/shader_template.frag
@@ -7,6 +7,6 @@ varying vec2 v_TextureCoord;
 varying vec4 v_Colour;
 
 void main() {
-    // write the fragment color by combining vertex color and texture
-    gl_FragColor = v_Colour * texture2D(gm_BaseTexture, v_TextureCoord);
+	// write the fragment color by combining vertex color and texture
+	gl_FragColor = v_Colour * texture2D(gm_BaseTexture, v_TextureCoord);
 }

--- a/org/lateralgm/resources/shader_template.vert
+++ b/org/lateralgm/resources/shader_template.vert
@@ -1,0 +1,21 @@
+/**
+ * A simple passthrough vertex shader for GLSLES version 100.
+ * @author John Doe
+ */
+
+attribute vec2 in_Position;       //< (x,y)
+attribute vec2 in_TextureCoord;   //< (u,v)
+attribute vec4 in_Colour;         //< (r,g,b,a)
+
+varying vec2 v_TextureCoord;
+varying vec4 v_Colour;
+
+void main() {
+    // transform the vertex coordinates to screen space
+    vec4 model_pos = vec4(in_Position.x, in_Position.y, 1.0, 1.0);
+    gl_Position = gm_Matrices[MATRIX_WORLD_VIEW_PROJECTION] * model_pos;
+
+    // pass the texture coords and color through to the fragment shader
+    v_TextureCoord = in_TextureCoord;
+    v_Colour = in_Colour;
+}

--- a/org/lateralgm/resources/shader_template.vert
+++ b/org/lateralgm/resources/shader_template.vert
@@ -11,11 +11,11 @@ varying vec2 v_TextureCoord;
 varying vec4 v_Colour;
 
 void main() {
-    // transform the vertex coordinates to screen space
-    vec4 model_pos = vec4(in_Position.x, in_Position.y, 1.0, 1.0);
-    gl_Position = gm_Matrices[MATRIX_WORLD_VIEW_PROJECTION] * model_pos;
+	// transform the vertex coordinates to screen space
+	vec4 model_pos = vec4(in_Position.x, in_Position.y, 1.0, 1.0);
+	gl_Position = gm_Matrices[MATRIX_WORLD_VIEW_PROJECTION] * model_pos;
 
-    // pass the texture coords and color through to the fragment shader
-    v_TextureCoord = in_TextureCoord;
-    v_Colour = in_Colour;
+	// pass the texture coords and color through to the fragment shader
+	v_TextureCoord = in_TextureCoord;
+	v_Colour = in_Colour;
 }


### PR DESCRIPTION
Idea here is simple, provide an actual template of source code when a new shader is created. GameMaker Studio has always done this and I think it's a good idea. It helps novice users pick up shaders easier by giving them a working one out of the box without having to scrape for the details alone. It also saves advanced users some time by not having them write the same basic outline for every new shader.

A couple of critical decisions were made here. The first is that I decided to put the shader template in a separate file in the jar rather than inlined in the Java class source. This way users can override it themselves. I made the static class variables public so plugins can also override the template to provide a shader that better matches their runtime. The template uses tabs, since JoshEdit has an option to convert those to spaces, so it can accommodate both. Finally, the shader template is a GLSLES version 100 shader since it's the lowest common denominator for cross-platform development. GameMaker Studio made the same decision and is probably transpiling from GLSLES, and that's why we should target it.