### PR TITLE
General Game Settings

### DIFF
--- a/org/lateralgm/file/GMXFileReader.java
+++ b/org/lateralgm/file/GMXFileReader.java
@@ -423,6 +423,15 @@ public final class GMXFileReader
 				Document setdoc = GMXFileReader.parseDocumentChecked(c.f, path + ".config.gmx"); //$NON-NLS-1$
 				if (setdoc == null) continue;
 
+				pSet.put(PGameSettings.USE_NEW_AUDIO,
+						Boolean.parseBoolean(setdoc.getElementsByTagName("option_use_new_audio").item(0).getTextContent())); //$NON-NLS-1$
+				pSet.put(PGameSettings.SHORT_CIRCUIT_EVAL,
+						Boolean.parseBoolean(setdoc.getElementsByTagName("option_shortcircuit").item(0).getTextContent())); //$NON-NLS-1$
+				pSet.put(PGameSettings.USE_FAST_COLLISION,
+						Boolean.parseBoolean(setdoc.getElementsByTagName("option_use_fast_collision").item(0).getTextContent())); //$NON-NLS-1$
+				pSet.put(PGameSettings.FAST_COLLISION_COMPAT,
+						Boolean.parseBoolean(setdoc.getElementsByTagName("option_fast_collision_compatibility").item(0).getTextContent())); //$NON-NLS-1$
+
 				pSet.put(
 						PGameSettings.START_FULLSCREEN,
 						Boolean.parseBoolean(setdoc.getElementsByTagName("option_fullscreen").item(0).getTextContent())); //$NON-NLS-1$

--- a/org/lateralgm/file/GMXFileWriter.java
+++ b/org/lateralgm/file/GMXFileWriter.java
@@ -441,6 +441,15 @@ public final class GMXFileWriter
 				}
 			optNode.appendChild(createElement(doc,"option_sync_vertex",Long.toString(syncvertex))); //$NON-NLS-1$
 
