### PR TITLE
Fix Double Cast Warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ branches:
     - "master"
 # obviously this is java duh
 language: java
+jdk:
+  - oraclejdk8
 
 os: linux
 dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ branches:
 # obviously this is java duh
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 os: linux
 dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ branches:
     - "master"
 # obviously this is java duh
 language: java
-jdk:
-  - openjdk8
 
 os: linux
 dist: xenial

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -131,7 +131,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.218"; //$NON-NLS-1$
+	public static final String version = "1.8.219"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/ui/swing/visuals/RoomVisual.java
+++ b/org/lateralgm/ui/swing/visuals/RoomVisual.java
@@ -600,9 +600,9 @@ public class RoomVisual extends AbstractVisual implements BoundedVisual,UpdateLi
 	@SuppressWarnings("unchecked")
 	private static <P extends Piece, V extends PieceVisual<P>>Class<V> getVisualClass(Class<P> p)
 		{
-		if (p == Piece.class) return (Class<V>)(Class<?>) PieceVisual.class;
-		if (p == Instance.class) return (Class<V>)(Class<?>) InstanceVisual.class;
-		if (p == Tile.class) return (Class<V>)(Class<?>) TileVisual.class;
+		if (p == Piece.class) return (Class<V>) (Class<?>) PieceVisual.class;
+		if (p == Instance.class) return (Class<V>) (Class<?>) InstanceVisual.class;
+		if (p == Tile.class) return (Class<V>) (Class<?>) TileVisual.class;
 		throw new IllegalArgumentException();
 		}
 

--- a/org/lateralgm/ui/swing/visuals/RoomVisual.java
+++ b/org/lateralgm/ui/swing/visuals/RoomVisual.java
@@ -600,9 +600,9 @@ public class RoomVisual extends AbstractVisual implements BoundedVisual,UpdateLi
 	@SuppressWarnings("unchecked")
 	private static <P extends Piece, V extends PieceVisual<P>>Class<V> getVisualClass(Class<P> p)
 		{
-		if (p == Piece.class) return (Class<V>) PieceVisual.class;
-		if (p == Instance.class) return (Class<V>) InstanceVisual.class;
-		if (p == Tile.class) return (Class<V>) TileVisual.class;
+		if (p == Piece.class) return (Class<V>) (Class<?>) PieceVisual.class;
+		if (p == Instance.class) return (Class<V>) (Class<?>) InstanceVisual.class;
+		if (p == Tile.class) return (Class<V>) (Class<?>) TileVisual.class;
 		throw new IllegalArgumentException();
 		}
 

--- a/org/lateralgm/ui/swing/visuals/RoomVisual.java
+++ b/org/lateralgm/ui/swing/visuals/RoomVisual.java
@@ -600,9 +600,9 @@ public class RoomVisual extends AbstractVisual implements BoundedVisual,UpdateLi
 	@SuppressWarnings("unchecked")
 	private static <P extends Piece, V extends PieceVisual<P>>Class<V> getVisualClass(Class<P> p)
 		{
-		if (p == Piece.class) return (Class<V>) (Class) PieceVisual.class;
-		if (p == Instance.class) return (Class<V>) (Class) InstanceVisual.class;
-		if (p == Tile.class) return (Class<V>) (Class) TileVisual.class;
+		if (p == Piece.class) return (Class<V>) PieceVisual.class;
+		if (p == Instance.class) return (Class<V>) InstanceVisual.class;
+		if (p == Tile.class) return (Class<V>) TileVisual.class;
 		throw new IllegalArgumentException();
 		}
 

--- a/org/lateralgm/ui/swing/visuals/RoomVisual.java
+++ b/org/lateralgm/ui/swing/visuals/RoomVisual.java
@@ -600,9 +600,9 @@ public class RoomVisual extends AbstractVisual implements BoundedVisual,UpdateLi
 	@SuppressWarnings("unchecked")
 	private static <P extends Piece, V extends PieceVisual<P>>Class<V> getVisualClass(Class<P> p)
 		{
-		if (p == Piece.class) return (Class<V>) (Class<?>) PieceVisual.class;
-		if (p == Instance.class) return (Class<V>) (Class<?>) InstanceVisual.class;
-		if (p == Tile.class) return (Class<V>) (Class<?>) TileVisual.class;
+		if (p == Piece.class) return (Class<V>) PieceVisual.class;
+		if (p == Instance.class) return (Class<V>) InstanceVisual.class;
+		if (p == Tile.class) return (Class<V>) TileVisual.class;
 		throw new IllegalArgumentException();
 		}
 

--- a/org/lateralgm/ui/swing/visuals/RoomVisual.java
+++ b/org/lateralgm/ui/swing/visuals/RoomVisual.java
@@ -600,9 +600,9 @@ public class RoomVisual extends AbstractVisual implements BoundedVisual,UpdateLi
 	@SuppressWarnings("unchecked")
 	private static <P extends Piece, V extends PieceVisual<P>>Class<V> getVisualClass(Class<P> p)
 		{
-		if (p == Piece.class) return (Class<V>) PieceVisual.class;
-		if (p == Instance.class) return (Class<V>) InstanceVisual.class;
-		if (p == Tile.class) return (Class<V>) TileVisual.class;
+		if (p == Piece.class) return (Class<V>)(Class<?>) PieceVisual.class;
+		if (p == Instance.class) return (Class<V>)(Class<?>) InstanceVisual.class;
+		if (p == Tile.class) return (Class<V>)(Class<?>) TileVisual.class;
 		throw new IllegalArgumentException();
 		}
 


### PR DESCRIPTION
Continued from #387 to fix three of the following warnings related to generic casting of piece visual classes. Alternative to simply suppressing the warning, is to just cast it to the generic capture before casting to the actual return type.

>Class is a raw type. References to generic type Class<T> should be parameterized	RoomVisual.java	/LateralGM/org/lateralgm/ui/swing/visuals	line 603	Java Problem
