### PR TITLE
Card Pane Association

### DIFF
--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -131,7 +131,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.222"; //$NON-NLS-1$
+	public static final String version = "1.8.223"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/main/PreferencesFrame.java
+++ b/org/lateralgm/main/PreferencesFrame.java
@@ -120,7 +120,7 @@ public class PreferencesFrame extends JDialog implements ActionListener
 			{
 			DefaultMutableTreeNode node = new DefaultMutableTreeNode(group.name);
 			root.add(node);
-			cardPane.add(group.makePanel(), group.name);
+			cardPane.add(group.makePanel(), Integer.toString(node.hashCode()));
 			}
 
 		//TODO: Fix UI bugs in JoshEdit repo and then use the serialize feature to save them.
@@ -161,20 +161,24 @@ public class PreferencesFrame extends JDialog implements ActionListener
 
 		tree.addTreeSelectionListener(new TreeSelectionListener()
 			{
-				public void valueChanged(TreeSelectionEvent e)
-					{
-					DefaultMutableTreeNode node =
-						(DefaultMutableTreeNode) tree.getLastSelectedPathComponent();
+			public void valueChanged(TreeSelectionEvent e)
+				{
+				// retrieve the node that was selected
+				DefaultMutableTreeNode node =
+					(DefaultMutableTreeNode) tree.getLastSelectedPathComponent();
 
-					/* if nothing is selected */
-					if (node == null) return;
+				// short-circuit if nothing is selected
+				if (node == null) return;
 
-					/* retrieve the node that was selected */
-					String nodeInfo = node.getUserObject().toString();
+				CardLayout cl = (CardLayout) (cardPane.getLayout());
 
-					CardLayout cl = (CardLayout) (cardPane.getLayout());
-					cl.show(cardPane,nodeInfo);
-					}
+				// show panel with same name as the node
+				String nodeInfo = node.getUserObject().toString();
+				cl.show(cardPane,nodeInfo);
+				// show card with node hash if name was not unique
+				nodeInfo = Integer.toString(node.hashCode());
+				cl.show(cardPane,nodeInfo);
+				}
 			});
 
 		JScrollPane scroll = new JScrollPane(tree);

--- a/org/lateralgm/subframes/GameSettingFrame.java
+++ b/org/lateralgm/subframes/GameSettingFrame.java
@@ -844,21 +844,27 @@ public class GameSettingFrame extends ResourceFrame<GameSettings,PGameSettings>
 		// reload after adding all root children to make sure its children are visible
 		((DefaultTreeModel)tree.getModel()).reload();
 
-		tree.addTreeSelectionListener(new TreeSelectionListener() {
-		public void valueChanged(TreeSelectionEvent e) {
+		tree.addTreeSelectionListener(new TreeSelectionListener()
+			{
+			public void valueChanged(TreeSelectionEvent e)
+				{
+				// retrieve the node that was selected
 				DefaultMutableTreeNode node = (DefaultMutableTreeNode)
 													 tree.getLastSelectedPathComponent();
-
-				// if nothing is selected
+	
+				// short-circuit if nothing is selected
 				if (node == null) return;
+	
+				CardLayout cl = (CardLayout) (cardPane.getLayout());
 
-				// retrieve the node that was selected
+				// show panel with same name as the node
 				String nodeInfo = node.getUserObject().toString();
-
-				CardLayout cl = (CardLayout)(cardPane.getLayout());
-				cl.show(cardPane, nodeInfo);
-			}
-		});
+				cl.show(cardPane,nodeInfo);
+				// show card with node hash if name was not unique
+				nodeInfo = Integer.toString(node.hashCode());
+				cl.show(cardPane,nodeInfo);
+				}
+			});
 
 		JSplitPane split = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT,true,
 				new JScrollPane(tree),cardPane);
@@ -892,7 +898,7 @@ public class GameSettingFrame extends ResourceFrame<GameSettings,PGameSettings>
 		root.add(node);
 		if (pane != null) {
 			pane.setName(key);
-			cardPane.add(Messages.getString(key),pane);
+			cardPane.add(pane,Integer.toString(node.hashCode()));
 		}
 		return node;
 	}


### PR DESCRIPTION
This fixes an issue that popped up in #547 without me having to patch the lgmplugin for ENIGMA right now. In #547 I added a "General" game settings panel, which was being confused with the ENIGMA "General" settings panel. This is my simple solution for now to first show the card with the same name as the selected tree node, then show the card whose name is a string of the tree node's hash code if that didn't show anything.

Now it's optional whether to give the card the tree node name or a name that is a string of the hash code of the tree node. All of LGM's main built-in panels opt for using the hash code as the string name of the card. This allows ENIGMA's panels to still be selected and not confused with the built-in LGM ones.