+			optNode.appendChild(createElement(doc,"option_use_new_audio", //$NON-NLS-1$
+					gs.get(PGameSettings.USE_NEW_AUDIO).toString()));
+			optNode.appendChild(createElement(doc,"option_shortcircuit", //$NON-NLS-1$
+					gs.get(PGameSettings.SHORT_CIRCUIT_EVAL).toString()));
+			optNode.appendChild(createElement(doc,"option_use_fast_collision", //$NON-NLS-1$
+					gs.get(PGameSettings.USE_FAST_COLLISION).toString()));
+			optNode.appendChild(createElement(doc,"option_fast_collision_compatibility", //$NON-NLS-1$
+					gs.get(PGameSettings.FAST_COLLISION_COMPAT).toString()));
+
 			optNode.appendChild(createElement(doc,"option_fullscreen", //$NON-NLS-1$
 					gs.get(PGameSettings.START_FULLSCREEN).toString()));
 			optNode.appendChild(createElement(doc,"option_sizeable", //$NON-NLS-1$

--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -131,7 +131,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.221"; //$NON-NLS-1$
+	public static final String version = "1.8.222"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/messages/messages.properties
+++ b/org/lateralgm/messages/messages.properties
@@ -791,13 +791,13 @@ GameSettingFrame.BUTTON_SAVE=Save
 GameSettingFrame.BUTTON_DISCARD=Cancel
 
 #General tab
+GameSettingFrame.TAB_GENERAL=General
 GameSettingFrame.USE_NEW_AUDIO=Use New Audio Engine
 GameSettingFrame.SHORT_CIRCUIT_EVAL=Short-Circuit evaluations
 GameSettingFrame.USE_FAST_COLLISION=Use Fast Collision System
 GameSettingFrame.FAST_COLLISION_COMPAT=Fast Collision System Compatibility Mode
 
 #Graphics tab
-GameSettingFrame.TAB_GENERAL=General
 GameSettingFrame.TAB_GRAPHICS=Graphics
 GameSettingFrame.HINT_GRAPHICS=Configure Graphics settings
 GameSettingFrame.FULLSCREEN=Start in fullscreen mode

--- a/org/lateralgm/messages/messages.properties
+++ b/org/lateralgm/messages/messages.properties
@@ -790,7 +790,14 @@ GameSettingFrame.TITLE=Game Settings
 GameSettingFrame.BUTTON_SAVE=Save
 GameSettingFrame.BUTTON_DISCARD=Cancel
 
+#General tab
+GameSettingFrame.USE_NEW_AUDIO=Use New Audio Engine
+GameSettingFrame.SHORT_CIRCUIT_EVAL=Short-Circuit evaluations
+GameSettingFrame.USE_FAST_COLLISION=Use Fast Collision System
+GameSettingFrame.FAST_COLLISION_COMPAT=Fast Collision System Compatibility Mode
+
 #Graphics tab
+GameSettingFrame.TAB_GENERAL=General
 GameSettingFrame.TAB_GRAPHICS=Graphics
 GameSettingFrame.HINT_GRAPHICS=Configure Graphics settings
 GameSettingFrame.FULLSCREEN=Start in fullscreen mode

--- a/org/lateralgm/messages/messages_da_DK.properties
+++ b/org/lateralgm/messages/messages_da_DK.properties
@@ -451,6 +451,13 @@ GameSettingFrame.TITLE=Spilindstillinger
 GameSettingFrame.BUTTON_SAVE=Gem
 GameSettingFrame.BUTTON_DISCARD=Gem ikke
 
+#General tab
+GameSettingFrame.TAB_GENERAL=Generel
+GameSettingFrame.USE_NEW_AUDIO=Brug ny lydmotor
+GameSettingFrame.SHORT_CIRCUIT_EVAL=Kortslutningsevalueringer
+GameSettingFrame.USE_FAST_COLLISION=Brug Hurtigt kollisionssystem
+GameSettingFrame.FAST_COLLISION_COMPAT=System med hurtig kollisionskompatibilitet
+
 #Graphics tab
 GameSettingFrame.TAB_GRAPHICS=Grafik
 GameSettingFrame.HINT_GRAPHICS=Konfigurér grafikindstillingerne

--- a/org/lateralgm/messages/messages_fr.properties
+++ b/org/lateralgm/messages/messages_fr.properties
@@ -442,6 +442,13 @@ GameSettingFrame.TITLE=Paramètres de jeu
 GameSettingFrame.BUTTON_SAVE=Enregistrer
 GameSettingFrame.BUTTON_DISCARD=Annuler
 
+#General tab
+GameSettingFrame.TAB_GENERAL=Général
+GameSettingFrame.USE_NEW_AUDIO=Utiliser un nouveau moteur audio
+GameSettingFrame.SHORT_CIRCUIT_EVAL=Évaluations de court-circuit
+GameSettingFrame.USE_FAST_COLLISION=Utiliser le système de collision rapide
+GameSettingFrame.FAST_COLLISION_COMPAT=Mode de compatibilité du système de collision rapide
+
 #Graphics tab
 GameSettingFrame.TAB_GRAPHICS=Graphiques
 GameSettingFrame.HINT_GRAPHICS=Configurer les paramètres graphiques

--- a/org/lateralgm/messages/messages_tr_TR.properties
+++ b/org/lateralgm/messages/messages_tr_TR.properties
@@ -449,6 +449,13 @@ GameSettingFrame.TITLE=Oyun ayarlarý
 GameSettingFrame.BUTTON_SAVE=Kaydet
 GameSettingFrame.BUTTON_DISCARD=Kaydetme
 
+#General tab
+GameSettingFrame.TAB_GENERAL=Genel
+GameSettingFrame.USE_NEW_AUDIO=Yeni Ses Motorunu Kullan
+GameSettingFrame.SHORT_CIRCUIT_EVAL=K\u0131sa Devre de\u011Ferlendirmeleri
+GameSettingFrame.USE_FAST_COLLISION=H\u0131zl\u0131 Çarp\u0131\u015Fma Sistemini Kullan\u0131n
+GameSettingFrame.FAST_COLLISION_COMPAT=H\u0131zl\u0131 Çarp\u0131\u015Fma Sistemi Uyumluluk Modu
+
 #Graphics tab
 GameSettingFrame.TAB_GRAPHICS=Grafikler
 GameSettingFrame.HINT_GRAPHICS=Grafik Ayarlarýný Düzenle

--- a/org/lateralgm/messages/messages_zh_CN.properties
+++ b/org/lateralgm/messages/messages_zh_CN.properties
@@ -705,9 +705,16 @@ PreferencesFrame.EXTENSIONS=\u6587\u4ef6\u6269\u5c55\u540d
 PreferencesFrame.EXTENSION_FORMAT={0}:
 
 #Global Game Settings
-GameSettingFrame.TITLE=Game Settings
+GameSettingFrame.TITLE=\u6E38\u620F\u8BBE\u7F6E
 GameSettingFrame.BUTTON_SAVE=\u4fdd\u5b58
 GameSettingFrame.BUTTON_DISCARD=\u53d6\u6d88
+
+#General tab
+GameSettingFrame.TAB_GENERAL=\u4E00\u822C\u7684
+GameSettingFrame.USE_NEW_AUDIO=\u4F7F\u7528\u65B0\u7684\u97F3\u9891\u5F15\u64CE
+GameSettingFrame.SHORT_CIRCUIT_EVAL=\u77ED\u8DEF\u8BC4\u4F30
+GameSettingFrame.USE_FAST_COLLISION=\u4F7F\u7528\u5FEB\u901F\u78B0\u649E\u7CFB\u7EDF
+GameSettingFrame.FAST_COLLISION_COMPAT=\u5FEB\u901F\u78B0\u649E\u7CFB\u7EDF\u517C\u5BB9\u6A21\u5F0F
 
 #Graphics tab
 GameSettingFrame.TAB_GRAPHICS=\u56fe\u50cf

--- a/org/lateralgm/resources/GameSettings.java
+++ b/org/lateralgm/resources/GameSettings.java
@@ -91,7 +91,8 @@ public class GameSettings extends Resource<GameSettings,GameSettings.PGameSettin
 		DISPLAY_ERRORS,WRITE_TO_LOG,ABORT_ON_ERROR,TREAT_UNINIT_AS_0,ERROR_ON_ARGS,AUTHOR,VERSION,
 		LAST_CHANGED,INFORMATION,/**/
 		INCLUDE_FOLDER,OVERWRITE_EXISTING,REMOVE_AT_GAME_END,VERSION_MAJOR,VERSION_MINOR,
-		VERSION_RELEASE,VERSION_BUILD,COMPANY,PRODUCT,COPYRIGHT,DESCRIPTION,GAME_ICON
+		VERSION_RELEASE,VERSION_BUILD,COMPANY,PRODUCT,COPYRIGHT,DESCRIPTION,GAME_ICON,
+		USE_NEW_AUDIO,SHORT_CIRCUIT_EVAL,USE_FAST_COLLISION,FAST_COLLISION_COMPAT
 		}
 
 	//GAME_ID and  DPLAY_GUID randomized in GmFile constructor
@@ -102,7 +103,8 @@ public class GameSettings extends Resource<GameSettings,GameSettings.PGameSettin
 			true,ProgressBar.DEFAULT,null,null,false,null,false,255,true,/**/
 			true,false,false,false,true,
 			"","100",ProjectFile.longTimeToGmTime(System.currentTimeMillis()),"",/**///$NON-NLS-1$ //$NON-NLS-3$
-			IncludeFolder.MAIN,false,false,1,0,0,0,"","","","",DEFAULT_ICON); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+			IncludeFolder.MAIN,false,false,1,0,0,0,"","","","",DEFAULT_ICON, //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+			true,true,false,false); 
 
 	@Override
 	public GameSettings makeInstance(ResourceReference<GameSettings> ref)

