### PR TITLE
Property Link Factory Context

### DIFF
--- a/org/lateralgm/main/LGM.java
+++ b/org/lateralgm/main/LGM.java
@@ -128,7 +128,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageReaderSpi;
 
 public final class LGM
 	{
-	public static final String version = "1.8.228"; //$NON-NLS-1$
+	public static final String version = "1.8.229"; //$NON-NLS-1$
 
 	// TODO: This list holds the class loader for any loaded plugins which should be
 	// cleaned up and closed when the application closes.

--- a/org/lateralgm/subframes/FontFrame.java
+++ b/org/lateralgm/subframes/FontFrame.java
@@ -64,11 +64,9 @@ import org.lateralgm.resources.Font;
 import org.lateralgm.resources.Font.PFont;
 import org.lateralgm.resources.sub.CharacterRange;
 import org.lateralgm.resources.sub.CharacterRange.PCharacterRange;
-import org.lateralgm.ui.swing.propertylink.FormattedLink;
 import org.lateralgm.ui.swing.propertylink.PropertyLinkFactory;
 import org.lateralgm.ui.swing.propertylink.ComboBoxLink.IndexComboBoxConversion;
 import org.lateralgm.ui.swing.util.ArrayListModel;
-import org.lateralgm.util.PropertyLink;
 import org.lateralgm.util.PropertyMap.PropertyUpdateEvent;
 import org.lateralgm.util.PropertyMap.PropertyUpdateListener;
 
@@ -82,7 +80,7 @@ public class FontFrame extends InstantiableResourceFrame<Font,PFont> implements
 	public JCheckBox italic, bold;
 	public JComboBox<String> aa;
 	public NumberField charMin, charMax;
-	private FormattedLink<PCharacterRange> minLink, maxLink;
+	private PropertyLinkFactory<PCharacterRange> rplf;
 	public JEditorPane previewText;
 	public JTextArea previewRange;
 	private JMenuItem cutItem, copyItem, pasteItem, selAllItem;
@@ -591,15 +589,20 @@ public class FontFrame extends InstantiableResourceFrame<Font,PFont> implements
 		CharacterRange cr = rangeList.getSelectedValue();
 		if (lastRange == cr) return;
 		lastRange = cr;
-		PropertyLink.removeAll(minLink,maxLink);
-		if (cr != null)
+		if (cr == null)
 			{
-			PropertyLinkFactory<PCharacterRange> rplf = new PropertyLinkFactory<PCharacterRange>(
-					cr.properties,this);
-			this.addSecondaryPropertyLinkFactory(rplf);
-			minLink = rplf.make(charMin,PCharacterRange.RANGE_MIN);
-			maxLink = rplf.make(charMax,PCharacterRange.RANGE_MAX);
+			rplf.removeAllLinks();
 			}
+
+		if (rplf != null)
+			{
+			rplf.setMap(cr.properties);
+			return;
+			}
+		rplf = new PropertyLinkFactory<PCharacterRange>(cr.properties,this);
+		this.addSecondaryPropertyLinkFactory(rplf);
+		rplf.make(charMin,PCharacterRange.RANGE_MIN);
+		rplf.make(charMax,PCharacterRange.RANGE_MAX);
 		}
 
 	public void updated(UpdateEvent e)

--- a/org/lateralgm/subframes/FontFrame.java
+++ b/org/lateralgm/subframes/FontFrame.java
@@ -589,18 +589,20 @@ public class FontFrame extends InstantiableResourceFrame<Font,PFont> implements
 		CharacterRange cr = rangeList.getSelectedValue();
 		if (lastRange == cr) return;
 		lastRange = cr;
-		if (cr == null)
+
+		if (rplf == null)
+			{
+			if (cr == null) return;
+			rplf = new PropertyLinkFactory<PCharacterRange>(cr.properties,this);
+			this.addSecondaryPropertyLinkFactory(rplf);
+			}
+		else
 			{
 			rplf.removeAllLinks();
+			if (cr == null) return;
+			rplf.setMap(cr.properties);
 			}
 
-		if (rplf != null)
-			{
-			rplf.setMap(cr.properties);
-			return;
-			}
-		rplf = new PropertyLinkFactory<PCharacterRange>(cr.properties,this);
-		this.addSecondaryPropertyLinkFactory(rplf);
 		rplf.make(charMin,PCharacterRange.RANGE_MIN);
 		rplf.make(charMax,PCharacterRange.RANGE_MAX);
 		}