--- a/org/lateralgm/subframes/GameSettingFrame.java
+++ b/org/lateralgm/subframes/GameSettingFrame.java
@@ -90,11 +90,71 @@ public class GameSettingFrame extends ResourceFrame<GameSettings,PGameSettings>
 	boolean imagesChanged = false;
 	public JPanel cardPane;
 
+	public NumberField gameId;
+	public JButton randomise;
+	public ColorSelect colorbutton;
+
+	private JPanel makeGeneralPane()
+		{
+		JPanel panel = new JPanel();
+		GroupLayout layout = new GroupLayout(panel);
+		layout.setAutoCreateGaps(true);
+		layout.setAutoCreateContainerGaps(true);
+		panel.setLayout(layout);
+
+		JLabel backcolor = new JLabel(Messages.getString("GameSettingFrame.BACKCOLOR")); //$NON-NLS-1$
+		plf.make(colorbutton = new ColorSelect(),PGameSettings.COLOR_OUTSIDE_ROOM);
+
+		JCheckBox useNewAudio = new JCheckBox(Messages.getString("GameSettingFrame.USE_NEW_AUDIO")); //$NON-NLS-1$
+		plf.make(useNewAudio,PGameSettings.USE_NEW_AUDIO);
+		JCheckBox shortCircuitEval = new JCheckBox(Messages.getString("GameSettingFrame.SHORT_CIRCUIT_EVAL")); //$NON-NLS-1$
+		plf.make(shortCircuitEval,PGameSettings.SHORT_CIRCUIT_EVAL);
+		JCheckBox useFastCollision = new JCheckBox(Messages.getString("GameSettingFrame.USE_FAST_COLLISION")); //$NON-NLS-1$
+		plf.make(useFastCollision,PGameSettings.USE_FAST_COLLISION);
+		JCheckBox fastCollisionCompat = new JCheckBox(Messages.getString("GameSettingFrame.FAST_COLLISION_COMPAT")); //$NON-NLS-1$
+		plf.make(fastCollisionCompat,PGameSettings.FAST_COLLISION_COMPAT);
+
+		JLabel lId = new JLabel(Messages.getString("GameSettingFrame.GAME_ID")); //$NON-NLS-1$
+		gameId = new NumberField(0,100000000);
+		plf.make(gameId,PGameSettings.GAME_ID);
+		randomise = new JButton(Messages.getString("GameSettingFrame.RANDOMIZE")); //$NON-NLS-1$
+		randomise.addActionListener(this);
+
+		layout.setHorizontalGroup(layout.createParallelGroup()
+		/**/.addGroup(layout.createSequentialGroup()
+		/*		*/.addGroup(layout.createParallelGroup()
+		/*				*/.addGroup(layout.createSequentialGroup()
+		/*						*/.addComponent(lId)
+		/*						*/.addComponent(gameId,DEFAULT_SIZE,DEFAULT_SIZE,PREFERRED_SIZE)))
+		/*		*/.addGroup(layout.createParallelGroup()
+		/*				*/.addComponent(randomise,DEFAULT_SIZE,DEFAULT_SIZE,MAX_VALUE)))
+		/**/.addGroup(layout.createSequentialGroup()
+		/*	*/.addComponent(backcolor)
+		/*	*/.addComponent(colorbutton))
+		/**/.addComponent(useNewAudio)
+		/**/.addComponent(shortCircuitEval)
+		/**/.addComponent(useFastCollision)
+		/**/.addComponent(fastCollisionCompat));
+		layout.setVerticalGroup(layout.createSequentialGroup()
+		/**/.addGroup(layout.createParallelGroup(Alignment.BASELINE)
+		/*		*/.addComponent(lId)
+		/*		*/.addComponent(gameId)
+		/*		*/.addComponent(randomise))
+		/**/.addGroup(layout.createParallelGroup(Alignment.BASELINE,false)
+		/*	*/.addComponent(backcolor)
+		/*	*/.addComponent(colorbutton))
+		/**/.addComponent(useNewAudio)
+		/**/.addComponent(shortCircuitEval)
+		/**/.addComponent(useFastCollision)
+		/**/.addComponent(fastCollisionCompat));
+
+		return panel;
+		}
+
 	public JCheckBox startFullscreen;
 	public IndexButtonGroup scaling;
 	public NumberField scale;
 	public JCheckBox interpolatecolors;
-	public ColorSelect colorbutton;
 	public JCheckBox resizeWindow;
 	public JCheckBox stayOnTop;
 	public JCheckBox noWindowBorder;
@@ -151,9 +211,6 @@ public class GameSettingFrame extends ResourceFrame<GameSettings,PGameSettings>
 		t = Messages.getString("GameSettingFrame.INTERPOLATE"); //$NON-NLS-1$
 		plf.make(interpolatecolors = new JCheckBox(t),PGameSettings.INTERPOLATE);
 
-		JLabel backcolor = new JLabel(Messages.getString("GameSettingFrame.BACKCOLOR")); //$NON-NLS-1$
-		plf.make(colorbutton = new ColorSelect(),PGameSettings.COLOR_OUTSIDE_ROOM);
-
 		resizeWindow = new JCheckBox(Messages.getString("GameSettingFrame.RESIZE")); //$NON-NLS-1$
 		stayOnTop = new JCheckBox(Messages.getString("GameSettingFrame.STAYONTOP")); //$NON-NLS-1$
 		noWindowBorder = new JCheckBox(Messages.getString("GameSettingFrame.NOBORDER")); //$NON-NLS-1$
@@ -178,9 +235,6 @@ public class GameSettingFrame extends ResourceFrame<GameSettings,PGameSettings>
 		/**/.addComponent(startFullscreen)
 		/**/.addComponent(scalegroup)
 		/**/.addComponent(interpolatecolors)