--- a/org/lateralgm/subframes/FontFrame.java
+++ b/org/lateralgm/subframes/FontFrame.java
@@ -105,6 +105,9 @@ public class FontFrame extends InstantiableResourceFrame<Font,PFont> implements
 		this.getRootPane().setDefaultButton(save);
 		((JComponent) getContentPane()).setBorder(new EmptyBorder(4,4,4,4));
 
+		rplf = new PropertyLinkFactory<PCharacterRange>(null,this);
+		this.addSecondaryPropertyLinkFactory(rplf);
+
 		propUpdateListener = new PropertyUpdateListener<PFont>()
 			{
 				public void updated(PropertyUpdateEvent<PFont> e)
@@ -590,18 +593,9 @@ public class FontFrame extends InstantiableResourceFrame<Font,PFont> implements
 		if (lastRange == cr) return;
 		lastRange = cr;
 
-		if (rplf == null)
-			{
-			if (cr == null) return;
-			rplf = new PropertyLinkFactory<PCharacterRange>(cr.properties,this);
-			this.addSecondaryPropertyLinkFactory(rplf);
-			}
-		else
-			{
-			rplf.removeAllLinks();
-			if (cr == null) return;
-			rplf.setMap(cr.properties);
-			}
+		rplf.removeAllLinks();
+		if (cr == null) return;
+		rplf.setMap(cr.properties);
 
 		rplf.make(charMin,PCharacterRange.RANGE_MIN);
 		rplf.make(charMax,PCharacterRange.RANGE_MAX);

--- a/org/lateralgm/subframes/PathFrame.java
+++ b/org/lateralgm/subframes/PathFrame.java
@@ -73,6 +73,8 @@ public class PathFrame extends InstantiableResourceFrame<Path,PPath>
 		pathEditor.properties.updateSource.addListener(pepl);
 		peplf = new PropertyLinkFactory<PPathEditor>(pathEditor.properties,this);
 		this.addSecondaryPropertyLinkFactory(peplf);
+		ppplf = new PropertyLinkFactory<PPathPoint>(null,null);
+		this.addSecondaryPropertyLinkFactory(ppplf);
 
 		GroupLayout layout = new GroupLayout(getContentPane())
 			{
@@ -318,18 +320,9 @@ public class PathFrame extends InstantiableResourceFrame<Path,PPath>
 				case SELECTED_POINT:
 					PathPoint pp = e.map.get(e.key);
 
-					if (ppplf == null)
-						{
-						if (pp == null) return;
-						ppplf = new PropertyLinkFactory<PPathPoint>(pp.properties,null);
-						PathFrame.this.addSecondaryPropertyLinkFactory(ppplf);
-						}
-					else
-						{
-						ppplf.removeAllLinks();
-						if (pp == null) return;
-						ppplf.setMap(pp.properties);
-						}
+					ppplf.removeAllLinks();
+					if (pp == null) return;
+					ppplf.setMap(pp.properties);
 
 					ppplf.make(tx,PPathPoint.X);
 					ppplf.make(ty,PPathPoint.Y);

--- a/org/lateralgm/subframes/PathFrame.java
+++ b/org/lateralgm/subframes/PathFrame.java
@@ -47,10 +47,8 @@ import org.lateralgm.resources.Path.PPath;
 import org.lateralgm.resources.Room;
 import org.lateralgm.resources.sub.PathPoint;
 import org.lateralgm.resources.sub.PathPoint.PPathPoint;
-import org.lateralgm.ui.swing.propertylink.FormattedLink;
 import org.lateralgm.ui.swing.propertylink.PropertyLinkFactory;
 import org.lateralgm.ui.swing.util.ArrayListModel;
-import org.lateralgm.util.PropertyLink;
 import org.lateralgm.util.PropertyMap.PropertyUpdateEvent;
 import org.lateralgm.util.PropertyMap.PropertyUpdateListener;
 
@@ -308,7 +306,7 @@ public class PathFrame extends InstantiableResourceFrame<Path,PPath>
 		super.actionPerformed(e);
 		}
 
-	FormattedLink<PPathPoint> ltx, lty, ltsp;
+	private PropertyLinkFactory<PPathPoint> ppplf;
 
 	private class PathEditorPropertyListener extends PropertyUpdateListener<PPathEditor>
 		{
@@ -318,23 +316,23 @@ public class PathFrame extends InstantiableResourceFrame<Path,PPath>
 			switch (e.key)
 				{
 				case SELECTED_POINT:
-					PropertyLink.removeAll(ltx,lty,ltsp);
 					PathPoint pp = e.map.get(e.key);
-					if (pp != null)
+					if (pp == null)
 						{
-						PropertyLinkFactory<PPathPoint> ppplf = new PropertyLinkFactory<PPathPoint>(
-								pp.properties,null);
-						PathFrame.this.addSecondaryPropertyLinkFactory(ppplf);
-						ltx = ppplf.make(tx,PPathPoint.X);
-						lty = ppplf.make(ty,PPathPoint.Y);
-						ltsp = ppplf.make(tsp,PPathPoint.SPEED);
+						ppplf.removeAllLinks();
+						return;
 						}
-					else
+
+					if (ppplf != null)
 						{
-						ltx = null;
-						lty = null;
-						ltsp = null;
+						ppplf.setMap(pp.properties);
+						return;
 						}
+					ppplf = new PropertyLinkFactory<PPathPoint>(pp.properties,null);
+					PathFrame.this.addSecondaryPropertyLinkFactory(ppplf);
+					ppplf.make(tx,PPathPoint.X);
+					ppplf.make(ty,PPathPoint.Y);
+					ppplf.make(tsp,PPathPoint.SPEED);
 					break;
 				default:
 					break;

--- a/org/lateralgm/subframes/PathFrame.java
+++ b/org/lateralgm/subframes/PathFrame.java
@@ -317,19 +317,20 @@ public class PathFrame extends InstantiableResourceFrame<Path,PPath>
 				{
 				case SELECTED_POINT:
 					PathPoint pp = e.map.get(e.key);
-					if (pp == null)
+
+					if (ppplf == null)
+						{
+						if (pp == null) return;
+						ppplf = new PropertyLinkFactory<PPathPoint>(pp.properties,null);
+						PathFrame.this.addSecondaryPropertyLinkFactory(ppplf);
+						}
+					else
 						{
 						ppplf.removeAllLinks();
-						return;
+						if (pp == null) return;
+						ppplf.setMap(pp.properties);
 						}
 
-					if (ppplf != null)
-						{
-						ppplf.setMap(pp.properties);
-						return;
-						}
-					ppplf = new PropertyLinkFactory<PPathPoint>(pp.properties,null);
-					PathFrame.this.addSecondaryPropertyLinkFactory(ppplf);
 					ppplf.make(tx,PPathPoint.X);
 					ppplf.make(ty,PPathPoint.Y);
 					ppplf.make(tsp,PPathPoint.SPEED);

--- a/org/lateralgm/subframes/ResourceFrame.java
+++ b/org/lateralgm/subframes/ResourceFrame.java
@@ -264,13 +264,13 @@ public abstract class ResourceFrame<R extends Resource<R,P>, P extends Enum<P>> 
 		if (node != null) node.frame = null; // allows a new frame to open
 		save.removeActionListener(this);
 		removeAll();
-		plf.clearAllLinks(); // << remove primary property links
+		plf.removeAllLinks(); // << remove primary property links
 		// remove secondary subresource based property links
 		for (WeakReference<PropertyLinkFactory<?>> wrs : plfSecondaries)
 			{
 			PropertyLinkFactory<?> plfSecondary = wrs.get();
 			if (plfSecondary == null) continue;
-			plfSecondary.clearAllLinks();
+			plfSecondary.removeAllLinks();
 			}
 		plfSecondaries.clear();
 		}

--- a/org/lateralgm/subframes/ResourceFrame.java
+++ b/org/lateralgm/subframes/ResourceFrame.java
@@ -264,13 +264,13 @@ public abstract class ResourceFrame<R extends Resource<R,P>, P extends Enum<P>> 
 		if (node != null) node.frame = null; // allows a new frame to open
 		save.removeActionListener(this);
 		removeAll();
-		plf.removeAllLinks(); // << remove primary property links
+		plf.clearAllLinks(); // << remove primary property links
 		// remove secondary subresource based property links
 		for (WeakReference<PropertyLinkFactory<?>> wrs : plfSecondaries)
 			{
 			PropertyLinkFactory<?> plfSecondary = wrs.get();
 			if (plfSecondary == null) continue;
-			plfSecondary.removeAllLinks();
+			plfSecondary.clearAllLinks();
 			}
 		plfSecondaries.clear();
 		}

--- a/org/lateralgm/subframes/RoomFrame.java
+++ b/org/lateralgm/subframes/RoomFrame.java
@@ -1890,6 +1890,10 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 		editor = new RoomEditor(res,this);
 		prelf = new PropertyLinkFactory<PRoomEditor>(editor.properties,null);
 		this.addSecondaryPropertyLinkFactory(prelf);
+		iplf = new PropertyLinkFactory<PInstance>(null,null);
+		this.addSecondaryPropertyLinkFactory(iplf);
+		tplf = new PropertyLinkFactory<PTile>(null,null);
+		this.addSecondaryPropertyLinkFactory(tplf);
 
 		GroupLayout layout = new GroupLayout(getContentPane())
 			{
@@ -2718,18 +2722,9 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 		if (lastObj == selectedInstance) return;
 		lastObj = selectedInstance;
 
-		if (iplf == null)
-			{
-			if (selectedInstance == null) return;
-			iplf = new PropertyLinkFactory<PInstance>(selectedInstance.properties,null);
-			this.addSecondaryPropertyLinkFactory(iplf);
-			}
-		else
-			{
-			iplf.removeAllLinks();
-			if (selectedInstance == null) return;
-			iplf.setMap(selectedInstance.properties);
-			}
+		iplf.removeAllLinks();
+		if (selectedInstance == null) return;
+		iplf.setMap(selectedInstance.properties);
 
 		iplf.make(oLocked,PInstance.LOCKED);
 		iplf.make(oSource,PInstance.OBJECT);
@@ -2760,18 +2755,9 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 		if (lastTile == selectedTile) return;
 		lastTile = selectedTile;
 
-		if (tplf == null)
-			{
-			if (selectedTile == null) return;
-			tplf = new PropertyLinkFactory<PTile>(selectedTile.properties,null);
-			this.addSecondaryPropertyLinkFactory(tplf);
-			}
-		else
-			{
-			tplf.removeAllLinks();
-			if (selectedTile == null) return;
-			tplf.setMap(selectedTile.properties);
-			}
+		tplf.removeAllLinks();
+		if (selectedTile == null) return;
+		tplf.setMap(selectedTile.properties);
 
 		tplf.make(teDepth,PTile.DEPTH);
 		tplf.make(tLocked,PTile.LOCKED);

--- a/org/lateralgm/subframes/RoomFrame.java
+++ b/org/lateralgm/subframes/RoomFrame.java
@@ -214,17 +214,14 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 	private final BgDefPropertyListener bdpl = new BgDefPropertyListener();
 	//Views
 	private JCheckBox vEnabled, vVisible;
-	private ButtonModelLink<PView> lvVisible;
 	private JList<JLabel> vList;
 	/**Guaranteed valid version of vList.getLastSelectedIndex()*/
 	private int lastValidView = -1;
+	private PropertyLinkFactory<PView> vplf;
 	private NumberField vRX, vRY, vRW, vRH;
 	private NumberField vPX, vPY, vPW, vPH;
-	private FormattedLink<PView> lvRX, lvRY, lvRW, lvRH, lvPX, lvPY, lvPW, lvPH;
 	private ResourceMenu<GmObject> vObj;
-	private PropertyLink<PView,ResourceReference<GmObject>> lvObj;
 	private NumberField vOHBor, vOVBor, vOHSp, vOVSp;
-	private FormattedLink<PView> lvOHBor, lvOVBor, lvOHSp, lvOVSp;
 	private final ViewPropertyListener vpl = new ViewPropertyListener();
 
 	private final PropertyLinkFactory<PRoomEditor> prelf;
@@ -2822,25 +2819,31 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 			return;
 			}
 		lastValidView = i;
-		PropertyLink.removeAll(lvVisible,lvRX,lvRY,lvRW,lvRH,lvPX,lvPY,lvPW,lvPH,lvObj,lvOHBor,lvOVBor,
-				lvOHSp,lvOVSp);
 		View view = res.views.get(i);
-		PropertyLinkFactory<PView> vplf = new PropertyLinkFactory<PView>(view.properties,this);
+
+		if (vplf != null)
+			{
+			vplf.setMap(view.properties);
+			return;
+			}
+
+		vplf = new PropertyLinkFactory<PView>(view.properties,this);
 		this.addSecondaryPropertyLinkFactory(vplf);
-		lvVisible = vplf.make(vVisible,PView.VISIBLE);
-		lvRX = vplf.make(vRX,PView.VIEW_X);
-		lvRY = vplf.make(vRY,PView.VIEW_Y);
-		lvRW = vplf.make(vRW,PView.VIEW_W);
-		lvRH = vplf.make(vRH,PView.VIEW_H);
-		lvPX = vplf.make(vPX,PView.PORT_X);
-		lvPY = vplf.make(vPY,PView.PORT_Y);
-		lvPW = vplf.make(vPW,PView.PORT_W);
-		lvPH = vplf.make(vPH,PView.PORT_H);
-		lvObj = vplf.make(vObj,PView.OBJECT);
-		lvOHBor = vplf.make(vOHBor,PView.BORDER_H);
-		lvOVBor = vplf.make(vOVBor,PView.BORDER_V);
-		lvOHSp = vplf.make(vOHSp,PView.SPEED_H);
-		lvOVSp = vplf.make(vOVSp,PView.SPEED_V);
+
+		vplf.make(vVisible,PView.VISIBLE);
+		vplf.make(vRX,PView.VIEW_X);
+		vplf.make(vRY,PView.VIEW_Y);
+		vplf.make(vRW,PView.VIEW_W);
+		vplf.make(vRH,PView.VIEW_H);
+		vplf.make(vPX,PView.PORT_X);
+		vplf.make(vPY,PView.PORT_Y);
+		vplf.make(vPW,PView.PORT_W);
+		vplf.make(vPH,PView.PORT_H);
+		vplf.make(vObj,PView.OBJECT);
+		vplf.make(vOHBor,PView.BORDER_H);
+		vplf.make(vOVBor,PView.BORDER_V);
+		vplf.make(vOHSp,PView.SPEED_H);
+		vplf.make(vOVSp,PView.SPEED_V);
 		}
 
 	// Display the selected tile with a border and centered in the editor window

--- a/org/lateralgm/subframes/RoomFrame.java
+++ b/org/lateralgm/subframes/RoomFrame.java
@@ -2717,20 +2717,20 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 		Instance selectedInstance = oList.getSelectedValue();
 		if (lastObj == selectedInstance) return;
 		lastObj = selectedInstance;
-		if (selectedInstance == null)
+
+		if (iplf == null)
+			{
+			if (selectedInstance == null) return;
+			iplf = new PropertyLinkFactory<PInstance>(selectedInstance.properties,null);
+			this.addSecondaryPropertyLinkFactory(iplf);
+			}
+		else
 			{
 			iplf.removeAllLinks();
-			return;
-			}
-
-		if (iplf != null)
-			{
+			if (selectedInstance == null) return;
 			iplf.setMap(selectedInstance.properties);
-			return;
 			}
 
-		iplf = new PropertyLinkFactory<PInstance>(selectedInstance.properties,this);
-		this.addSecondaryPropertyLinkFactory(iplf);
 		iplf.make(oLocked,PInstance.LOCKED);
 		iplf.make(oSource,PInstance.OBJECT);
 		iplf.make(objectName.getDocument(), PInstance.NAME);
@@ -2759,20 +2759,20 @@ public class RoomFrame extends InstantiableResourceFrame<Room,PRoom> implements
 		Tile selectedTile = tList.getSelectedValue();
 		if (lastTile == selectedTile) return;
 		lastTile = selectedTile;
-		if (selectedTile == null)
+
+		if (tplf == null)
+			{
+			if (selectedTile == null) return;
+			tplf = new PropertyLinkFactory<PTile>(selectedTile.properties,null);
+			this.addSecondaryPropertyLinkFactory(tplf);
+			}
+		else
 			{
 			tplf.removeAllLinks();
-			return;
-			}
-
-		if (tplf != null)
-			{
+			if (selectedTile == null) return;
 			tplf.setMap(selectedTile.properties);
-			return;
 			}
 
-		tplf = new PropertyLinkFactory<PTile>(selectedTile.properties,this);
-		this.addSecondaryPropertyLinkFactory(tplf);
 		tplf.make(teDepth,PTile.DEPTH);
 		tplf.make(tLocked,PTile.LOCKED);
 		tplf.make(teSource,PTile.BACKGROUND);

--- a/org/lateralgm/ui/swing/propertylink/PropertyLinkFactory.java
+++ b/org/lateralgm/ui/swing/propertylink/PropertyLinkFactory.java
@@ -35,13 +35,30 @@ public class PropertyLinkFactory<K extends Enum<K>>
 	/* Necessary for mass disposing links created by the factory */
 	private List<PropertyLink<K,?>> mapLinks = new ArrayList<PropertyLink<K,?>>();
 
+	/*
+	 * Removes all the links from the map.
+	 */
 	public void removeAllLinks()
 		{
 		for (PropertyLink<K,?> link : mapLinks)
 			link.remove();
+		}
+
+	/*
+	 * Removes all the links from the map and also forgets them.
+	 * This method is more suitable for disposing so there will
+	 * not be strong references preventing garbage collection.
+	 */
+	public void clearAllLinks()
+		{
+		removeAllLinks();
 		mapLinks.clear();
 		}
 
+	/*
+	 * Remove all of the links from the previous map and then add
+	 * them to the new map, automatically reinitializing all links.
+	 */
 	public void setMap(PropertyMap<K> m)
 		{
 		map = m;

--- a/org/lateralgm/ui/swing/propertylink/PropertyLinkFactory.java
+++ b/org/lateralgm/ui/swing/propertylink/PropertyLinkFactory.java
@@ -35,29 +35,21 @@ public class PropertyLinkFactory<K extends Enum<K>>
 	/* Necessary for mass disposing links created by the factory */
 	private List<PropertyLink<K,?>> mapLinks = new ArrayList<PropertyLink<K,?>>();
 
-	/*
+	/**
 	 * Removes all the links from the map.
 	 */
 	public void removeAllLinks()
 		{
 		for (PropertyLink<K,?> link : mapLinks)
 			link.remove();
-		}
-
-	/*
-	 * Removes all the links from the map and also forgets them.
-	 * This method is more suitable for disposing so there will
-	 * not be strong references preventing garbage collection.
-	 */
-	public void clearAllLinks()
-		{
-		removeAllLinks();
 		mapLinks.clear();
 		}
 
-	/*
+	/**
 	 * Remove all of the links from the previous map and then add
 	 * them to the new map, automatically reinitializing all links.
+	 * 
+	 * @param m The new map to link the properties of.
 	 */
 	public void setMap(PropertyMap<K> m)
 		{

--- a/org/lateralgm/ui/swing/propertylink/PropertyLinkFactory.java
+++ b/org/lateralgm/ui/swing/propertylink/PropertyLinkFactory.java
@@ -21,7 +21,6 @@ import javax.swing.JFormattedTextField;
 import javax.swing.JList;
 import javax.swing.text.Document;
 
-import org.lateralgm.ui.swing.propertylink.ComboBoxLink;
 import org.lateralgm.ui.swing.propertylink.ComboBoxLink.DefaultComboBoxConversion;
 import org.lateralgm.ui.swing.propertylink.ComboBoxLink.ComboBoxConversion;
 import org.lateralgm.util.PropertyEditor;

--- a/org/lateralgm/util/PropertyLink.java
+++ b/org/lateralgm/util/PropertyLink.java
@@ -27,11 +27,23 @@ public abstract class PropertyLink<K extends Enum<K>, V> extends PropertyUpdateL
 		m.getUpdateSource(k).addListener(this);
 		}
 
+	/**
+	 * Removes the link as a listener of the map it was bound to.
+	 * Child implementations will also remove the link as a
+	 * listener of the corresponding component.
+	 */
 	public void remove()
 		{
 		map.getUpdateSource(key).removeListener(this);
 		}
 
+	/**
+	 * Removes the link as a listener of the old map, and
+	 * adds it as a listener of the new map. The component
+	 * will be reset with the value from the new map.
+	 * 
+	 * @param m The PropertyMap to bind to.
+	 */
 	public void setMap(PropertyMap<K> m)
 		{
 		// does not call this.remove() because some subclasses


### PR DESCRIPTION
This fixes the concurrency exceptions reintroduced by c85f9581f9266e74bb52c37218e353430d2d0191 for property links. The problem was our weak references to the secondary property link factories were being GC'd too early sometimes, making it impossible for us to clean up the old links. My solution is to just save a reference to the secondary property link factories and use it to update the links when the current item changes in Master-Detail views.

This is actually less memory and cleaner code because we don't need to save the individual links. Since the factories keep a list of all links to dispose of them, we already have what we need to bind them to a different map. This is also faster because now we avoid unnecessary object creation by reusing the existing links instead of creating new ones. This is pretty much similar to the .NET equivalents like [BindingOperations](https://docs.microsoft.com/en-us/dotnet/api/system.windows.data.bindingoperations.clearallbindings?view=net-5.0), [BindingContext](https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.bindingcontext?view=net-5.0), and [BindingManagerBase](https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.bindingmanagerbase?view=net-5.0).