-		/**/.addGroup(layout.createSequentialGroup()
-		/*	*/.addComponent(backcolor)
-		/*	*/.addComponent(colorbutton))
 		/**/.addComponent(resizeWindow)
 		/**/.addComponent(stayOnTop)
 		/**/.addComponent(noWindowBorder)
@@ -193,9 +247,6 @@ public class GameSettingFrame extends ResourceFrame<GameSettings,PGameSettings>
 		/**/.addComponent(startFullscreen)
 		/**/.addComponent(scalegroup)
 		/**/.addComponent(interpolatecolors)
-		/**/.addGroup(layout.createParallelGroup(Alignment.BASELINE,false)
-		/*	*/.addComponent(backcolor)
-		/*	*/.addComponent(colorbutton))
 		/**/.addComponent(resizeWindow)
 		/**/.addComponent(stayOnTop)
 		/**/.addComponent(noWindowBorder)
@@ -359,8 +410,6 @@ public class GameSettingFrame extends ResourceFrame<GameSettings,PGameSettings>
 	public BufferedImage backLoadImage;
 	public BufferedImage frontLoadImage;
 	public JCheckBox scaleProgressBar;
-	public NumberField gameId;
-	public JButton randomise;
 
 	private JPanel makeLoadingPane()
 		{
@@ -452,29 +501,13 @@ public class GameSettingFrame extends ResourceFrame<GameSettings,PGameSettings>
 
 		JFileChooser fc = new JFileChooser();
 		fc.setFileFilter(new CustomFileFilter(Messages.getString("GameSettingFrame.ICO_FILES"),".ico")); //$NON-NLS-1$ //$NON-NLS-2$
-		JLabel lId = new JLabel(Messages.getString("GameSettingFrame.GAME_ID")); //$NON-NLS-1$
-		gameId = new NumberField(0,100000000);
-		plf.make(gameId,PGameSettings.GAME_ID);
-		randomise = new JButton(Messages.getString("GameSettingFrame.RANDOMIZE")); //$NON-NLS-1$
-		randomise.addActionListener(this);
 
 		layout.setHorizontalGroup(layout.createParallelGroup()
 		/**/.addComponent(loadImage,DEFAULT_SIZE,DEFAULT_SIZE,MAX_VALUE)
-		/**/.addComponent(progBar,DEFAULT_SIZE,DEFAULT_SIZE,MAX_VALUE)
-		/**/.addGroup(layout.createSequentialGroup()
-		/*		*/.addGroup(layout.createParallelGroup()
-		/*				*/.addGroup(layout.createSequentialGroup()
-		/*						*/.addComponent(lId)
-		/*						*/.addComponent(gameId,DEFAULT_SIZE,DEFAULT_SIZE,PREFERRED_SIZE)))
-		/*		*/.addGroup(layout.createParallelGroup()
-		/*				*/.addComponent(randomise,DEFAULT_SIZE,DEFAULT_SIZE,MAX_VALUE))));
+		/**/.addComponent(progBar,DEFAULT_SIZE,DEFAULT_SIZE,MAX_VALUE));
 		layout.setVerticalGroup(layout.createSequentialGroup()
 		/**/.addComponent(loadImage)
-		/**/.addComponent(progBar)
-		/**/.addGroup(layout.createParallelGroup(Alignment.BASELINE)
-		/*		*/.addComponent(lId)
-		/*		*/.addComponent(gameId)
-		/*		*/.addComponent(randomise)));
+		/**/.addComponent(progBar));
 		return panel;
 		}
 
@@ -868,20 +901,21 @@ public class GameSettingFrame extends ResourceFrame<GameSettings,PGameSettings>
 		{
 		cardPane = new JPanel(new CardLayout());
 
-		buildTab(root, "GameSettingFrame.TAB_GRAPHICS", makeGraphicsPane());
-		buildTab(root, "GameSettingFrame.TAB_RESOLUTION", makeResolutionPane());
-		buildTab(root, "GameSettingFrame.TAB_OTHER", makeOtherPane());
-		buildTab(root, "GameSettingFrame.TAB_LOADING", makeLoadingPane());
-		buildTab(root, "GameSettingFrame.TAB_INCLUDE", makeIncludePane());
-		buildTab(root, "GameSettingFrame.TAB_ERRORS", makeErrorPane());
-		buildTab(root, "GameSettingFrame.TAB_INFO", makeInfoPane());
-		buildTab(root, "GameSettingFrame.TAB_TEXTUREATLASES", makeTextureAtlasesPane());
+		buildTab(root, "GameSettingFrame.TAB_GENERAL", makeGeneralPane()); //$NON-NLS-1$
+		buildTab(root, "GameSettingFrame.TAB_GRAPHICS", makeGraphicsPane()); //$NON-NLS-1$
+		buildTab(root, "GameSettingFrame.TAB_RESOLUTION", makeResolutionPane()); //$NON-NLS-1$
+		buildTab(root, "GameSettingFrame.TAB_OTHER", makeOtherPane()); //$NON-NLS-1$
+		buildTab(root, "GameSettingFrame.TAB_LOADING", makeLoadingPane()); //$NON-NLS-1$
+		buildTab(root, "GameSettingFrame.TAB_INCLUDE", makeIncludePane()); //$NON-NLS-1$
+		buildTab(root, "GameSettingFrame.TAB_ERRORS", makeErrorPane()); //$NON-NLS-1$
+		buildTab(root, "GameSettingFrame.TAB_INFO", makeInfoPane()); //$NON-NLS-1$
+		buildTab(root, "GameSettingFrame.TAB_TEXTUREATLASES", makeTextureAtlasesPane()); //$NON-NLS-1$
 
-		DefaultMutableTreeNode pnode = buildTab(root, "GameSettingFrame.TAB_PLATFORMS", null);
+		DefaultMutableTreeNode pnode = buildTab(root, "GameSettingFrame.TAB_PLATFORMS", null); //$NON-NLS-1$
 
-		buildTab(pnode, "GameSettingFrame.TAB_WINDOWS", makeWindowsPane());
-		buildTab(pnode, "GameSettingFrame.TAB_MAC", null);
-		buildTab(pnode, "GameSettingFrame.TAB_UBUNTU", null);
+		buildTab(pnode, "GameSettingFrame.TAB_WINDOWS", makeWindowsPane()); //$NON-NLS-1$
+		buildTab(pnode, "GameSettingFrame.TAB_MAC", null); //$NON-NLS-1$
+		buildTab(pnode, "GameSettingFrame.TAB_UBUNTU", null); //$NON-NLS-1$
 		}
 
 	public void actionPerformed(ActionEvent e)
@@ -903,13 +937,17 @@ public class GameSettingFrame extends ResourceFrame<GameSettings,PGameSettings>
 			}
 		}
 		if (name == null) return;
-		if (name.endsWith(".TAB_GRAPHICS")) {
-			if (e.getSource() instanceof JRadioButton) scale.setEnabled(scaling.getValue() > 0);
-		} else if (name.endsWith(".TAB_RESOLUTION")) {
+		if (name.endsWith(".TAB_GENERAL")) { //$NON-NLS-1$
+			if (e.getSource() == randomise)
+				gameId.setValue(new Random().nextInt(100000001));
+		} if (name.endsWith(".TAB_GRAPHICS")) { //$NON-NLS-1$
+			if (e.getSource() instanceof JRadioButton)
+				scale.setEnabled(scaling.getValue() > 0);
+		} else if (name.endsWith(".TAB_RESOLUTION")) { //$NON-NLS-1$
 			resolutionPane.setVisible(setResolution.isSelected());
-		} else if (name.endsWith(".TAB_LOADING")) {
+		} else if (name.endsWith(".TAB_LOADING")) { //$NON-NLS-1$
 			loadActionPerformed(e);
-		} else if (name.endsWith(".TAB_WINDOWS")) {
+		} else if (name.endsWith(".TAB_WINDOWS")) { //$NON-NLS-1$
 			windowsActionPerformed(e);
 		}
 
@@ -983,10 +1021,6 @@ public class GameSettingFrame extends ResourceFrame<GameSettings,PGameSettings>
 				frontLoadImage = img;
 				imagesChanged = true;
 				}
-			}
-		else if (e.getSource() == randomise)
-			{
-			gameId.setValue(new Random().nextInt(100000001));
 			}
 		}
 


### PR DESCRIPTION
This adds a "General" tab to the game settings frame. This resolves the original part of #255 by adding the missing setting even though it does not entirely resolve the issue because there are still missing settings.

* Add "General" game settings tab.
* Add missing new audio engine/short-circuit eval/fast collision settings.
* Serialize/deserialize new settings in GMX reader.
* Move color outside window setting from graphics tab to new "General" tab.
* Move game id from loading tab to new "General" tab.
* Add missing localization comments in game settings frame.

![New General Game Settings Tab](https://user-images.githubusercontent.com/3212801/108443384-ac4d4180-7226-11eb-8d66-210a92b9d60d.png)
